### PR TITLE
feat: allow admin to manage clusters on ArgoCD and move from chezmoi-sh to chezmoidotsh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Throughout this document, different ages (A0, A1, A2, A3) represent development 
 
 > \[!NOTE]
 > Everything about this age can be found on the
-> [`archive/stone-age`](https://github.com/chezmoi-sh/arcane/tree/archive/stone-age) branch.
+> [`archive/stone-age`](https://github.com/chezmoidotsh/arcane/tree/archive/stone-age) branch.
 
 The project began as a straightforward repository that I would use to keep track
 of the services that my Raspberry Pi 4 was hosting. The name of this was `Nex.RPi`
@@ -110,7 +110,7 @@ components most of the time, \~5.5Wh).
 
 > \[!NOTE]
 > Everything about this age can be found on the
-> [`archive/bronze-age`](https://github.com/chezmoi-sh/arcane/tree/archive/bronze-age)
+> [`archive/bronze-age`](https://github.com/chezmoidotsh/arcane/tree/archive/bronze-age)
 > branch.
 
 ### Age 1.0 *(Q1-Q3 2024 - A1.0)*

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ improvements on them.*
 ```bash
 
 # Clone the repository
-git clone https://github.com/chezmoi-sh/arcane.git
+git clone https://github.com/chezmoidotsh/arcane.git
 
 # Run the development environment
 devcontainer up --workspace-folder .

--- a/catalog/ansible/pve.kairos-cluster/README.md
+++ b/catalog/ansible/pve.kairos-cluster/README.md
@@ -67,7 +67,7 @@ kairos_bundles_flux:
   description: Open and extensible continuous delivery solution for Kubernetes.
   url: https://github.com/kairos-io/community-bundles/tree/main/flux
   targets:
-    - run://ghcr.io/chezmoi-sh/kairos-bundles:flux-sync # sync FluxCD configuration
+    - run://ghcr.io/chezmoidotsh/kairos-bundles:flux-sync # sync FluxCD configuration
 kairos_bundles_flux_config:
   git:
     url: https://github.com/fluxcd/flux2-monitoring-example.git
@@ -80,7 +80,7 @@ kairos_bundles_flux_config:
 ```yaml
 bundles:
   - targets:
-      - run://ghcr.io/chezmoi-sh/kairos-bundles:flux-sync
+      - run://ghcr.io/chezmoidotsh/kairos-bundles:flux-sync
 
 flux:
   git:

--- a/catalog/ansible/pve.kairos-cluster/defaults/main.yml
+++ b/catalog/ansible/pve.kairos-cluster/defaults/main.yml
@@ -41,7 +41,7 @@ kairos_bundles_suc: # System-Upgrade-Controller (https://github.com/rancher/syst
 #   url: https://github.com/kairos-io/community-bundles/tree/main/flux
 #   targets:
 #     - run://quay.io/kairos/community-bundles:flux_latest # bootstrap FluxCD
-#     - run://ghcr.io/chezmoi-sh/kairos-bundles-dev/flux-sync:latest # sync FluxCD configuration
+#     - run://ghcr.io/chezmoidotsh/kairos-bundles-dev/flux-sync:latest # sync FluxCD configuration
 # kairos_bundles_flux_config: # Flux CD (https://fluxcd.io/)
 #   git:
 #     url: ...

--- a/catalog/ansible/pve.kairos-cluster/meta/main.yml
+++ b/catalog/ansible/pve.kairos-cluster/meta/main.yml
@@ -2,7 +2,7 @@ galaxy_info:
   author: Alexandre Nicolaie <xunleii@users.noreply.github.com>
   description: Ansible role to deploy a Kairos cluster on Proxmox VE
 
-  issue_tracker_url: https://github.com/chezmoi-sh/arcane/issues
+  issue_tracker_url: https://github.com/chezmoidotsh/arcane/issues
   license: Apache-2.0
 
   min_ansible_version: 2.1

--- a/catalog/crossplane/domainidentity.amazonses.chezmoi.sh/README.md
+++ b/catalog/crossplane/domainidentity.amazonses.chezmoi.sh/README.md
@@ -11,7 +11,7 @@ To use this XRD, you must have a Crossplane installation running with the
 [AWS provider](https://marketplace.upbound.io/providers/upbound/provider-aws-iam/latest),
 [Go templating function](https://marketplace.upbound.io/functions/crossplane-contrib/function-go-templating/latest),
 [Auto ready function](https://marketplace.upbound.io/functions/crossplane-contrib/function-auto-ready/latest) and
-[Cloudflare provider](https://github.com/chezmoi-sh/provider-cloudflare) *(if you use the cloudflare one)*
+[Cloudflare provider](https://github.com/chezmoidotsh/provider-cloudflare) *(if you use the cloudflare one)*
 installed and configured.
 
 ### Install the XRD

--- a/catalog/flakes/chezmoi.sh/yaldap/flake.nix
+++ b/catalog/flakes/chezmoi.sh/yaldap/flake.nix
@@ -45,20 +45,20 @@
             config.Labels = {
               "org.opencontainers.image.authors" = "chezmoi.sh Lab <xunleii@users.noreply.github.com>";
               "org.opencontainers.image.description" = "yaLDAP is an easy-to-use LDAP server using YAML file as directory definition.";
-              "org.opencontainers.image.documentation" = "https://github.com/chezmoi-sh/yaldap";
+              "org.opencontainers.image.documentation" = "https://github.com/chezmoidotsh/yaldap";
               "org.opencontainers.image.licenses" = "Apache-2.0";
               "org.opencontainers.image.revision" = version;
-              "org.opencontainers.image.source" = "https://github.com/chezmoi-sh/arcane/blob/main/catalog/flakes/chezmoi-sh/yaldap/flake.nix";
+              "org.opencontainers.image.source" = "https://github.com/chezmoidotsh/arcane/blob/main/catalog/flakes/chezmoidotsh/yaldap/flake.nix";
               "org.opencontainers.image.title" = "ydalp";
-              "org.opencontainers.image.url" = "https://github.com/chezmoi-sh/arcane";
+              "org.opencontainers.image.url" = "https://github.com/chezmoidotsh/arcane";
               "org.opencontainers.image.version" = version;
 
               "sh.chezmoi.catalog.build.engine.type" = "nix";
               "sh.chezmoi.catalog.build.engine.version" = "${pkgs.lib.version}";
               "sh.chezmoi.catalog.category" = "system/network";
-              "sh.chezmoi.catalog.origin.author" = "Chezmoi.sh Lab <https://github.com/chezmoi-sh>";
+              "sh.chezmoi.catalog.origin.author" = "Chezmoi.sh Lab <https://github.com/chezmoidotsh>";
               "sh.chezmoi.catalog.origin.license" = "MIT";
-              "sh.chezmoi.catalog.origin.repository" = "github.com/chezmoi-sh/yaldap";
+              "sh.chezmoi.catalog.origin.repository" = "github.com/chezmoidotsh/yaldap";
             };
             config.User = "23169:42291"; # NOTE: random UID/GID
           };

--- a/catalog/flakes/chezmoi.sh/yaldap/yaldap.nix
+++ b/catalog/flakes/chezmoi.sh/yaldap/yaldap.nix
@@ -1,11 +1,11 @@
 { self, pkgs, ... }:
 
 let
-  # renovate: datasource=github-tags depName=chezmoi-sh/yaldap
+  # renovate: datasource=github-tags depName=chezmoidotsh/yaldap
   version = "v0.2.0";
 
   src = pkgs.fetchFromGitHub {
-    owner = "chezmoi-sh";
+    owner = "chezmoidotsh";
     repo = "yaldap";
     rev = version;
     hash = "sha256-rch6HFdpoFjdBjp/GAY9kSreVKg+ZrPTKBzJImlAPEQ=";
@@ -42,7 +42,7 @@ rec {
 
     meta = with pkgs.lib; {
       description = "yaLDAP is an easy-to-use LDAP server using YAML file as directory definition.";
-      homepage = "https://github.com/chezmoi-sh/yaldap";
+      homepage = "https://github.com/chezmoidotsh/yaldap";
       license = licenses.agpl3Only;
       # maintainers = with pkgs.maintainers; [ xunleii ]; # Not currently a maintainer.
       maintainers = [

--- a/catalog/kairos-bundles/flux-sync/Dockerfile
+++ b/catalog/kairos-bundles/flux-sync/Dockerfile
@@ -8,6 +8,6 @@ COPY flux-sync.service .
 COPY flux-sync.sh .
 COPY run.sh .
 
-LABEL org.opencontainers.image.source="https://github.com/chezmoi-sh/arcane/tree/main/catalog/kairos-bundles/flux-sync"
+LABEL org.opencontainers.image.source="https://github.com/chezmoidotsh/arcane/tree/main/catalog/kairos-bundles/flux-sync"
 LABEL org.opencontainers.image.description="Kairos Bundles to synchronize your Kubernetes cluster with your Git repository"
 LABEL org.opencontainers.image.licenses="Apache-2.0"

--- a/catalog/kairos-bundles/flux-sync/README.md
+++ b/catalog/kairos-bundles/flux-sync/README.md
@@ -26,7 +26,7 @@ To use this bundle, you need to specify the following parameters:
 ```yaml
 bundles:
   - targets:
-    - run://ghcr.io/chezmoi-sh/kairos-bundles:flux-sync
+    - run://ghcr.io/chezmoidotsh/kairos-bundles:flux-sync
 
 flux:
   git:

--- a/projects/amiya.akn/README.md
+++ b/projects/amiya.akn/README.md
@@ -73,7 +73,7 @@ This project uses [ArgoCD](https://argoproj.github.io/cd/) for GitOps-based depl
 
 1. **Clone the repository**:
    ```bash
-   git clone https://github.com/chezmoi-sh/arcane.git
+   git clone https://github.com/chezmoidotsh/arcane.git
    cd arcane/projects/amiya.akn
    ```
 
@@ -124,7 +124,7 @@ This project uses [ArgoCD](https://argoproj.github.io/cd/) for GitOps-based depl
    spec:
      project: default
      source:
-       repoURL: https://github.com/chezmoi-sh/arcane.git
+       repoURL: https://github.com/chezmoidotsh/arcane.git
        targetRevision: HEAD
        path: projects/amiya.akn/src/apps/new-app/overlays/prod
      destination:

--- a/projects/amiya.akn/docs/BOOTSTRAP_ARGOCD.md
+++ b/projects/amiya.akn/docs/BOOTSTRAP_ARGOCD.md
@@ -76,7 +76,7 @@ Generate a private key:
 ```bash
 kubectl create namespace argocd # if not already created
 kubectl create --namespace argocd secret generic argocd-repo-creds-github.chezmoi-sh \
-  --from-literal=url=https://github.com/chezmoi-sh \
+  --from-literal=url=https://github.com/chezmoidotsh \
   --from-literal=githubAppID=$GITHUB_APP_ID \
   --from-literal=githubAppInstallationID=$GITHUB_INSTALLATION_ID \
   --from-file=githubAppPrivateKey=$GITHUB_PRIVATE_KEY_PATH

--- a/projects/amiya.akn/docs/bootstrap/talos/amiya-akn-01.patch-config.yaml
+++ b/projects/amiya.akn/docs/bootstrap/talos/amiya-akn-01.patch-config.yaml
@@ -62,7 +62,7 @@ cluster:
     cni:
       name: custom
       urls:
-        - https://raw.githubusercontent.com/chezmoi-sh/arcane/refs/heads/main/projects/amiya.akn/docs/bootstrap/talos/manifests/cilium~1.17.3.yaml
+        - https://raw.githubusercontent.com/chezmoidotsh/arcane/refs/heads/main/projects/amiya.akn/docs/bootstrap/talos/manifests/cilium~1.17.3.yaml
   proxy:
     disabled: true
 
@@ -74,8 +74,8 @@ cluster:
   # -- Install extra components
   extraManifests:
     # -- CoreDNS configuration override
-    - https://raw.githubusercontent.com/chezmoi-sh/arcane/refs/heads/main/projects/amiya.akn/docs/bootstrap/talos/manifests/coredns~v1.12.1.yaml
+    - https://raw.githubusercontent.com/chezmoidotsh/arcane/refs/heads/main/projects/amiya.akn/docs/bootstrap/talos/manifests/coredns~v1.12.1.yaml
 
     # -- Metrics Server
-    - https://raw.githubusercontent.com/chezmoi-sh/arcane/refs/heads/main/projects/amiya.akn/docs/bootstrap/talos/manifests/kubelet-serving-cert-approver~0.9.1.yaml
-    - https://raw.githubusercontent.com/chezmoi-sh/arcane/refs/heads/main/projects/amiya.akn/docs/bootstrap/talos/manifests/metrics-server~0.7.2.yaml
+    - https://raw.githubusercontent.com/chezmoidotsh/arcane/refs/heads/main/projects/amiya.akn/docs/bootstrap/talos/manifests/kubelet-serving-cert-approver~0.9.1.yaml
+    - https://raw.githubusercontent.com/chezmoidotsh/arcane/refs/heads/main/projects/amiya.akn/docs/bootstrap/talos/manifests/metrics-server~0.7.2.yaml

--- a/projects/amiya.akn/src/apps/*argocd/README.md
+++ b/projects/amiya.akn/src/apps/*argocd/README.md
@@ -113,7 +113,7 @@ TODO: create a Github App to manage ArgoCD access to private repositories.
 
 ```bash
 kubectl create --namespace argocd secret generic argocd-repo-creds-github.chezmoi-sh \
-  --from-literal=url=https://github.com/chezmoi-sh \
+  --from-literal=url=https://github.com/chezmoidotsh \
   --from-literal=githubAppID=<app-id> \
   --from-literal=githubAppInstallationID=<installation-id> \
   --from-file=githubAppPrivateKey=<private-key-file>

--- a/projects/amiya.akn/src/apps/*argocd/argocd.appprojects.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/argocd.appprojects.yaml
@@ -15,7 +15,7 @@ spec:
   sourceNamespaces:
     - argocd # NOTE: only allow SEED applications to be installed in the argocd namespace
   sourceRepos:
-    - https://github.com/chezmoi-sh/arcane.git # NOTE: main repository
+    - https://github.com/chezmoidotsh/arcane.git # NOTE: main repository
   destinations:
     - # NOTE: only allow the cluster where ArgoCD is installed
       name: "*"
@@ -44,8 +44,8 @@ spec:
   sourceNamespaces:
     - "*" # NOTE: allow application inside any namespace to be installed
   sourceRepos:
-    - https://github.com/chezmoi-sh/arcane.git # NOTE: main repository
-    - https://github.com/chezmoi-sh/vault.kubernetes.git # NOTE: vault repository
+    - https://github.com/chezmoidotsh/arcane.git # NOTE: main repository
+    - https://github.com/chezmoidotsh/vault.kubernetes.git # NOTE: vault repository
 
     - https://charts.external-secrets.io/ # NOTE: external-secrets repository (required on all clusters)
     - https://charts.jetstack.io # NOTE: cert-manager repository (required on all clusters)
@@ -108,7 +108,7 @@ spec:
   sourceNamespaces:
     - crossplane # NOTE: only allow crossplane resources to be installed in the crossplane namespace
   sourceRepos:
-    - https://github.com/chezmoi-sh/arcane.git # NOTE: main repository
+    - https://github.com/chezmoidotsh/arcane.git # NOTE: main repository
   destinations:
     - # NOTE: crossplane resources should only be installed in the crossplane namespace
       namespace: crossplane

--- a/projects/amiya.akn/src/apps/*argocd/argocd.github-secrets.externalsecret.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/argocd.github-secrets.externalsecret.yaml
@@ -31,7 +31,7 @@ spec:
           app.kubernetes.io/part-of: argocd
           argocd.argoproj.io/secret-type: repo-creds
       data:
-        url: https://github.com/chezmoi-sh
+        url: https://github.com/chezmoidotsh
         githubAppID: "{{ .githubAppID }}"
         githubAppInstallationID: "{{ .githubAppInstallationID }}"
         githubAppPrivateKey: "{{ .githubAppPrivateKey }}"

--- a/projects/amiya.akn/src/apps/*argocd/argocd.helmvalues/default.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/argocd.helmvalues/default.yaml
@@ -142,8 +142,6 @@ configs:
       p, role:restricted-admin, certificates, create, *, deny
       p, role:restricted-admin, certificates, update, *, deny
       p, role:restricted-admin, certificates, delete, *, deny
-      p, role:restricted-admin, clusters, create, *, deny
-      p, role:restricted-admin, clusters, delete, *, deny
       p, role:restricted-admin, accounts, update, *, deny
       p, role:restricted-admin, gpgkeys, create, *, deny
       p, role:restricted-admin, gpgkeys, delete, *, deny

--- a/projects/amiya.akn/src/apps/*argocd/argocd.helmvalues/default.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/argocd.helmvalues/default.yaml
@@ -107,13 +107,13 @@ configs:
   # Only the `arcane` repository is configured here, as the other ones are managed by
   # ArgoCD itself.
   repositories:
-    github.chezmoi-sh.arcane:
+    github.chezmoidotsh.arcane:
       name: chezmoi.sh/arcane
-      url: https://github.com/chezmoi-sh/arcane.git
+      url: https://github.com/chezmoidotsh/arcane.git
       type: git
-    github.chezmoi-sh.vault.kubernetes:
+    github.chezmoidotsh.vault.kubernetes:
       name: chezmoi.sh/vault.kubernetes
-      url: https://github.com/chezmoi-sh/vault.kubernetes.git
+      url: https://github.com/chezmoidotsh/vault.kubernetes.git
       type: git
 
   # ArgoCD clusters configuration

--- a/projects/amiya.akn/src/apps/*argocd/argocd.helmvalues/extensions.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/argocd.helmvalues/extensions.yaml
@@ -12,9 +12,9 @@ server:
       - name: extension-application-map
         env:
           - name: EXTENSION_URL
-            value: https://github.com/chezmoi-sh/argocd-extension-application-map/releases/download/v1.0.0/extension-application-map.tar
+            value: https://github.com/chezmoidotsh/argocd-extension-application-map/releases/download/v1.0.0/extension-application-map.tar
           - name: EXTENSION_CHECKSUM_URL
-            value: https://github.com/chezmoi-sh/argocd-extension-application-map/releases/download/v1.0.0/extension-application-map_checksums.txt
+            value: https://github.com/chezmoidotsh/argocd-extension-application-map/releases/download/v1.0.0/extension-application-map_checksums.txt
 
       # # Metrics server extension (https://github.com/argoproj-labs/argocd-extension-metrics)
       # - name: extension-metrics-server

--- a/projects/amiya.akn/src/apps/*argocd/argocd.helmvalues/extensions.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/argocd.helmvalues/extensions.yaml
@@ -12,9 +12,9 @@ server:
       - name: extension-application-map
         env:
           - name: EXTENSION_URL
-            value: https://github.com/chezmoidotsh/argocd-extension-application-map/releases/download/v1.0.0/extension-application-map.tar
+            value: https://github.com/chezmoidotsh/argocd-extension-application-map/releases/download/v1.0.1/extension-application-map.tar
           - name: EXTENSION_CHECKSUM_URL
-            value: https://github.com/chezmoidotsh/argocd-extension-application-map/releases/download/v1.0.0/extension-application-map_checksums.txt
+            value: https://github.com/chezmoidotsh/argocd-extension-application-map/releases/download/v1.0.1/extension-application-map_checksums.txt
 
       # # Metrics server extension (https://github.com/argoproj-labs/argocd-extension-metrics)
       # - name: extension-metrics-server

--- a/projects/amiya.akn/src/apps/*argocd/kustomization.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 
   # Install Argotails that manages all Tailscale clusters
   # secrets based on Tailscale's devices
-  - https://github.com/chezmoi-sh/argotails.git//deploy/manifests/default?ref=v0.1.5
+  - https://github.com/chezmoidotsh/argotails.git//deploy/manifests/default?ref=v0.1.5
   - argotails.ts-secrets.externalsecret.yaml
 
 helmCharts:

--- a/projects/amiya.akn/src/apps/*argocd/seed.apps/kubevault.application.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/seed.apps/kubevault.application.yaml
@@ -9,7 +9,7 @@ spec:
     server: https://kubernetes.default.svc
   project: system
   sources:
-    - repoURL: https://github.com/chezmoi-sh/vault.kubernetes.git
+    - repoURL: https://github.com/chezmoidotsh/vault.kubernetes.git
       targetRevision: main
       path: .
   syncPolicy:

--- a/projects/amiya.akn/src/apps/*argocd/seed.apps/shoot.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/seed.apps/shoot.applicationset.yaml
@@ -37,7 +37,7 @@ spec:
             application and configurations for the cluster {{ .name }}.
       project: seed
       sources:
-        - repoURL: https://github.com/chezmoi-sh/arcane.git
+        - repoURL: https://github.com/chezmoidotsh/arcane.git
           path: projects/amiya.akn/src/apps/*argocd/shoot.apps
           targetRevision: main
 

--- a/projects/amiya.akn/src/apps/*argocd/seed.apps/shoot.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/seed.apps/shoot.applicationset.yaml
@@ -21,8 +21,10 @@ spec:
     - clusters: {}
   template:
     metadata:
+      {{ if index .metadata.annotations "device.tailscale.com/address" }}
       annotations:
         link.argocd.argoproj.io/external-link: https://login.tailscale.com/admin/machines/{{ index .metadata.annotations "device.tailscale.com/address" }}
+      {{ end }}
       name: "{{ .name }}"
     spec:
       destination:

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/apps.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/apps.applicationset.yaml
@@ -22,7 +22,7 @@ spec:
         generators:
           - list: { elements: [] } # NOTE: this list will be populated by the `seed` ApplicationSet with the cluster metadata
           - git:
-              repoURL: https://github.com/chezmoi-sh/arcane.git
+              repoURL: https://github.com/chezmoidotsh/arcane.git
               revision: main
               directories:
                 - path: projects/{{ index .metadata.annotations "device.tailscale.com/hostname" | default .name }}/src/apps/*
@@ -38,7 +38,7 @@ spec:
         namespace: '{{ .path.basename | trimPrefix "*" }}'
       project: applications
       sources:
-        - repoURL: https://github.com/chezmoi-sh/arcane.git
+        - repoURL: https://github.com/chezmoidotsh/arcane.git
           path: "{{ .path.path }}"
           targetRevision: main
   templatePatch: |

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/cert-manager.application.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/cert-manager.application.yaml
@@ -10,7 +10,7 @@ spec:
   project: system
   sources:
     - ref: origin
-      repoURL: https://github.com/chezmoi-sh/arcane.git
+      repoURL: https://github.com/chezmoidotsh/arcane.git
       targetRevision: main
     - chart: cert-manager
       helm:

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/external-secrets.application.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/external-secrets.application.yaml
@@ -10,7 +10,7 @@ spec:
   project: system
   sources:
     - ref: origin
-      repoURL: https://github.com/chezmoi-sh/arcane.git
+      repoURL: https://github.com/chezmoidotsh/arcane.git
       targetRevision: main
     - chart: external-secrets
       helm:

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/system.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/system.applicationset.yaml
@@ -22,7 +22,7 @@ spec:
         generators:
           - list: { elements: [] } # NOTE: this list will be populated by the `seed` ApplicationSet with the cluster metadata
           - git:
-              repoURL: https://github.com/chezmoi-sh/arcane.git
+              repoURL: https://github.com/chezmoidotsh/arcane.git
               revision: main
               directories:
                 - path: projects/{{ index .metadata.annotations "device.tailscale.com/hostname" | default .name }}/src/infrastructure/kubernetes/*
@@ -48,7 +48,7 @@ spec:
         namespace: '{{ .path.basename | trimPrefix "*" | trimSuffix "-system" }}-system'
       project: system
       sources:
-        - repoURL: https://github.com/chezmoi-sh/arcane.git
+        - repoURL: https://github.com/chezmoidotsh/arcane.git
           path: "{{ .path.path }}"
           targetRevision: main
       syncPolicy:

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/tailscale.application.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/tailscale.application.yaml
@@ -11,7 +11,7 @@ spec:
   sources:
     # Install Tailscale default resources (ProxyClass, NetworkPolicy, etc.)
     - ref: origin
-      repoURL: https://github.com/chezmoi-sh/arcane.git
+      repoURL: https://github.com/chezmoidotsh/arcane.git
       targetRevision: main
       path: defaults/kubernetes/tailscale/kustomize
 

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/traefik.application.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/traefik.application.yaml
@@ -10,7 +10,7 @@ spec:
   project: system
   sources:
     - ref: origin
-      repoURL: https://github.com/chezmoi-sh/arcane.git
+      repoURL: https://github.com/chezmoidotsh/arcane.git
       targetRevision: main
       path: defaults/kubernetes/traefik/kustomize
 

--- a/projects/amiya.akn/src/apps/*crossplane/crossplane.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/*crossplane/crossplane.applicationset.yaml
@@ -18,7 +18,7 @@ spec:
   goTemplateOptions: ["missingkey=error"]
   generators:
     - git:
-        repoURL: https://github.com/chezmoi-sh/arcane.git
+        repoURL: https://github.com/chezmoidotsh/arcane.git
         revision: main
         directories:
           - path: projects/*/src/infrastructure/crossplane
@@ -34,7 +34,7 @@ spec:
         namespace: crossplane
       project: crossplane
       sources:
-        - repoURL: https://github.com/chezmoi-sh/arcane.git
+        - repoURL: https://github.com/chezmoidotsh/arcane.git
           path: "{{ .path.path }}"
           targetRevision: main
       syncPolicy:

--- a/projects/amiya.akn/src/apps/*sso/yaldap/kustomization.yaml
+++ b/projects/amiya.akn/src/apps/*sso/yaldap/kustomization.yaml
@@ -19,5 +19,5 @@ resources:
   - yaldap.externalsecret.yaml
 
 images:
-  - name: ghcr.io/chezmoi-sh/flakes-dev/yaldap
+  - name: ghcr.io/chezmoidotsh/flakes-dev/yaldap
     newTag: v0.2.0-24.11-x86_64-linux # TODO: Handle multi-arch images

--- a/projects/amiya.akn/src/apps/*sso/yaldap/yaldap.workload.yaml
+++ b/projects/amiya.akn/src/apps/*sso/yaldap/yaldap.workload.yaml
@@ -30,7 +30,7 @@ spec:
             - --backend.url=file:///run/secrets/yaldap/backend.yaml
             - --listen-address=:8389
             - --session-ttl=1h
-          image: ghcr.io/chezmoi-sh/flakes-dev/yaldap
+          image: ghcr.io/chezmoidotsh/flakes-dev/yaldap
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/projects/amiya.akn/src/seed.application.yaml
+++ b/projects/amiya.akn/src/seed.application.yaml
@@ -10,7 +10,7 @@ spec:
   project: seed
   sources:
     - ref: origin
-      repoURL: https://github.com/chezmoi-sh/arcane.git
+      repoURL: https://github.com/chezmoidotsh/arcane.git
       targetRevision: main
       path: projects/amiya.akn/src/apps/*argocd/seed.apps
   syncPolicy:

--- a/projects/maison/src/clusters/production/flux-system/gotk-sync.yaml
+++ b/projects/maison/src/clusters/production/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 1m0s
   ref:
     branch: main
-  url: https://github.com/chezmoi-sh/arcane.git
+  url: https://github.com/chezmoidotsh/arcane.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/projects/maison/src/infrastructure/ansible/bootstrap-cluster.yaml
+++ b/projects/maison/src/infrastructure/ansible/bootstrap-cluster.yaml
@@ -26,10 +26,10 @@
     #   description: Open and extensible continuous delivery solution for Kubernetes.
     #   url: https://github.com/kairos-io/community-bundles/tree/main/flux
     #   targets:
-    #     - run://ghcr.io/chezmoi-sh/kairos-bundles:flux-sync # sync FluxCD configuration
+    #     - run://ghcr.io/chezmoidotsh/kairos-bundles:flux-sync # sync FluxCD configuration
     # kairos_bundles_flux_config:
     #   git:
-    #     url: https://github.com/chezmoi-sh/arcane.git
+    #     url: https://github.com/chezmoidotsh/arcane.git
     #     path: project/maison/src/clusters/production/recovery # FluxCD configuration path with all recovery manifests
     #     branch: main
     kairos_cloudinit_k3s:

--- a/projects/shodan.akn/README.md
+++ b/projects/shodan.akn/README.md
@@ -88,7 +88,7 @@ This project uses [ArgoCD](https://argoproj.github.io/cd/) for GitOps-based depl
 
 1. **Clone the repository**:
    ```bash
-   git clone https://github.com/chezmoi-sh/arcane.git
+   git clone https://github.com/chezmoidotsh/arcane.git
    cd arcane/projects/shodan.akn
    ```
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
-		"github>chezmoi-sh/renovate-config",
-		"github>chezmoi-sh/renovate-config:github-actions(monthly)",
-		"github>chezmoi-sh/renovate-config:gitmoji"
+		"github>chezmoidotsh/renovate-config",
+		"github>chezmoidotsh/renovate-config:github-actions(monthly)",
+		"github>chezmoidotsh/renovate-config:gitmoji"
 	]
 }


### PR DESCRIPTION
This pull request primarily addresses the migration of repository references throughout the codebase from `chezmoi-sh` to `chezmoidotsh`. Additionally, it introduces a new scope for the 'Spirit of Fire' project in the `.commitlintrc.js` file. Below is a categorized summary of the most important changes:

### Repository Reference Updates
* Updated repository URLs in various files, including `README.md`, `Dockerfile`, and YAML configuration files, to reflect the new organization `chezmoidotsh`. These changes ensure consistency across documentation, configurations, and source code. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R63) [[2]](diffhunk://#diff-d1bb003169db83e656466097626230f95ab99ce2a733ee7ba5050f27113dc85dL5-R5) [[3]](diffhunk://#diff-3d44833597000bd227391d4a20cabfad16769bc11fa28aecf870a02ea4f7a658L11-R11) [[4]](diffhunk://#diff-23277f0ef7b09fbc063e08d1611300abb588b701c2bc288024ad029678dfefa9L76-R76) [[5]](diffhunk://#diff-4b4ee6e34b3de37f08195e0c4394460c8a379626720ebf271e8cfb378c4cca32L18-R18) [[6]](diffhunk://#diff-4b4ee6e34b3de37f08195e0c4394460c8a379626720ebf271e8cfb378c4cca32L47-R48) [[7]](diffhunk://#diff-4b4ee6e34b3de37f08195e0c4394460c8a379626720ebf271e8cfb378c4cca32L111-R111) [[8]](diffhunk://#diff-610e4a0fbdf9a586a57b124b9ee356c5290196827712af58d8f9bbd7bda56e65L110-R116) [[9]](diffhunk://#diff-2f9c023d9f5871f34b9152797485cbac0445f84b84774e8a5df5af8cc1917030L15-R17) [[10]](diffhunk://#diff-740641877edc18786715731f0e69768f298e36ff0c735c092c2994d5b570c924L18-R18)

### `.commitlintrc.js` Enhancements
* Added a new scope for the 'Spirit of Fire' project to the `const scopes` array, enabling better categorization of commits related to this project.

### Documentation Updates
* Corrected outdated URLs in the `CHANGELOG.md` file to point to the updated repository location. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL25-R25) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL113-R113)

### Configuration and Deployment Adjustments
* Updated repository references in Kubernetes and ArgoCD-related configuration files to ensure proper integration with the new organization. These changes include updates to `argocd.appprojects.yaml`, `argocd.github-secrets.externalsecret.yaml`, and `argocd.helmvalues/default.yaml`. [[1]](diffhunk://#diff-4b4ee6e34b3de37f08195e0c4394460c8a379626720ebf271e8cfb378c4cca32L47-R48) [[2]](diffhunk://#diff-3b72ce6578dd1aa0907d25d7bc8d2f9e82d26d35d26b328c2251414c79732ee1L34-R34) [[3]](diffhunk://#diff-610e4a0fbdf9a586a57b124b9ee356c5290196827712af58d8f9bbd7bda56e65L110-R116)

### Miscellaneous Fixes
* Adjusted URLs in the `catalog/flakes` configurations to reflect the new repository structure, ensuring compatibility with the updated organization. [[1]](diffhunk://#diff-659ae373705a39b7c8715f84533d1e0f4980dbcbc38746ec282e13d2be41a1d8L48-R61) [[2]](diffhunk://#diff-a0bf43ce99c4eca8ce6c72d0065c73ed153270bba4a0672507f8d0562283cea2L4-R8) [[3]](diffhunk://#diff-a0bf43ce99c4eca8ce6c72d0065c73ed153270bba4a0672507f8d0562283cea2L45-R45)

These changes collectively improve the consistency and maintainability of the codebase while introducing support for a new project scope.