### PR TITLE
:arrow_up:(project:amiya.akn): Upgrade external-secrets operator to 0.16.0

### DIFF
--- a/projects/amiya.akn/src/apps/*argocd/argocd.github-secrets.externalsecret.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/argocd.github-secrets.externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: argocd-github

--- a/projects/amiya.akn/src/apps/*argocd/argocd.oidc-credentials.externalsecret.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/argocd.oidc-credentials.externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: argocd-oidc

--- a/projects/amiya.akn/src/apps/*argocd/argocd.sops-secrets.externalsecret.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/argocd.sops-secrets.externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: argocd-sops

--- a/projects/amiya.akn/src/apps/*argocd/argocd.ts-secrets.externalsecret.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/argocd.ts-secrets.externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: argocd-tailscale

--- a/projects/amiya.akn/src/apps/*argocd/argotails.ts-secrets.externalsecret.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/argotails.ts-secrets.externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: argotails-secrets

--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/external-secrets.application.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/external-secrets.application.yaml
@@ -23,7 +23,7 @@ spec:
           # - $origin/projects/{{ .name }}/src/infrastructure/kubernetes/external-secrets/override.helmvalues.yaml
           # - $origin/projects/{{ index .metadata.annotations "device.tailscale.com/hostname" | default .name }}/src/infrastructure/kubernetes/external-secrets/override.helmvalues.yaml
       repoURL: https://charts.external-secrets.io/
-      targetRevision: 0.14.4
+      targetRevision: 0.16.0
   syncPolicy:
     syncOptions:
       - CreateNamespace=true

--- a/projects/amiya.akn/src/apps/*sso/authelia/authelia-ldap.externalsecret.yaml
+++ b/projects/amiya.akn/src/apps/*sso/authelia/authelia-ldap.externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: authelia-ldap

--- a/projects/amiya.akn/src/apps/*sso/authelia/authelia-oidc.externalsecret.yaml
+++ b/projects/amiya.akn/src/apps/*sso/authelia/authelia-oidc.externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: authelia-oidc

--- a/projects/amiya.akn/src/apps/*sso/authelia/authelia-smtp.externalsecret.yaml
+++ b/projects/amiya.akn/src/apps/*sso/authelia/authelia-smtp.externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: authelia-smtp

--- a/projects/amiya.akn/src/apps/*sso/authelia/authelia.externalsecret.yaml
+++ b/projects/amiya.akn/src/apps/*sso/authelia/authelia.externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: authelia

--- a/projects/amiya.akn/src/apps/*sso/yaldap/yaldap.externalsecret.yaml
+++ b/projects/amiya.akn/src/apps/*sso/yaldap/yaldap.externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   labels:

--- a/projects/amiya.akn/src/infrastructure/kubernetes/*external-dns/unifi.externalsecret.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/*external-dns/unifi.externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: external-dns-unifi-secret

--- a/projects/amiya.akn/src/infrastructure/kubernetes/*longhorn/longhorn.externalsecret.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/*longhorn/longhorn.externalsecret.yaml
@@ -1,6 +1,6 @@
 # trunk-ignore-all(checkov/CKV_SECRET_6): No secrets in this file
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: longhorn

--- a/projects/amiya.akn/src/infrastructure/kubernetes/cert-manager/override.helmvalues.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/cert-manager/override.helmvalues.yaml
@@ -18,7 +18,7 @@ extraObjects:
                   name: letsencrypt-issuer-credentials
                   key: api-token
   - |-
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: ExternalSecret
     metadata:
       name: letsencrypt-issuer-credentials

--- a/projects/amiya.akn/src/infrastructure/kubernetes/external-secrets/override.helmvalues.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/external-secrets/override.helmvalues.yaml
@@ -3,7 +3,7 @@ extraObjects:
   # NOTE: kubevault is the default secret store for External Secrets Operator.
   #       Because this cluster is the same as the one where the secrets are
   #       stored, we don't need any trickery to access the secrets.
-  - apiVersion: external-secrets.io/v1beta1
+  - apiVersion: external-secrets.io/v1
     kind: ClusterSecretStore
     metadata:
       name: kubevault


### PR DESCRIPTION
This pull request updates the `apiVersion` of `ExternalSecret` and related resources from `external-secrets.io/v1beta1` to `external-secrets.io/v1` across multiple YAML configuration files. Additionally, it upgrades the Helm chart version for External Secrets in the application configuration. These changes ensure compatibility with the latest version of the External Secrets Operator.

### Updates to `apiVersion` for `ExternalSecret` and related resources:
* Updated `apiVersion` from `external-secrets.io/v1beta1` to `external-secrets.io/v1` in multiple files under `projects/amiya.akn/src/apps/*argocd` (e.g., `argocd.github-secrets.externalsecret.yaml`, `argocd.oidc-credentials.externalsecret.yaml`, `argocd.sops-secrets.externalsecret.yaml`, etc.). [[1]](diffhunk://#diff-3b72ce6578dd1aa0907d25d7bc8d2f9e82d26d35d26b328c2251414c79732ee1L2-R2) [[2]](diffhunk://#diff-b341b0f83267a8adf272d3d396c6629ac54abde7a5cf45c0bfe9dcc9bdfe32f0L2-R2) [[3]](diffhunk://#diff-1f3f098a433a152dced888c62be4b74e276ddaaa8af2ab5db15f79efe0f0f899L2-R2) [[4]](diffhunk://#diff-d2e5a3bee485dc5e7ac226ddd6390831255c3f1f61b7e246241f40de140e13abL2-R2) [[5]](diffhunk://#diff-9353c06b94dd589a9054d9efd60e6efe676a66d1e341352b16cb49f80b7a7092L2-R2)
* Updated `apiVersion` for `ExternalSecret` resources in `projects/amiya.akn/src/apps/*sso` (e.g., `authelia.externalsecret.yaml`, `authelia-ldap.externalsecret.yaml`, `authelia-smtp.externalsecret.yaml`, etc.). [[1]](diffhunk://#diff-7b1f3513e669385ba0b9cb8d493807ebddcc5a16b9744f67c3c10830a621ec89L2-R2) [[2]](diffhunk://#diff-9565280768965965ca2c73a9675b09ff3ea1aedfa8baa20532a5f54369d4218eL2-R2) [[3]](diffhunk://#diff-3e0cc8066a131d0a30db533aad58deff1aafd712666480f94fb0ca9e7a478651L2-R2) [[4]](diffhunk://#diff-dd983cb44b61a330fa81a71a72007669db6b45aa89d60a0dd4827d51a437044fL2-R2) [[5]](diffhunk://#diff-6c813ae10a6e2fc7dc615c44574614ae0380750d149772a38c0a426b765e756bL2-R2)
* Updated `apiVersion` for `ExternalSecret` in infrastructure-related files (e.g., `external-dns/unifi.externalsecret.yaml`, `longhorn/longhorn.externalsecret.yaml`, and `cert-manager/override.helmvalues.yaml`). [[1]](diffhunk://#diff-12579bb10a70a3c48402216ef8441819e48be5678c0abcefe40436de10c3e64dL2-R2) [[2]](diffhunk://#diff-5e3fadbc00fc24818779ddd22952e1c0cfe0981a912399cbe801cdcda07d5e22L3-R3) [[3]](diffhunk://#diff-f7cd228befb13b01076c8d1d6405d4f47cc59da26356bd60e7bb26ec1fe23977L21-R21)
* Updated `apiVersion` for `ClusterSecretStore` in `external-secrets/override.helmvalues.yaml`.

### Helm chart upgrade:
* Upgraded the `targetRevision` of the External Secrets Helm chart in `external-secrets.application.yaml` from `0.14.4` to `0.16.0`.