### PR TITLE
:arrow_up:(project:amiya.akn): Upgrade external-secrets operator to 0.18.0

### DIFF
--- a/projects/amiya.akn/src/apps/*argocd/shoot.apps/external-secrets.application.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/shoot.apps/external-secrets.application.yaml
@@ -23,7 +23,7 @@ spec:
           # - $origin/projects/{{ .name }}/src/infrastructure/kubernetes/external-secrets/override.helmvalues.yaml
           # - $origin/projects/{{ index .metadata.annotations "device.tailscale.com/hostname" | default .name }}/src/infrastructure/kubernetes/external-secrets/override.helmvalues.yaml
       repoURL: https://charts.external-secrets.io/
-      targetRevision: 0.16.0
+      targetRevision: 0.18.0
   syncPolicy:
     syncOptions:
       - CreateNamespace=true


### PR DESCRIPTION
This pull request updates the version of the `external-secrets` Helm chart used in the ArgoCD application configuration. 

Version update:

* [`projects/amiya.akn/src/apps/*argocd/shoot.apps/external-secrets.application.yaml`](diffhunk://#diff-7eee7fa7107a43faab1cdd678a7c337bd4ec6e0d64f164506be1d67683c2abcbL26-R26): Updated the `targetRevision` of the `external-secrets` Helm chart from `0.16.0` to `0.18.0` to ensure compatibility with the latest features and fixes.