### PR TITLE
:pencil2:(project:amiya.akn): Add amiya in the longhorn URL

### DIFF
--- a/projects/amiya.akn/src/infrastructure/kubernetes/*longhorn/longhorn.httproute.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/*longhorn/longhorn.httproute.yaml
@@ -27,7 +27,7 @@ spec:
       namespace: traefik-system
       sectionName: chezmoi.sh-websecure
   hostnames:
-    - longhorn.akn.chezmoi.sh
+    - longhorn.amiya.akn.chezmoi.sh
   rules:
     - backendRefs:
         - group: ""


### PR DESCRIPTION
This pull request includes a small change to the `longhorn.httproute.yaml` file. The change updates the hostname in the `hostnames` section to reflect the correct subdomain for the `longhorn` service.