### PR TITLE
:truck: (project:amiya.akn): Migrate cert-manager's CF API token to OpenBao

### DIFF
--- a/docs/decisions/003-openbao-path-naming-conventions.md
+++ b/docs/decisions/003-openbao-path-naming-conventions.md
@@ -189,6 +189,7 @@ This category contains shared credentials for third-party services (AWS, Cloudfl
 
 ***AWS credentials***: `/shared/third-parties/aws/{service}/{app-or-purpose}` - *For example, the AWS credentials used by `amiya.akn/cnpg` to access to the `important-backup` bucket are stored in: `/shared/third-parties/aws/iam/amiya.akn/cnpg-important-backup-rw`*\
 ***Cloudflare credentials***: `/shared/third-parties/cloudflare/{service}/{app-or-purpose}` - *For example, the Cloudflare credentials used by `amiya.akn/cert-manager` to access to all DNS zones are stored in: `/shared/third-parties/cloudflare/iam/amiya.akn/cert-manager-rw`*\
+***Let's Encrypt account***: `/shared/third-parties/letsencrypt/certificate-authority/account` - *For example, the Let's Encrypt account credentials used by cert-manager are stored in: `/shared/third-parties/letsencrypt/certificate-authority/account`*\
 ***Other providers***: `/shared/third-parties/{provider}/{service}/{project-name}/{app-or-purpose}`
 
 > \[!NOTE]
@@ -327,6 +328,7 @@ Cloud provider credentials follow service-based organization:
 
 ## Changelog
 
+* **2025-08-17**: **FEATURE**: Add example for Let's Encrypt account path convention `/shared/third-parties/letsencrypt/certificate-authority/account` for ACME account credentials used by cert-manager
 * **2025-08-11**: **FEATURE**: Add personal mount structure with user-isolated namespaces. Implemented two-tier templated policies (`personal-user-access` for standard users, `personal-admin-access` for administrators) using OIDC alias metadata templating. This enables self-service secret management for personal tools (Talos contexts, kubectl configs, personal API tokens) while maintaining zero-trust principles and administrative oversight capabilities.
 * **2025-07-01**: **SECURITY**: Migrate SSO secrets from `/shared/sso/*` to per-project mounts following `/{cluster}/{app}/auth/{secret}` pattern. This change addresses security vulnerability where `global-eso-policy` allowed any cluster to access OIDC `client_secret` credentials from other clusters, enabling potential identity spoofing attacks. The new structure maintains proper isolation while allowing Authelia legitimate cross-mount access via dedicated policies.
 * **2025-06-30**: Update path naming conventions to match the new policy naming conventions.

--- a/projects/amiya.akn/src/apps/*argocd/argocd.appprojects.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/argocd.appprojects.yaml
@@ -114,7 +114,11 @@ spec:
     - # NOTE: crossplane resources should only be installed in the crossplane namespace
       namespace: crossplane
       server: https://kubernetes.default.svc
+    - # NOTE: crossplane-secrets are used to store all secrets
+      namespace: crossplane-secrets
+      server: https://kubernetes.default.svc
     - # NOTE: in order to configure RBAC on the "vault", this namespace should be allowed too
+      # TODO: when all crossplane secret will be migrated to Vault, remove this namespace
       namespace: kubevault-kvstore
       server: https://kubernetes.default.svc
   clusterResourceWhitelist: [{ group: "*", kind: "*" }]

--- a/projects/amiya.akn/src/apps/*argocd/seed.apps/shoot.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/*argocd/seed.apps/shoot.applicationset.yaml
@@ -8,11 +8,6 @@ metadata:
       configurations across all clusters configured in ArgoCD. It achieves this
       by deploying an application that, in turn, deploys two other ApplicationSets:
       one for system/cluster applications and another for applications.
-
-    # Source reference for argocd-extension-application-map
-    source-ref.argocd.argoproj.io/0.path: projects/amiya.akn/src/apps/*argocd/shoot.apps
-    source-ref.argocd.argoproj.io/0.repository-url: https://github.com/chezmoidotsh/arcane.git
-    source-ref.argocd.argoproj.io/0.target-revision: main
   name: shoot
 spec:
   ignoreApplicationDifferences:
@@ -26,6 +21,12 @@ spec:
     - clusters: {}
   template:
     metadata:
+      annotations:
+        # Source reference for argocd-extension-application-map
+        source-ref.argocd.argoproj.io/0.path: projects/amiya.akn/src/apps/*argocd/shoot.apps
+        source-ref.argocd.argoproj.io/0.repository-url: https://github.com/chezmoidotsh/arcane.git
+        source-ref.argocd.argoproj.io/0.target-revision: main
+
       name: "{{ .name }}"
     spec:
       destination:

--- a/projects/amiya.akn/src/apps/*crossplane/crossplane-secrets.namespace.yaml
+++ b/projects/amiya.akn/src/apps/*crossplane/crossplane-secrets.namespace.yaml
@@ -1,0 +1,8 @@
+# This namespace is dedicated to secrets created by Crossplane.
+# Only Crossplane and External Secrets Operator (ESO) will have permissions on this namespace
+# to manage and access the secrets as required for resource provisioning and secret synchronization.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane-secrets

--- a/projects/amiya.akn/src/apps/*crossplane/crossplane.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/*crossplane/crossplane.applicationset.yaml
@@ -27,6 +27,12 @@ spec:
       annotations:
         # All Crossplane resources should be deployed with other applications
         argocd.argoproj.io/sync-wave: "100"
+
+        # Source reference for argocd-extension-application-map
+        source-ref.argocd.argoproj.io/0.path: "{{ .path.path }}"
+        source-ref.argocd.argoproj.io/0.repository-url: https://github.com/chezmoidotsh/arcane.git
+        source-ref.argocd.argoproj.io/0.target-revision: main
+
       name: crossplane-{{ index .path.segments 1 }}
     spec:
       destination:

--- a/projects/amiya.akn/src/apps/*crossplane/kustomization.yaml
+++ b/projects/amiya.akn/src/apps/*crossplane/kustomization.yaml
@@ -3,6 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - crossplane-secrets.namespace.yaml
+
   # Crossplane x ArgoCD
   - crossplane.applicationset.yaml
 

--- a/projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml
+++ b/projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml
@@ -10,16 +10,9 @@
 #   - DNS Write (4755a26eedb94da69e1066d98aa820be): Allows creating and managing DNS records
 #
 # Security:
-#   The token is stored in a Kubernetes secret in the kubevault-kvstore namespace
-#   and is used by cert-manager to validate domain ownership during certificate issuance.
-#
-# Usage:
-#   This token is specifically scoped to the chezmoi.sh domain and is used by
-#   cert-manager to automatically create and manage DNS records for SSL/TLS
-#   certificate validation.
+#   The secret is synchronized to Vault (vault.chezmoi.sh) using External Secrets Operator.
 #
 # trunk-ignore-all(checkov/CKV2_K8S_5,trivy/KSV113): this is a policy to allow a specific user to use a specific secrets... so it's fine
-
 ---
 apiVersion: account.cloudflare.crossplane.io/v1alpha1
 kind: APIToken
@@ -36,35 +29,34 @@ spec:
         resources:
           com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94: "*"
   writeConnectionSecretToRef:
-    name: cloud-cloudflare-amiyaakn-certmanager
-    namespace: kubevault-kvstore
+    name: amiya.akn-cloudflare-token-certmanager
+    namespace: crossplane-secrets
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
 metadata:
-  name: kubevault:kubernetes.amiya.akn.chezmoi.sh:cert-manager
-  namespace: kubevault-kvstore
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    resourceNames:
-      - cloud-cloudflare-amiyaakn-certmanager
-    verbs:
-      - get
-      - list
-      - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: kubevault:kubernetes.amiya.akn.chezmoi.sh:cert-manager
-  namespace: kubevault-kvstore
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: kubevault:kubernetes.amiya.akn.chezmoi.sh:cert-manager
-subjects:
-  - kind: ServiceAccount
-    name: kubernetes.amiya.akn.chezmoi.sh
+  name: amiya.akn-cloudflare-token-certmanager
+  namespace: crossplane-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: vault.chezmoi.sh
+  selector:
+    secret:
+      name: amiya.akn-cloudflare-token-certmanager
+  template:
+    metadata:
+      annotations:
+        description: Cloudflare API Token for cert-manager
+        origin: crossplane
+        owner: amiya.akn
+        renewal-process: |
+          Remove the amiyaakn-chezmoi-sh-cert-manager APIToken then wait ArgoCD to create a new one.
+  data:
+    - conversionStrategy: None
+      match:
+        secretKey: attribute.value
+        remoteRef:
+          remoteKey: shared/data/third-parties/cloudflare/iam/amiya.akn/cert-manager-rw
+          property: api_token

--- a/projects/amiya.akn/src/infrastructure/kubernetes/cert-manager/letsencrypt-issuer-credentials.externalsecret.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/cert-manager/letsencrypt-issuer-credentials.externalsecret.yaml
@@ -6,21 +6,15 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: kubevault
+    name: vault.chezmoi.sh
   target:
     name: letsencrypt-issuer-credentials
   data:
-    - secretKey: api-token # ... breaks entropy to avoid checkov error
+    - secretKey: api-token
       remoteRef:
-        conversionStrategy: Default
-        decodingStrategy: None
-        key: cloud-cloudflare-amiyaakn-certmanager
-        metadataPolicy: None
-        property: attribute.value
+        key: shared/third-parties/cloudflare/iam/amiya.akn/cert-manager-rw
+        property: api_token
     - secretKey: email
       remoteRef:
-        conversionStrategy: Default
-        decodingStrategy: None
-        key: cloud-letsencrypt
-        metadataPolicy: None
+        key: shared/third-parties/letsencrypt/certificate-authority/account
         property: email

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/aws.default.providerconfig.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/aws.default.providerconfig.yaml
@@ -19,7 +19,7 @@ spec:
   refreshInterval: 720h # 30 days
   secretStoreRef:
     kind: ClusterSecretStore
-    name: kubevault
+    name: vault.chezmoi.sh
   target:
     name: aws-credentials
     template:
@@ -34,9 +34,9 @@ spec:
   data:
     - secretKey: access_key_id
       remoteRef:
-        key: cloud-aws-chezmoish-crossplane
+        key: shared/third-parties/aws/iam/chezmoi.sh/crossplane-rw
         property: access_key_id
     - secretKey: secret_access_key
       remoteRef:
-        key: cloud-aws-chezmoish-crossplane
+        key: shared/third-parties/aws/iam/chezmoi.sh/crossplane-rw
         property: secret_access_key

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.default.providerconfig.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.default.providerconfig.yaml
@@ -19,7 +19,7 @@ spec:
   refreshInterval: 720h # 30 days
   secretStoreRef:
     kind: ClusterSecretStore
-    name: kubevault
+    name: vault.chezmoi.sh
   target:
     name: cloudflare-credentials
     template:
@@ -30,9 +30,9 @@ spec:
   data:
     - secretKey: email
       remoteRef:
-        key: cloud-cloudflare-chezmoish-crossplane
+        key: shared/third-parties/cloudflare/iam/chezmoi.sh/crossplane-rw
         property: email
     - secretKey: api_key
       remoteRef:
-        key: cloud-cloudflare-chezmoish-crossplane
+        key: shared/third-parties/cloudflare/iam/chezmoi.sh/crossplane-rw
         property: api_key


### PR DESCRIPTION
This pull request introduces several improvements to secret management, naming conventions, and infrastructure configuration across multiple clusters and applications. The main focus is on migrating secrets from legacy namespaces and structures to a new standardized Vault-backed approach, updating provider configurations to use the new secret paths, and enhancing documentation and metadata for clarity and maintainability.

**Secret management and migration:**

* Added a dedicated `crossplane-secrets` namespace for storing secrets managed by Crossplane and External Secrets Operator, and updated relevant ArgoCD and Crossplane configurations to include this namespace. [[1]](diffhunk://#diff-21d04101c31ff6ccaf5339752faebe72d477b7fb7f31123c5a86e15b0390b52aR1-R8) [[2]](diffhunk://#diff-c94615cc7b091119a00cd70d743f1e3b2da88bf11703cc5559d27925a15362f6R6-R7) [[3]](diffhunk://#diff-4b4ee6e34b3de37f08195e0c4394460c8a379626720ebf271e8cfb378c4cca32R117-R121)
* Migrated Cloudflare API token for cert-manager in `amiya.akn` from the `kubevault-kvstore` namespace to `crossplane-secrets`, and replaced legacy RBAC resources with an External Secrets Operator `PushSecret` for syncing to Vault.
* Updated provider configurations for AWS and Cloudflare in `chezmoi.sh` to reference new Vault secret paths under `/shared/third-parties/{provider}/...`, and switched the secret store from `kubevault` to `vault.chezmoi.sh`. [[1]](diffhunk://#diff-b09e3299203a96a8fe840429be4379da5100d55f412c8b523fd407dd85e123c6L22-R22) [[2]](diffhunk://#diff-b09e3299203a96a8fe840429be4379da5100d55f412c8b523fd407dd85e123c6L37-R41) [[3]](diffhunk://#diff-fd97a6f016ff9cb2b021de92240cc1376046c9f5e5cbc08e85fd282c47122048L22-R22) [[4]](diffhunk://#diff-fd97a6f016ff9cb2b021de92240cc1376046c9f5e5cbc08e85fd282c47122048L33-R37)
* Updated cert-manager external secret configuration to use Vault and new secret paths for Cloudflare and Let's Encrypt credentials.

**Documentation and conventions:**

* Added new path naming convention for Let's Encrypt account credentials to documentation, clarifying storage location and usage for ACME accounts. [[1]](diffhunk://#diff-ccb98c3f476ab92f2262fb3f37ed4143ccc67c6279790007a5a9c53a6eee882eR192) [[2]](diffhunk://#diff-ccb98c3f476ab92f2262fb3f37ed4143ccc67c6279790007a5a9c53a6eee882eR331)

**Metadata and source references:**

* Moved ArgoCD source reference annotations in `shoot.applicationset.yaml` from the top-level metadata to the template metadata for improved traceability and maintainability. [[1]](diffhunk://#diff-7f343902deea19d9519b78a9bc5f0001dd234c334597b7c335fe50dd77e27d7aL11-L15) [[2]](diffhunk://#diff-7f343902deea19d9519b78a9bc5f0001dd234c334597b7c335fe50dd77e27d7aR24-R29)
* Added source reference annotations to Crossplane ApplicationSet for better tracking of resource origins.

**Cluster-specific changes:**

* Added Cloudflare API token resource for cert-manager in `kazimierz.akn` cluster, scoped for DNS management, following the legacy pattern for now.
* Disabled Envoy Gateway deployment for `kazimierz.akn` cluster, documenting that Traefik is used instead.
* Included default Tailscale Helm values for remote cluster configuration in `kazimierz.akn`.