### PR TITLE
:sparkles:(project:lungmen.akn): Configure ESO to connect to Vault

### DIFF
--- a/projects/lungmen.akn/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/crossplane/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - lungmen.akn.xclustervault.yaml

--- a/projects/lungmen.akn/src/infrastructure/crossplane/lungmen.akn.xclustervault.yaml
+++ b/projects/lungmen.akn/src/infrastructure/crossplane/lungmen.akn.xclustervault.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: lungmen-akn-eso-credentials
+spec:
+  dataFrom:
+    - extract:
+        key: amiya.akn/external-secrets/remote-jwt/lungmen.akn
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  target:
+    name: lungmen-akn-eso-credentials
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          vault.crossplane.chezmoi.sh/cluster-name: lungmen.akn
+---
+apiVersion: vault.chezmoi.sh/v1alpha1
+kind: RemoteClusterVault
+metadata:
+  name: lungmen.akn
+spec:
+  name: lungmen.akn
+  host: https://kubernetes.lungmen.akn.chezmoi.sh:6443

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/external-secrets/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/external-secrets/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - openbao.rbac.yaml

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/external-secrets/openbao.rbac.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/external-secrets/openbao.rbac.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openbao:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: openbao-auth-delegator
+    namespace: external-secrets-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openbao-auth-delegator
+  namespace: external-secrets-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: openbao-auth-delegator
+  name: openbao-auth-delegator-token
+  namespace: external-secrets-system
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
This pull request introduces infrastructure configuration for managing external secrets and vault integration in the `lungmen.akn` project. The changes set up Crossplane and Kubernetes resources to enable secure secret retrieval via External Secrets and configure RBAC for OpenBao authentication.

**Vault and External Secrets integration:**

* Added `lungmen.akn.xclustervault.yaml` defining an `ExternalSecret` resource for fetching credentials from Vault and a `RemoteClusterVault` resource for remote cluster access.
* Created a Crossplane `Kustomization` manifest to include the new vault integration resources.

**Kubernetes RBAC and Service Account setup:**

* Added a Kubernetes `Component` manifest for external secrets, referencing new RBAC resources for OpenBao.
* Defined RBAC resources: a `ClusterRoleBinding` for OpenBao authentication delegation, a dedicated `ServiceAccount`, and a corresponding service account token `Secret` in the `external-secrets-system` namespace.