### PR TITLE
:sparkles:(project:chezmoi.sh,project:lungmen.akn,project:amiya.akn): Configure all TS OAuth client as code

### DIFF
--- a/projects/amiya.akn/src/infrastructure/crossplane/amiya.akn.tailscale-oauth.yaml
+++ b/projects/amiya.akn/src/infrastructure/crossplane/amiya.akn.tailscale-oauth.yaml
@@ -1,0 +1,66 @@
+apiVersion: tf.upbound.io/v1beta1
+kind: Workspace
+metadata:
+  name: amiya.akn-tailscale-oauth-client
+spec:
+  forProvider:
+    module: |
+      resource "tailscale_oauth_client" "self" {
+        description = "OAuth client for TS Operator on amiya-akn"
+        scopes      = ["auth_keys", "devices:core"]
+        tags        = ["tag:kubernetes-cluster"]
+      }
+
+      output "client_id" {
+        description = "OAuth Client ID"
+        value       = tailscale_oauth_client.self.id
+      }
+
+      output "client_secret" {
+        sensitive = true
+        description = "OAuth Client Secret"
+        value       = tailscale_oauth_client.self.key
+      }
+
+    source: Inline
+  providerConfigRef:
+    name: tailscale
+  writeConnectionSecretToRef:
+    name: amiya.akn-tailscale-oauth-client
+    namespace: crossplane-secrets
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: amiya.akn-tailscale-oauth-client
+  namespace: crossplane-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: vault.chezmoi.sh
+  selector:
+    secret:
+      name: amiya.akn-tailscale-oauth-client
+  template:
+    metadata:
+      annotations:
+        description: Tailscale OAuth Client for Tailscale Operator amiya.akn
+        origin: crossplane
+        owner: amiya.akn
+        renewal-process: |
+          Remove the amiya.akn-tailscale-oauth-client Workspace then wait ArgoCD to create a new one.
+        x-apps: tailscale-operator
+  data:
+    - conversionStrategy: None
+      match:
+        secretKey: client_id
+        remoteRef:
+          remoteKey: shared/data/third-parties/tailscale/oauth/amiya.akn
+          property: client_id
+    - conversionStrategy: None
+      match:
+        secretKey: client_secret
+        remoteRef:
+          remoteKey: shared/data/third-parties/tailscale/oauth/amiya.akn
+          property: client_secret

--- a/projects/amiya.akn/src/infrastructure/crossplane/argotails.tailscale-oauth.yaml
+++ b/projects/amiya.akn/src/infrastructure/crossplane/argotails.tailscale-oauth.yaml
@@ -1,0 +1,66 @@
+apiVersion: tf.upbound.io/v1beta1
+kind: Workspace
+metadata:
+  name: argotails-tailscale-oauth-client
+spec:
+  forProvider:
+    module: |
+      resource "tailscale_oauth_client" "self" {
+        description = "OAuth client for Argotails on amiya-akn"
+        scopes      = ["devices:core:read"]
+        tags        = []
+      }
+
+      output "client_id" {
+        description = "OAuth Client ID"
+        value       = tailscale_oauth_client.self.id
+      }
+
+      output "client_secret" {
+        sensitive = true
+        description = "OAuth Client Secret"
+        value       = tailscale_oauth_client.self.key
+      }
+
+    source: Inline
+  providerConfigRef:
+    name: tailscale
+  writeConnectionSecretToRef:
+    name: argotails-tailscale-oauth-client
+    namespace: crossplane-secrets
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: argotails-tailscale-oauth-client
+  namespace: crossplane-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: vault.chezmoi.sh
+  selector:
+    secret:
+      name: argotails-tailscale-oauth-client
+  template:
+    metadata:
+      annotations:
+        description: Tailscale OAuth Client for Argotails on amiya.akn
+        origin: crossplane
+        owner: amiya.akn/argotails
+        renewal-process: |
+          Remove the argotails-tailscale-oauth-client Workspace then wait ArgoCD to create a new one.
+        x-apps: argotails
+  data:
+    - conversionStrategy: None
+      match:
+        secretKey: client_id
+        remoteRef:
+          remoteKey: amiya.akn/data/argocd/network/argotails-auth
+          property: client_id
+    - conversionStrategy: None
+      match:
+        secretKey: client_secret
+        remoteRef:
+          remoteKey: amiya.akn/data/argocd/network/argotails-auth
+          property: client_secret

--- a/projects/amiya.akn/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/amiya.akn/src/infrastructure/crossplane/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - amiya.akn.tailscale-oauth.yaml
   - aws.iam.authelia.yaml
   - cloudflare.iam.cert-manager.yaml
 

--- a/projects/amiya.akn/src/infrastructure/kubernetes/tailscale/kustomization.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/tailscale/kustomization.yaml
@@ -3,15 +3,19 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
+  # Plugin required for Tailscale to access TUN/TAP interfaces
   - ../../../../../../catalog/kustomize/tun-device-plugin
 
+  # Additional configuration for remote cluster resource access
   - remote-cluster.proxyclass.yaml
   - ts-dns.dnsconfig.yaml
 
+  # Security policies (NetworkPolicies, PodSecurityStandards, etc.)
   - security/
 
 patches:
   - path: restricted.proxyclass.yaml
+  - path: operator-oauth.externalsecret.yaml
 
 generators:
   - # Protect some "private" information like internal IPs addresses.

--- a/projects/amiya.akn/src/infrastructure/kubernetes/tailscale/operator-oauth.externalsecret.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/tailscale/operator-oauth.externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: operator-oauth
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  data:
+    - remoteRef:
+        key: shared/data/third-parties/tailscale/oauth/amiya.akn
+        property: client_id
+      secretKey: client_id
+    - remoteRef:
+        key: shared/data/third-parties/tailscale/oauth/amiya.akn
+        property: client_secret
+      secretKey: client_secret

--- a/projects/amiya.akn/src/infrastructure/kubernetes/tailscale/override.helmvalues.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/tailscale/override.helmvalues.yaml
@@ -1,4 +1,0 @@
----
-operatorConfig:
-  defaultTags:
-    - tag:kubernetes-seed

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - cloudflare.default.providerconfig.yaml
   - terraform.provider.yaml
   - terraform.default.providerconfig.yaml
+  - terraform.tailscale.providerconfig.yaml
 
   # Vault provider configuration
   - vault.provider.yaml

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
   - aws.default.providerconfig.yaml
   - cloudflare.provider.yaml
   - cloudflare.default.providerconfig.yaml
+  - terraform.provider.yaml
+  - terraform.default.providerconfig.yaml
 
   # Vault provider configuration
   - vault.provider.yaml

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/runtimeconfigs.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/runtimeconfigs.yaml
@@ -30,3 +30,40 @@ spec:
           volumes:
             - name: tmpdir
               emptyDir: {}
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: hardened-for-terraform
+spec:
+  deploymentTemplate:
+    spec:
+      selector: {}
+      template:
+        spec:
+          securityContext:
+            fsGroup: 48291
+            runAsNonRoot: true
+            runAsUser: 48291
+            runAsGroup: 48291
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: package-runtime
+              env:
+                - name: TF_PLUGIN_CACHE_DIR
+                  value: /tmp
+                - name: XP_TF_DIR
+                  value: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: [ALL]
+                privileged: false
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - name: tmpdir
+                  mountPath: /tmp
+          volumes:
+            - name: tmpdir
+              emptyDir: {}

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/terraform.default.providerconfig.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/terraform.default.providerconfig.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: tf.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  configuration: |
+    // Modules _must_ use remote state. The provider does not persist state.
+    terraform {
+      backend "kubernetes" {
+        secret_suffix     = "providerconfig-default"
+        namespace         = "crossplane"
+        in_cluster_config = true
+      }
+    }

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/terraform.provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/terraform.provider.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-terraform
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.0.0
+  runtimeConfigRef:
+    name: hardened-for-terraform

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/terraform.tailscale.providerconfig.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/terraform.tailscale.providerconfig.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: tf.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: tailscale
+spec:
+  configuration: |
+    // Modules _must_ use remote state. The provider does not persist state.
+    terraform {
+      backend "kubernetes" {
+        secret_suffix     = "providerconfig-tailscale"
+        namespace         = "crossplane"
+        in_cluster_config = true
+      }
+    }
+
+    // Install Tailscale provider
+    variable "oauth_client_id" { type = string }
+    variable "oauth_client_secret" { type = string }
+
+    terraform {
+      required_providers {
+        tailscale = {
+          source  = "tailscale/tailscale"
+          version = "0.21.1"
+        }
+      }
+    }
+
+    provider "tailscale" {
+      oauth_client_id = var.oauth_client_id
+      oauth_client_secret = var.oauth_client_secret
+    }
+  credentials:
+    - filename: terraform.tfvars.json
+      secretRef:
+        name: tailscale-credentials
+        key: terraform.tfvars.json
+        namespace: crossplane
+      source: Secret
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tailscale-credentials
+spec:
+  refreshInterval: 720h # 30 days
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  dataFrom:
+    - extract:
+        key: amiya.akn/crossplane/providers/tailscale
+  target:
+    template:
+      type: Opaque
+      engineVersion: v2
+      data:
+        terraform.tfvars.json: |
+          {
+            "oauth_client_id": "{{ .oauth_client_id }}",
+            "oauth_client_secret": "{{ .oauth_client_secret }}"
+          }

--- a/projects/lungmen.akn/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/crossplane/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 
 resources:
   - cloudflare.iam.cert-manager.yaml
+  - lungmen.akn.tailscale-oauth.yaml
   - lungmen.akn.xclustervault.yaml

--- a/projects/lungmen.akn/src/infrastructure/crossplane/lungmen.akn.tailscale-oauth.yaml
+++ b/projects/lungmen.akn/src/infrastructure/crossplane/lungmen.akn.tailscale-oauth.yaml
@@ -1,0 +1,66 @@
+apiVersion: tf.upbound.io/v1beta1
+kind: Workspace
+metadata:
+  name: lungmen.akn-tailscale-oauth-client
+spec:
+  forProvider:
+    module: |
+      resource "tailscale_oauth_client" "self" {
+        description = "OAuth client for TS Operator on lungmen-akn"
+        scopes      = ["auth_keys", "devices:core"]
+        tags        = ["tag:kubernetes-cluster"]
+      }
+
+      output "client_id" {
+        description = "OAuth Client ID"
+        value       = tailscale_oauth_client.self.id
+      }
+
+      output "client_secret" {
+        sensitive = true
+        description = "OAuth Client Secret"
+        value       = tailscale_oauth_client.self.key
+      }
+
+    source: Inline
+  providerConfigRef:
+    name: tailscale
+  writeConnectionSecretToRef:
+    name: lungmen.akn-tailscale-oauth-client
+    namespace: crossplane-secrets
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: lungmen.akn-tailscale-oauth-client
+  namespace: crossplane-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: vault.chezmoi.sh
+  selector:
+    secret:
+      name: lungmen.akn-tailscale-oauth-client
+  template:
+    metadata:
+      annotations:
+        description: Tailscale OAuth Client for Tailscale Operator lungmen.akn
+        origin: crossplane
+        owner: lungmen.akn
+        renewal-process: |
+          Remove the lungmen.akn-tailscale-oauth-client Workspace then wait ArgoCD to create a new one.
+        x-apps: tailscale-operator
+  data:
+    - conversionStrategy: None
+      match:
+        secretKey: client_id
+        remoteRef:
+          remoteKey: shared/data/third-parties/tailscale/oauth/lungmen.akn
+          property: client_id
+    - conversionStrategy: None
+      match:
+        secretKey: client_secret
+        remoteRef:
+          remoteKey: shared/data/third-parties/tailscale/oauth/lungmen.akn
+          property: client_secret

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/tailscale/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/tailscale/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: operator-oauth.externalsecret.yaml

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/tailscale/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/tailscale/kustomization.yaml
@@ -2,5 +2,10 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+resources:
+  # Plugin required for Tailscale to access TUN/TAP interfaces
+  - ../../../../../../catalog/kustomize/tun-device-plugin
+
 patches:
+  - path: restricted.proxyclass.yaml
   - path: operator-oauth.externalsecret.yaml

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/tailscale/operator-oauth.externalsecret.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/tailscale/operator-oauth.externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: operator-oauth
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  data:
+    - remoteRef:
+        key: shared/data/third-parties/tailscale/oauth/lungmen.akn
+        property: client_id
+      secretKey: client_id
+    - remoteRef:
+        key: shared/data/third-parties/tailscale/oauth/lungmen.akn
+        property: client_secret
+      secretKey: client_secret

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/tailscale/restricted.proxyclass.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/tailscale/restricted.proxyclass.yaml
@@ -1,0 +1,33 @@
+# To adhere to security best practices, most clusters are configured with Admission
+# Controllers in "restricted" mode.
+# However, the Tailscale Operator requires modifying the pods' Security Context.
+# Thus, it is essential to create a ProxyClass with the appropriate configurations to
+# allow the operator to manage these Security Contexts.
+---
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyClass
+metadata:
+  name: restricted
+spec:
+  statefulSet:
+    pod:
+      tailscaleContainer:
+        resources:
+          requests:
+            squat.ai/tun: "1"
+          limits:
+            squat.ai/tun: "1"
+---
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyClass
+metadata:
+  name: restricted-egress
+spec:
+  statefulSet:
+    pod:
+      tailscaleContainer:
+        resources:
+          requests:
+            squat.ai/tun: "1"
+          limits:
+            squat.ai/tun: "1"


### PR DESCRIPTION
This pull request introduces Terraform-based automation for Tailscale OAuth client provisioning and secret management across the `amiya.akn` and `lungmen.akn` clusters. It also adds hardened runtime configurations and provider setups for Crossplane Terraform integration, and refines Kubernetes manifests for secure operator deployments. Key changes are grouped below by theme.

**Tailscale OAuth Client Automation (Terraform & Secrets):**

* Added Terraform `Workspace` and `PushSecret` resources for automated creation and secret management of Tailscale OAuth clients in both `amiya.akn` and `lungmen.akn` clusters (`amiya.akn.tailscale-oauth.yaml`, `lungmen.akn.tailscale-oauth.yaml`, `argotails.tailscale-oauth.yaml`). [[1]](diffhunk://#diff-867f25f2dd97a66673642fa861dc0e716da07dd9d537b4621a81ae9cbdb6444aR1-R66) [[2]](diffhunk://#diff-d6aef5efff317c978508f698f3827a5eb295108e07cc1ad94764b0309a0f437cR1-R66) [[3]](diffhunk://#diff-cb0a60f391218c4e5e3045f4825bcd9b2832e98062f44581120625d4cc10fd21R1-R66)
* Integrated external secret synchronization for Tailscale Operator OAuth credentials in Kubernetes (`operator-oauth.externalsecret.yaml` for both clusters). [[1]](diffhunk://#diff-a15cf4a64363c275d5a47bbfc6d247b6e1edffb7246e213d02ebb05f53ffa188R1-R18) [[2]](diffhunk://#diff-31d3423bbe48b50da2068f385b322cb2060edf37026324f8976100574352a6ceR1-R18)

**Crossplane Terraform Provider Integration:**

* Added and configured the Crossplane Terraform provider, including a hardened runtime config and provider configs for default and Tailscale-specific usage (`terraform.provider.yaml`, `terraform.default.providerconfig.yaml`, `terraform.tailscale.providerconfig.yaml`, `runtimeconfigs.yaml`). [[1]](diffhunk://#diff-4415bf4037260ab242a0f9f73afb1601559c9628aa41f5dea538a1c4188b77deR1-R9) [[2]](diffhunk://#diff-f4d458e5ab0e6c938d02414df79ac3479bd649f71cc35cb0979bb54540489d36R1-R15) [[3]](diffhunk://#diff-74bc887f33caac73bd128548dfb40586e89a180ac0aa0b423fbf60d37cc22baeR1-R63) [[4]](diffhunk://#diff-d550009428fcdb9344c33d481a7096d651baec3bc2cf11cf15d7a02aba30e1beR33-R69)
* Updated Crossplane kustomization manifests to include new Terraform provider resources.

**Kubernetes Operator & Security Enhancements:**

* Updated Kubernetes manifests to include Tailscale plugins, remote cluster access, security policies, and OAuth secret integration for operator deployments in both clusters (`kustomization.yaml`, `restricted.proxyclass.yaml`). [[1]](diffhunk://#diff-8b85e27a3ad640c9f46271cfdb0b9ae7ea287dfa8976f8fa1f3bd9e451c53398R6-R18) [[2]](diffhunk://#diff-ea5494b5a39e1d37769eff81b4c33663a30700110dc53806bfd566340bb34838R1-R11) [[3]](diffhunk://#diff-ff6a0ff66c3a1adefabe5067c18ca36e969eb529b5507b147727e01caa0552adR1-R33)
* Removed default tags from Tailscale operator Helm values to streamline configuration.

**Cluster Resource Inclusion:**

* Updated kustomization files to include new OAuth automation and secret resources in both clusters. [[1]](diffhunk://#diff-57eb64e08742a800d9d141e4bedaf7c532817f4e7335afbd7c5e72ef714848a1R6) [[2]](diffhunk://#diff-2f9947cb2af017141da9282c3c3d1a6e2ad47f46957fdb738bfd90de5dca2161R7)

---

**References:**  
[[1]](diffhunk://#diff-867f25f2dd97a66673642fa861dc0e716da07dd9d537b4621a81ae9cbdb6444aR1-R66) [[2]](diffhunk://#diff-d6aef5efff317c978508f698f3827a5eb295108e07cc1ad94764b0309a0f437cR1-R66) [[3]](diffhunk://#diff-cb0a60f391218c4e5e3045f4825bcd9b2832e98062f44581120625d4cc10fd21R1-R66) [[4]](diffhunk://#diff-a15cf4a64363c275d5a47bbfc6d247b6e1edffb7246e213d02ebb05f53ffa188R1-R18) [[5]](diffhunk://#diff-31d3423bbe48b50da2068f385b322cb2060edf37026324f8976100574352a6ceR1-R18) [[6]](diffhunk://#diff-4415bf4037260ab242a0f9f73afb1601559c9628aa41f5dea538a1c4188b77deR1-R9) [[7]](diffhunk://#diff-f4d458e5ab0e6c938d02414df79ac3479bd649f71cc35cb0979bb54540489d36R1-R15) [[8]](diffhunk://#diff-74bc887f33caac73bd128548dfb40586e89a180ac0aa0b423fbf60d37cc22baeR1-R63) [[9]](diffhunk://#diff-d550009428fcdb9344c33d481a7096d651baec3bc2cf11cf15d7a02aba30e1beR33-R69) [[10]](diffhunk://#diff-3b759ac543e0bab60f91962d4e321f20a9e95d6125902e5e195bf93c8b62dbb2R19-R21) [[11]](diffhunk://#diff-8b85e27a3ad640c9f46271cfdb0b9ae7ea287dfa8976f8fa1f3bd9e451c53398R6-R18) [[12]](diffhunk://#diff-ea5494b5a39e1d37769eff81b4c33663a30700110dc53806bfd566340bb34838R1-R11) [[13]](diffhunk://#diff-ff6a0ff66c3a1adefabe5067c18ca36e969eb529b5507b147727e01caa0552adR1-R33) [[14]](diffhunk://#diff-58d3d5139cab5174fd60eb3b9022097763ca7f5c792a6e8a49846642548f89c8L1-L4) [[15]](diffhunk://#diff-57eb64e08742a800d9d141e4bedaf7c532817f4e7335afbd7c5e72ef714848a1R6) [[16]](diffhunk://#diff-2f9947cb2af017141da9282c3c3d1a6e2ad47f46957fdb738bfd90de5dca2161R7)