### PR TITLE
Revert ":arrow_up: (deps): Update Helm release longhorn to v1.10.0"

### DIFF
--- a/projects/amiya.akn/src/infrastructure/kubernetes/*longhorn/kustomization.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/*longhorn/kustomization.yaml
@@ -13,5 +13,5 @@ resources:
 helmCharts:
   - name: longhorn
     repo: https://charts.longhorn.io/
-    version: 1.10.0
+    version: 1.9.2
     valuesFile: longhorn.helmvalues/default.yaml

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/*longhorn/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/*longhorn/kustomization.yaml
@@ -14,5 +14,5 @@ resources:
 helmCharts:
   - name: longhorn
     repo: https://charts.longhorn.io/
-    version: 1.10.0
+    version: 1.9.2
     valuesFile: longhorn.helmvalues/default.yaml


### PR DESCRIPTION
Reverts chezmoidotsh/arcane#443 (failed to upgrade with 1.10.0 ... see https://github.com/longhorn/longhorn/issues/11864)