### PR TITLE
:recycle:(project:amiya.akn): Migrate Pocket ID to database-backed file storage

### DIFF
--- a/projects/amiya.akn/src/apps/*pocket-id/kustomization.yaml
+++ b/projects/amiya.akn/src/apps/*pocket-id/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
   - pocket-id.postgresql.yaml
   - pocket-id.postgresql-backup.yaml
   - pocket-id.postgresql-objectstore.yaml
-  - pocket-id.statefulset.yaml
+  - pocket-id.deployment.yaml
   - security/
 
 images:

--- a/projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml
+++ b/projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml
@@ -1,17 +1,15 @@
 ---
-# trunk-ignore-all(trivy/KSV110): Namespace is managed by kustomize
+# trunk-ignore-all(checkov/CKV_K8S_21): Namespace is managed by kustomize
 # trunk-ignore-all(checkov/CKV_K8S_35): SMTP_USER cannot be exposed as a file like other secrets
-# trunk-ignore-all(checkov/CKV2_K8S_6): NetworkPolicy are managed into security/ folder
 # trunk-ignore-all(trivy/KSV0125): The image comes from a Github registry so ... I trust it for now
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: application
     app.kubernetes.io/instance: pocket-id-server
   name: pocket-id-server
 spec:
-  serviceName: pocket-id
   replicas: 1
   selector:
     matchLabels:
@@ -57,14 +55,14 @@ spec:
               value: postgres
             - name: DB_CONNECTION_STRING_FILE
               value: /var/run/secrets/pocket-id.org/postgres_connection_string
+            - name: FILE_BACKEND
+              value: database
             # Security and encryption
             - name: KEYS_STORAGE
               value: database
             - name: ENCRYPTION_KEY_FILE
               value: /var/run/secrets/pocket-id.org/encryption_key
             # Storage paths
-            - name: UPLOAD_PATH
-              value: /data/uploads
             - name: GEOLITE_DB_PATH
               value: /data/GeoLite2-City.mmdb
 
@@ -173,6 +171,8 @@ spec:
               mountPath: /var/run/secrets/pocket-id.org
               readOnly: true
       volumes:
+        - name: data
+          emptyDir: {}
         - name: pocket-id-secrets
           projected:
             sources:
@@ -197,21 +197,6 @@ spec:
         runAsUser: 45706
         seccompProfile:
           type: RuntimeDefault
-  volumeClaimTemplates:
-    - apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: data
-        labels:
-          app.kubernetes.io/component: storage
-          recurring-job-group.longhorn.io/daily: enabled
-          recurring-job-group.longhorn.io/weekly: enabled
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Feature Overview

> [!WARNING]
> **Dependency**: This PR depends on the upcoming Pocket ID release that includes database-backed file storage support, notably [pocket-id/pocket-id#1091](https://github.com/pocket-id/pocket-id/pull/1091). This PR should **not be merged** until that feature is released.

> [!NOTE]
> **Summary**: Migrate Pocket ID from StatefulSet with persistent volume to Deployment with database-backed file storage, eliminating the need for persistent storage management and simplifying backup procedures through unified CloudNativePG backups.

## Context and Motivation

**Current State:**

Pocket ID currently runs as a StatefulSet with a 1Gi PersistentVolumeClaim for storing uploaded files (avatars, logos, etc.). This architecture requires:
* Persistent storage management via Longhorn
* Separate backup configuration with recurring job labels (`daily`, `weekly` groups)
* Dual backup strategy coordination between PostgreSQL (CloudNativePG S3) and filesystem (Longhorn snapshots)
* Volume lifecycle management independent of application data

**Problem Statement:**

StatefulSet architecture with persistent volumes introduces operational complexity through split backup strategies. Application data resides in PostgreSQL with CloudNativePG automated S3 backups, while uploaded files require separate Longhorn recurring jobs with different retention policies. This dual-backup approach increases recovery complexity and potential for inconsistency between database state and filesystem state.

**Why Now:**

Pocket ID upstream has implemented database-backed file storage functionality ([pocket-id/pocket-id#1091](https://github.com/pocket-id/pocket-id/pull/1091)), enabling consolidation of all application data (database records + file storage) into a single PostgreSQL cluster with unified backup strategy. This represents an opportunity to simplify deployment architecture and backup procedures while maintaining full feature parity.

## Implementation Details

### Component 1: Workload Type Migration (StatefulSet → Deployment)

**Purpose:**

Convert Pocket ID from StatefulSet to standard Deployment architecture, as persistent storage is no longer required with database-backed file storage.

**Technical Details:**

Migrated workload definition from StatefulSet to Deployment with the following changes:

* Removed `serviceName: pocket-id` field (StatefulSet-specific configuration not applicable to Deployments)
* Removed `volumeClaimTemplates` section (no persistent storage required)
* Replaced PersistentVolumeClaim with `emptyDir` volume for temporary storage (GeoLite2 database)
* Maintained all other specifications: replicas, selectors, pod template, security context, probes

Deployment architecture enables standard Kubernetes rolling updates without StatefulSet ordering constraints, simplifying operational procedures.

**Key Files Modified:**

* `projects/amiya.akn/src/apps/*pocket-id/pocket-id.statefulset.yaml` → `projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml` - Workload type migration (projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml:1-215)
* `projects/amiya.akn/src/apps/*pocket-id/kustomization.yaml` - Updated resource reference (projects/amiya.akn/src/apps/*pocket-id/kustomization.yaml:27)

### Component 2: File Storage Backend Configuration

**Purpose:**

Configure Pocket ID to use database-backed file storage instead of filesystem-based storage.

**Technical Details:**

Updated environment variable configuration:

* **Added**: `FILE_BACKEND=database` - Enables database-backed file storage via PostgreSQL BLOBs
* **Removed**: `UPLOAD_PATH=/data/uploads` - No longer required as files are stored in database

File storage now handled entirely by PostgreSQL via CloudNativePG cluster (`pocket-id-database`), eliminating need for filesystem paths and persistent volumes. Uploaded files (avatars, organization logos, custom branding assets) stored as database records with full ACID guarantees and integrated backup via CloudNativePG S3 retention policies.

**Key Files Modified:**

* `projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml` - Environment variable updates (projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml:59-60)

### Component 3: Volume Configuration Simplification

**Purpose:**

Simplify volume configuration by replacing persistent storage with ephemeral storage for temporary files.

**Technical Details:**

Replaced PersistentVolumeClaim with emptyDir volume:

```yaml
volumes:
  - name: data
    emptyDir: {}
```

EmptyDir volume provides temporary storage for GeoLite2 geolocation database (`/data/GeoLite2-City.mmdb`) which is downloaded on container startup and does not require persistence across pod restarts. Volume lifecycle tied to pod lifecycle, automatically cleaned up on pod deletion.

Removed volumeClaimTemplates configuration:
* No persistent storage allocation required
* No Longhorn recurring job labels (`daily`, `weekly` backup groups)
* No storage capacity management (eliminated 1Gi storage request)
* No separate backup strategy for filesystem data

**Key Files Modified:**

* `projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml` - Volume configuration changes (projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml:174-176)

### Component 4: Unified Backup Strategy

**Purpose:**

Consolidate all Pocket ID data (database records + uploaded files) into a single backup strategy via CloudNativePG automated S3 backups.

**Technical Details:**

**Before (Dual Backup Strategy)**:
* **PostgreSQL data**: CloudNativePG S3 backups with 7-day retention
* **Filesystem data**: Longhorn recurring jobs (`daily`, `weekly` groups) with separate retention policies
* **Recovery complexity**: Requires coordinating PostgreSQL restore with filesystem snapshot restore, ensuring consistency between database state and file state
* **Potential inconsistency**: Database records may reference files not present in filesystem backup (or vice versa) if backup timing differs

**After (Unified Backup Strategy)**:
* **All data**: CloudNativePG S3 backups with consistent 7-day retention
* **Single recovery point**: Database backup contains both application data and uploaded files
* **Guaranteed consistency**: ACID transaction guarantees ensure database records and file storage always consistent
* **Simplified recovery**: Single restore operation (CloudNativePG backup) recovers complete application state

**Operational Benefits**:
* Eliminated Longhorn recurring job configuration for Pocket ID volumes
* Reduced backup storage overhead (no duplicate file storage in Longhorn snapshots)
* Simplified disaster recovery procedures (single backup source)
* Consistent retention policies across all application data
* Reduced operational complexity for backup monitoring and verification

**Key Impact:**

This migration eliminates the need to maintain and monitor two separate backup systems for a single application, reducing the operational burden and potential for recovery failures due to backup inconsistency.

## Architecture and Design Decisions

**Architectural Approach:**

Simplified deployment architecture leveraging database-backed file storage to eliminate persistent volume requirements, reducing operational complexity and unifying backup strategy while maintaining full feature parity.

**Design Decisions:**

1. **Decision**: Database-backed file storage over filesystem storage
   * **Rationale**: Eliminates need for persistent volumes, **simplifies backup strategy to single CloudNativePG S3 backup**, provides ACID guarantees for file operations, ensures consistency between database records and file storage, reduces storage management overhead. Database storage acceptable for Pocket ID's file size requirements (primarily avatars and logos).
   * **Alternatives Considered**: Keep filesystem storage with PVC (operational complexity + dual backup strategy), Object storage backend (requires S3-compatible infrastructure + additional backup configuration)

2. **Decision**: Deployment over StatefulSet
   * **Rationale**: StatefulSet ordering and persistent identity not required when no persistent volumes are used. Deployment provides standard Kubernetes rolling update behavior with simpler operational semantics. No functional difference for single-replica workload.
   * **Alternatives Considered**: Keep StatefulSet with emptyDir (unnecessary complexity), DaemonSet (inappropriate for application deployment)

3. **Decision**: EmptyDir for temporary storage
   * **Rationale**: GeoLite2 database downloaded on startup and does not require persistence. EmptyDir provides sufficient temporary storage without persistent volume overhead. Automatic cleanup on pod deletion prevents storage accumulation.
   * **Alternatives Considered**: ConfigMap for GeoLite2 (size limitations), Persistent volume (unnecessary for ephemeral data + would require separate backup strategy), No volume (breaks GeoLite2 functionality)

4. **Decision**: Unified backup strategy via CloudNativePG
   * **Rationale**: Single backup source (PostgreSQL S3 backups) eliminates operational complexity of coordinating dual backup strategies. Guaranteed consistency between database records and file storage through ACID transactions. Simplified disaster recovery with single restore operation. Reduced backup storage overhead by eliminating Longhorn snapshot requirements.
   * **Alternatives Considered**: Keep dual backup strategy (unnecessary complexity), Application-level backup (reinventing CloudNativePG functionality), No file backups (data loss risk)

**Infrastructure Impact:**

* [x] Reduced storage requirements (eliminated 1Gi PVC)
* [x] **Simplified backup configuration (eliminated Longhorn recurring jobs for Pocket ID)**
* [x] **Unified backup strategy (all data in CloudNativePG S3 backups)**
* [x] Workload type change (StatefulSet → Deployment)
* [x] Database storage increase (file storage now in PostgreSQL)

**Integration Points:**

* Integrates with: CloudNativePG PostgreSQL Cluster
  * Via: `FILE_BACKEND=database` configuration
  * Purpose: Database-backed file storage with S3 backup integration

* Integrates with: CloudNativePG S3 Backup System
  * Via: Existing PostgreSQL cluster backup configuration
  * Purpose: **Unified backup for both application data and uploaded files**

* Integrates with: Existing PostgreSQL connection
  * Via: `DB_CONNECTION_STRING_FILE` environment variable
  * Purpose: Reuses existing database connection for file storage operations

## Security Considerations

**Security Measures Maintained:**

* Database connection credentials via projected volume with read-only mount
* Encryption key management unchanged (database-backed)
* Security context with non-root user (UID 45706) and seccomp profile
* Network policies unchanged (managed in `security/` folder)
* PostgreSQL SSL/TLS connection for file storage operations

**Security Impact Analysis:**

No new attack vectors introduced. File storage moved from filesystem to database while maintaining encryption-at-rest via CloudNativePG configuration. Database-backed storage provides additional integrity guarantees through ACID transactions. Secret management unchanged with same projected volume approach.

**Data Protection:**

Files stored in PostgreSQL with CloudNativePG automated S3 backups (existing configuration). Backup retention policies apply to file storage data. No changes to encryption-at-rest or encryption-in-transit. Database BLOB storage with transaction integrity for file operations. **Unified backup strategy ensures consistent recovery point for all application data.**

## Testing and Validation

**Testing Required Before Merge:**

* [x] Verify Pocket ID release includes `FILE_BACKEND=database` support
* [ ] Test file upload functionality (avatars, organization logos)
* [ ] Verify file retrieval from database storage
* [ ] Confirm GeoLite2 database download to emptyDir volume
* [ ] Test pod restart with file persistence in database
* [ ] Validate PostgreSQL storage usage with file uploads
* [ ] **Verify CloudNativePG backup includes file storage data**
* [ ] **Test disaster recovery with unified backup restore**

**Validation Instructions:**

```bash
# Verify Deployment rollout
kubectl -n pocket-id rollout status deployment/pocket-id-server

# Check pod status
kubectl -n pocket-id get pods -l app.kubernetes.io/instance=pocket-id-server

# Verify environment variables
kubectl -n pocket-id exec deployment/pocket-id-server -- env | grep -E 'FILE_BACKEND|UPLOAD_PATH'

# Check volume mounts
kubectl -n pocket-id exec deployment/pocket-id-server -- df -h /data

# Verify no PersistentVolumeClaims exist
kubectl -n pocket-id get pvc

# Test file upload via web interface
# 1. Navigate to Pocket ID admin interface
# 2. Upload organization logo
# 3. Verify display in UI
# 4. Restart pod
# 5. Confirm logo persists after restart

# Verify PostgreSQL storage usage
kubectl -n pocket-id exec -it pocket-id-database-1 -- psql -U pocket-id -c "SELECT pg_size_pretty(pg_database_size('pocket-id'));"

# Verify CloudNativePG backup includes file data
kubectl -n pocket-id get backup
kubectl -n pocket-id describe backup <latest-backup-name>
```

**Expected Outcomes:**

* Deployment successfully rolls out with no persistent volumes
* File uploads stored in PostgreSQL database
* File retrieval works correctly from database storage
* Pod restarts do not lose uploaded files (database persistence)
* GeoLite2 database downloaded to emptyDir on startup
* No PersistentVolumeClaim resources in pocket-id namespace
* **CloudNativePG backups include file storage data**
* **Single backup source for complete application state**

## Deployment Strategy

**Deployment Method:**

* [x] ArgoCD automated sync (manual-sync application)
* [x] Rolling update via Deployment

**Deployment Prerequisites:**

* Pocket ID release with database-backed file storage support ([pocket-id/pocket-id#1091](https://github.com/pocket-id/pocket-id/pull/1091)) **must be available**
* CloudNativePG PostgreSQL cluster healthy and accessible
* **CloudNativePG backup verification before migration**
* Existing Pocket ID data migrated to new storage backend (if applicable)

**Migration Procedure:**

1. **Pre-migration backup**: Create manual CloudNativePG backup before deployment
2. **Backup verification**: Verify backup completion and S3 upload success
3. **Application sync**: Trigger ArgoCD sync for pocket-id application
4. **Deployment rollout**: Kubernetes performs rolling update (StatefulSet → Deployment)
5. **Data migration**: Pocket ID automatically migrates existing files on startup (if migration logic implemented by upstream)
6. **Validation**: Test file upload/retrieval functionality
7. **Backup validation**: Verify CloudNativePG backup includes file storage data
8. **Cleanup**: Remove old PersistentVolumeClaim after validation

**Rollback Procedure:**

1. Revert git commit and sync via ArgoCD
2. Deployment rolls back to StatefulSet with persistent volume
3. Files stored in database during migration period may need manual extraction
4. Restore CloudNativePG backup if data corruption occurred (unified backup contains all data)

## Performance and Resource Impact

**Resource Changes:**

* **Storage**: -1Gi PersistentVolume (eliminated), +variable PostgreSQL storage (depends on uploaded files)
* **Memory**: No change (same container memory limits)
* **CPU**: Minimal increase for database BLOB operations
* **Network**: Minimal increase for database file storage I/O
* **Backup storage**: Reduced overall backup storage (eliminated Longhorn snapshots for Pocket ID)

**Performance Considerations:**

Database-backed file storage introduces database I/O for file operations (upload/download). Impact expected to be minimal for Pocket ID's use case (small file sizes, infrequent uploads). PostgreSQL BLOB storage provides acceptable performance for avatar and logo serving. CloudNativePG cluster configured with appropriate resource limits for additional storage load.

**Storage Estimation:**

Typical Pocket ID deployment:
* User avatars: ~50-100KB each, ~100 users → ~10MB
* Organization logos: ~100-200KB each, ~10 organizations → ~2MB
* Custom branding: ~1-2MB total
* **Total estimated**: <20MB additional PostgreSQL storage
* **Backup storage reduction**: Eliminated 1Gi Longhorn recurring job snapshots

**Operational Efficiency:**

* Simplified backup monitoring (single backup system to monitor)
* Reduced backup verification procedures (no need to coordinate PostgreSQL + Longhorn backups)
* Faster disaster recovery (single restore operation vs. dual restore)
* Reduced backup storage costs (eliminated duplicate file storage in Longhorn)

## Related Work and References

**Upstream References:**

* [pocket-id/pocket-id#1091](https://github.com/pocket-id/pocket-id/pull/1091) - Database-backed file storage implementation (dependency)

**Related Pull Requests:**

* None (first Pocket ID architecture change in amiya.akn)

**Documentation Updates:**

* No documentation updates required (internal architecture change)

---
<sub>Analysis and writing by Claude under human supervision</sub>