### PR TITLE
:recycle:(project:amiya.akn): Migrate Pocket ID to Deployment with DB storage

### DIFF
--- a/projects/amiya.akn/src/apps/*pocket-id/kustomization.yaml
+++ b/projects/amiya.akn/src/apps/*pocket-id/kustomization.yaml
@@ -5,24 +5,25 @@ namespace: pocket-id
 
 labels:
   - pairs:
+      app.kubernetes.io/instance: pocket-id
       app.kubernetes.io/name: pocket-id
     includeTemplates: true
     includeSelectors: true
   - pairs:
-      app.kubernetes.io/instance: pocket-id
-    includeTemplates: true
-    includeSelectors: true
-  - pairs:
       # renovate: datasource=docker depName=ghcr.io/pocket-id/pocket-id
-      app.kubernetes.io/version: v1.16.0-distroless
-    includeTemplates: true
+      app.kubernetes.io/version: v1.16.0
 
 resources:
   - pocket-id-public.httproute.yaml
+  - pocket-id.deployment.yaml
   - pocket-id.externalsecret.yaml
   - pocket-id.httproute.yaml
-  - pocket-id.postgresql.yaml
   - pocket-id.postgresql-backup.yaml
   - pocket-id.postgresql-objectstore.yaml
-  - pocket-id.statefulset.yaml
+  - pocket-id.postgresql.yaml
   - security/
+
+images:
+  # renovate: datasource=docker depName=ghcr.io/pocket-id/pocket-id
+  - name: ghcr.io/pocket-id/pocket-id
+    newTag: v1.16.0

--- a/projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml
+++ b/projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml
@@ -1,17 +1,15 @@
 ---
-# trunk-ignore-all(trivy/KSV110): Namespace is managed by kustomize
 # trunk-ignore-all(checkov/CKV_K8S_35): SMTP_USER cannot be exposed as a file like other secrets
-# trunk-ignore-all(checkov/CKV2_K8S_6): NetworkPolicy are managed into security/ folder
 # trunk-ignore-all(trivy/KSV0125): The image comes from a Github registry so ... I trust it for now
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/component: application
     app.kubernetes.io/instance: pocket-id-server
   name: pocket-id-server
+  namespace: pocket-id
 spec:
-  serviceName: pocket-id
   replicas: 1
   selector:
     matchLabels:
@@ -63,8 +61,8 @@ spec:
             - name: ENCRYPTION_KEY_FILE
               value: /var/run/secrets/pocket-id.org/encryption_key
             # Storage paths
-            - name: UPLOAD_PATH
-              value: /data/uploads
+            - name: FILE_BACKEND
+              value: database
             - name: GEOLITE_DB_PATH
               value: /data/GeoLite2-City.mmdb
 
@@ -173,6 +171,8 @@ spec:
               mountPath: /var/run/secrets/pocket-id.org
               readOnly: true
       volumes:
+        - name: data
+          emptyDir: {}
         - name: pocket-id-secrets
           projected:
             sources:
@@ -197,21 +197,6 @@ spec:
         runAsUser: 45706
         seccompProfile:
           type: RuntimeDefault
-  volumeClaimTemplates:
-    - apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: data
-        labels:
-          app.kubernetes.io/component: storage
-          recurring-job-group.longhorn.io/daily: enabled
-          recurring-job-group.longhorn.io/weekly: enabled
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
 ---
 apiVersion: v1
 kind: Service
@@ -219,6 +204,7 @@ metadata:
   labels:
     app.kubernetes.io/component: application
   name: pocket-id
+  namespace: pocket-id
 spec:
   ports:
     - name: http


### PR DESCRIPTION
This pull request migrates the `pocket-id` application from using a `StatefulSet` to a `Deployment` for its main server component, simplifies storage configuration, and updates resource references and image tags in the Kustomization file. The changes improve deployment flexibility and streamline the configuration.

**Migration from StatefulSet to Deployment:**

* The main application manifest was renamed from `pocket-id.statefulset.yaml` to `pocket-id.deployment.yaml`, and the resource type was changed from `StatefulSet` to `Deployment` to better fit stateless workloads. (`projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml`, [projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yamlL7-L14](diffhunk://#diff-26f9ec9c410da3ca7046f1b6f95e9838007749258055136becce9f8db6737fcfL7-L14))

**Storage configuration changes:**

* Removed the `PersistentVolumeClaim` storage configuration and replaced it with an ephemeral `emptyDir` volume, reflecting the move to stateless deployment. (`projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml`, [[1]](diffhunk://#diff-26f9ec9c410da3ca7046f1b6f95e9838007749258055136becce9f8db6737fcfR175-R176) [[2]](diffhunk://#diff-26f9ec9c410da3ca7046f1b6f95e9838007749258055136becce9f8db6737fcfL200-L214)
* Updated environment variables to use `FILE_BACKEND=database` instead of specifying an upload path, aligning with the new storage approach. (`projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yaml`, [projects/amiya.akn/src/apps/*pocket-id/pocket-id.deployment.yamlL66-R66](diffhunk://#diff-26f9ec9c410da3ca7046f1b6f95e9838007749258055136becce9f8db6737fcfL66-R66))

**Kustomization and resource updates:**

* Updated the Kustomization file to reference the new deployment manifest and reordered resource entries for clarity. (`projects/amiya.akn/src/apps/*pocket-id/kustomization.yaml`, [projects/amiya.akn/src/apps/*pocket-id/kustomization.yamlL7-R29](diffhunk://#diff-7a3bbca10db6df3d0bb4909efbf64b6d06282c68ce14f15abfbdca4fac6edcc7L7-R29))
* Updated the image tag and version labels to ensure consistency with the deployed version. (`projects/amiya.akn/src/apps/*pocket-id/kustomization.yaml`, [projects/amiya.akn/src/apps/*pocket-id/kustomization.yamlL7-R29](diffhunk://#diff-7a3bbca10db6df3d0bb4909efbf64b6d06282c68ce14f15abfbdca4fac6edcc7L7-R29))