### PR TITLE
Fix vault NetPol blocking OpenBao egress to lungmen kube-apiserver

### DIFF
--- a/docs/incidents/2026-05-30-lungmen-databases-pushsecrets-504-vault-netpol.md
+++ b/docs/incidents/2026-05-30-lungmen-databases-pushsecrets-504-vault-netpol.md
@@ -1,0 +1,136 @@
+---
+title: "lungmen.akn databases PushSecrets 504 — vault namespace NetPol"
+date: 2026-05-30
+author: "[anthropic:claude-sonnet-4-6]"
+participants:
+  - "Alexandre"
+  - "[anthropic:claude-sonnet-4-6]"
+severity: "Medium"
+status: "Final"
+detection-method: "User report"
+mttd: "unknown"
+mttr: "~15m from investigation start to fix"
+services-affected:
+  - "databases PushSecrets (lungmen.akn) — n8n, atuin, forgejo, immich, linkding, paperless"
+users-affected: "No direct user impact; database credential sync to OpenBao interrupted"
+related-incidents:
+  - "docs/incidents/2026-05-25-lungmen-clustersecretstore-vault-auth-failure.md"
+related-adrs: []
+---
+
+# Post-Mortem: lungmen.akn databases PushSecrets 504 — vault namespace NetPol
+
+## Executive Summary
+
+PushSecrets in the `databases` namespace on `lungmen.akn` were failing to push database credentials into OpenBao. The root cause was CiliumNetworkPolicies recently added to the `vault` namespace on `amiya.akn` blocking OpenBao's egress to lungmen's Kubernetes API server — a connection OpenBao must make to validate JWTs during Kubernetes auth. The fix is a dedicated CiliumNetworkPolicy allowing FQDN-scoped access to `kubernetes.lungmen.akn.chezmoi.sh:6443`.
+
+***
+
+## Event Summary
+
+**Expected outcome:** PushSecrets in the `databases` namespace sync PostgreSQL credentials (username, password, URI, etc.) to OpenBao every 5 minutes.
+
+**Actual outcome:** All databases PushSecrets returned `set secret failed: unable to log in with Kubernetes auth [...] Code: 504. Raw Message: upstream request timeout` on `PUT https://vault.chezmoi.sh/v1/auth/lungmen.akn/login`.
+
+**Impact:** CNPG credential sync to OpenBao interrupted. Existing credentials in OpenBao remained valid (no data loss); impact limited to new credential rotations or cluster provisioning.
+
+**Duration:** Unknown — detected via user report; interruption duration not measured. Timeline omitted — timestamps not reliably reconstructable.
+
+**First signal:** User report of ESO errors in the `databases` namespace.
+
+***
+
+## Timeline
+
+*Omitted — timestamps not reliably reconstructable.*
+
+***
+
+## What Went Well
+
+* The ESO error message was precise and immediately actionable: exact URL, HTTP code, raw message. Root cause was localized in under 5 minutes.
+* Diagnosis correctly ruled out false leads (stale CA cert, DNS failure, Tailscale) by focusing on the 504 code — a timeout on OpenBao's side, not ESO's.
+* The fix is surgical: a `toFQDNs`-scoped policy per remote cluster rather than a blanket `world` egress allowance on port 6443.
+
+***
+
+## Root-Cause Analysis
+
+### Technique: 5 Whys
+
+1. **Why did PushSecrets fail?** → ESO received a 504 when authenticating to OpenBao via `auth/lungmen.akn`.
+2. **Why did OpenBao return 504?** → OpenBao could not reach `kubernetes.lungmen.akn.chezmoi.sh:6443` to validate the Kubernetes JWT presented by ESO (TokenReview).
+3. **Why couldn't OpenBao reach that endpoint?** → Cilium blocked egress from the OpenBao pod to that destination (`world` entity, port 6443).
+4. **Why was that egress blocked?** → The `default-hardened` CiliumNetworkPolicy in the `vault` namespace denies all egress by default, and `allow-openbao-to-kubernetes-api` only permitted port 6443 toward the local kube-apiserver (`kube-system` endpoint + `host` entity) — not toward remote cluster API servers.
+5. **Why didn't the policy cover remote clusters?** → When `allow-openbao-to-kubernetes-api` was written, only the local use case (amiya → amiya kube-apiserver) was modeled. OpenBao's need to reach remote cluster API servers to validate their JWTs was not identified as a required egress path.
+
+### Root Causes
+
+* **`allow-openbao-to-kubernetes-api` was written without modeling remote Kubernetes auth backends.** OpenBao must reach the API server of *each remote cluster* registered via a Crossplane `RemoteClusterVault` to perform JWT TokenReview. This outbound connection is not visible in ESO's configuration and is easy to overlook — it is OpenBao, not ESO, that initiates it.
+
+### Contributing Factors
+
+* **No smoke test after adding vault namespace NetPols.** There was no verification that all OpenBao auth backends were still functional after the new policies were applied.
+* **Recent related incident** (`2026-05-25`) on the same auth chain (lungmen ESO ↔ OpenBao), which could have prompted explicit testing of this path.
+
+***
+
+## Warning Signs Missed
+
+| Signal                                                                              | When visible                   | Why not acted on                                                          |
+| ----------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------- |
+| The 2026-05-25 incident already touched the same ESO → OpenBao → lungmen auth chain | When writing the vault NetPols | Focus was on the local auth use case; remote auth paths were not in scope |
+
+***
+
+## Control Analysis
+
+### In Control
+
+* `allow-openbao-to-kubernetes-api` should have been written accounting for all Kubernetes auth backends configured in OpenBao, not only the local one.
+* A post-deployment smoke test (verify `ClusterSecretStore` is `Ready` and PushSecrets are `Synced`) would have caught the regression immediately.
+
+### Out of Control
+
+| External factor                      | What would reduce exposure? |
+| ------------------------------------ | --------------------------- |
+| None — incident is entirely internal | —                           |
+
+***
+
+## Systemic Lessons
+
+* **Adding NetworkPolicies to a broker namespace (OpenBao, ArgoCD) requires modeling *all* egress paths, including outbound connections the broker initiates toward third-party systems.** These indirect outbound connections (OpenBao → remote kube-apiserver) are invisible in ESO's configuration and easy to miss.
+* **Every `RemoteClusterVault` added via Crossplane requires a corresponding CNP in the `vault` namespace.** This coupling is not expressed in code — it is an implicit convention that must be made explicit in the bootstrap checklist and/or the Crossplane Composition itself.
+
+***
+
+## Change Register
+
+| # | Priority | Action                                                                                                                                                     | Owner                          | Due Date   | Verification                                        |
+| - | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ---------- | --------------------------------------------------- |
+| 1 | P0       | Add `allow-openbao-to-lungmen-api` CNP (`toFQDNs: kubernetes.lungmen.akn.chezmoi.sh:6443`) — **already applied**                                           | \[anthropic:claude-sonnet-4-6] | 2026-05-30 | All databases PushSecrets in `Synced` state         |
+| 2 | P1       | Add a comment in `remote.x.v1alpha1.openbao.yaml` (Crossplane Composition) noting that a vault namespace CNP is required for each new `RemoteClusterVault` | Alexandre                      | 2026-06-06 | Comment visible in the Composition; PR merged       |
+| 3 | P2       | Add a post-NetPol smoke-test checklist in `HOW_TO_BOOTSTRAP.md`: verify `ClusterSecretStore` Ready and PushSecrets Synced                                  | Alexandre                      | 2026-06-15 | "Post-NetPol validation" section present in the doc |
+
+***
+
+## Resolution Tracker
+
+### Done
+
+* [x] Add `allow-openbao-to-lungmen-api` CiliumNetworkPolicy (`toFQDNs: kubernetes.lungmen.akn.chezmoi.sh:6443`) — applied in `projects/amiya.akn/src/apps/vault/security/` and `dist/`
+
+### Pending — after next PR merges
+
+* [ ] Add comment in `catalog/crossplane/clustervault.vault.chezmoi.sh/remote.x.v1alpha1.openbao.yaml` noting CiliumNetworkPolicy requirement per `RemoteClusterVault`
+* [ ] Add post-NetPol smoke-test checklist in `projects/lungmen.akn/docs/HOW_TO_BOOTSTRAP.md`
+
+***
+
+## Verification Schedule
+
+| Checkpoint    | Date       | What we'll check                                        | Forum                |
+| ------------- | ---------- | ------------------------------------------------------- | -------------------- |
+| Immediate     | 2026-05-30 | All databases PushSecrets in `Synced` after ArgoCD sync | ArgoCD UI            |
+| 1-week review | 2026-06-06 | Action #2 complete; no new 504s on `auth/lungmen.akn`   | ArgoCD events review |

--- a/docs/incidents/2026-05-30-lungmen-databases-pushsecrets-504-vault-netpol.md
+++ b/docs/incidents/2026-05-30-lungmen-databases-pushsecrets-504-vault-netpol.md
@@ -6,19 +6,20 @@ participants:
   - "Alexandre"
   - "[anthropic:claude-sonnet-4-6]"
 severity: "Medium"
-status: "Final"
+status: "Open"
 detection-method: "User report"
-mttd: "unknown"
-mttr: "~15m from investigation start to fix"
+duration: "Unknown — detected via user report; interruption duration not measured"
 services-affected:
   - "databases PushSecrets (lungmen.akn) — n8n, atuin, forgejo, immich, linkding, paperless"
 users-affected: "No direct user impact; database credential sync to OpenBao interrupted"
+root-cause-family:
+  - "network-policy-incomplete"
 related-incidents:
-  - "docs/incidents/2026-05-25-lungmen-clustersecretstore-vault-auth-failure.md"
+  - path: "docs/incidents/2026-05-25-lungmen-clustersecretstore-vault-auth-failure.md"
+    relation: "Same auth chain (ESO → OpenBao → lungmen Kubernetes auth)"
 related-adrs: []
+related-issues: []
 ---
-
-# Post-Mortem: lungmen.akn databases PushSecrets 504 — vault namespace NetPol
 
 ## Executive Summary
 
@@ -56,7 +57,10 @@ PushSecrets in the `databases` namespace on `lungmen.akn` were failing to push d
 
 ## Root-Cause Analysis
 
-### Technique: 5 Whys
+**Technique:** 5 Whys
+**Why this technique:** Single failure chain with a clear causal sequence from symptom to structural condition; no branching into independent causes.
+
+### Analysis
 
 1. **Why did PushSecrets fail?** → ESO received a 504 when authenticating to OpenBao via `auth/lungmen.akn`.
 2. **Why did OpenBao return 504?** → OpenBao could not reach `kubernetes.lungmen.akn.chezmoi.sh:6443` to validate the Kubernetes JWT presented by ESO (TokenReview).
@@ -105,13 +109,32 @@ PushSecrets in the `databases` namespace on `lungmen.akn` were failing to push d
 
 ***
 
+## From Lesson to Control
+
+| Lesson                                               | Artifact type    | Linked artifact                                                                    |
+| ---------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------- |
+| Broker namespace NetPols must model all egress paths | Pre-deploy check | `projects/lungmen.akn/docs/HOW_TO_BOOTSTRAP.md` — post-NetPol smoke-test checklist |
+| Every RemoteClusterVault requires a vault CNP        | Comment in code  | `catalog/crossplane/clustervault.vault.chezmoi.sh/remote.x.v1alpha1.openbao.yaml`  |
+
+***
+
 ## Change Register
 
-| # | Priority | Action                                                                                                                                                     | Owner                          | Due Date   | Verification                                        |
-| - | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ---------- | --------------------------------------------------- |
-| 1 | P0       | Add `allow-openbao-to-lungmen-api` CNP (`toFQDNs: kubernetes.lungmen.akn.chezmoi.sh:6443`) — **already applied**                                           | \[anthropic:claude-sonnet-4-6] | 2026-05-30 | All databases PushSecrets in `Synced` state         |
-| 2 | P1       | Add a comment in `remote.x.v1alpha1.openbao.yaml` (Crossplane Composition) noting that a vault namespace CNP is required for each new `RemoteClusterVault` | Alexandre                      | 2026-06-06 | Comment visible in the Composition; PR merged       |
-| 3 | P2       | Add a post-NetPol smoke-test checklist in `HOW_TO_BOOTSTRAP.md`: verify `ClusterSecretStore` Ready and PushSecrets Synced                                  | Alexandre                      | 2026-06-15 | "Post-NetPol validation" section present in the doc |
+* [ ] \[due:: 2026-06-06] \[priority:: medium] \[size:: S] \[owner:: Alexandre] Add a comment in `remote.x.v1alpha1.openbao.yaml` (Crossplane Composition) noting that a vault namespace CNP is required for each new `RemoteClusterVault`
+  * **Verification:** Comment visible in the Composition; next `RemoteClusterVault` creation is preceded by a corresponding CNP
+  * **If not done:** Next new remote cluster silently breaks PushSecrets, same incident shape recurs
+
+* [ ] \[due:: 2026-06-15] \[priority:: medium] \[size:: S] \[owner:: Alexandre] Add a post-NetPol smoke-test checklist in `HOW_TO_BOOTSTRAP.md`: verify `ClusterSecretStore` Ready and PushSecrets Synced
+  * **Verification:** "Post-NetPol validation" section present in the doc; next NetPol change in the vault namespace triggers the checklist
+  * **If not done:** Future vault NetPol changes can silently break auth backends without detection
+
+***
+
+## Agent Knowledge
+
+* \[OpenBao + Cilium]: When adding or modifying CiliumNetworkPolicies in the `vault` namespace, model ALL Kubernetes auth backends' egress paths — each remote cluster API server (e.g., `kubernetes.lungmen.akn.chezmoi.sh:6443`) needs an explicit `toFQDNs` allow rule.
+* \[OpenBao + Kubernetes auth]: OpenBao initiates outbound connections to remote cluster API servers for JWT TokenReview — this is invisible in ESO's config and easy to miss when writing network policies.
+* \[RemoteClusterVault]: Each `RemoteClusterVault` Crossplane resource implicitly requires a corresponding CiliumNetworkPolicy in the `vault` namespace. This coupling is not expressed in code.
 
 ***
 
@@ -121,7 +144,7 @@ PushSecrets in the `databases` namespace on `lungmen.akn` were failing to push d
 
 * [x] Add `allow-openbao-to-lungmen-api` CiliumNetworkPolicy (`toFQDNs: kubernetes.lungmen.akn.chezmoi.sh:6443`) — applied in `projects/amiya.akn/src/apps/vault/security/` and `dist/`
 
-### Pending — after next PR merges
+### Pending — after PR merges
 
 * [ ] Add comment in `catalog/crossplane/clustervault.vault.chezmoi.sh/remote.x.v1alpha1.openbao.yaml` noting CiliumNetworkPolicy requirement per `RemoteClusterVault`
 * [ ] Add post-NetPol smoke-test checklist in `projects/lungmen.akn/docs/HOW_TO_BOOTSTRAP.md`
@@ -130,7 +153,7 @@ PushSecrets in the `databases` namespace on `lungmen.akn` were failing to push d
 
 ## Verification Schedule
 
-| Checkpoint    | Date       | What we'll check                                        | Forum                |
-| ------------- | ---------- | ------------------------------------------------------- | -------------------- |
-| Immediate     | 2026-05-30 | All databases PushSecrets in `Synced` after ArgoCD sync | ArgoCD UI            |
-| 1-week review | 2026-06-06 | Action #2 complete; no new 504s on `auth/lungmen.akn`   | ArgoCD events review |
+| Checkpoint | Date       | What we'll check                                                         | Forum       |
+| ---------- | ---------- | ------------------------------------------------------------------------ | ----------- |
+| 1-week     | 2026-06-06 | All databases PushSecrets in `Synced`; no new 504s on `auth/lungmen.akn` | Solo review |
+| 1-month    | 2026-06-30 | Change Register items #1 and #2 complete; no recurrence                  | Solo review |

--- a/projects/amiya.akn/dist/apps/vault/cilium.io.v2.CiliumNetworkPolicy.allow-openbao-to-lungmen-api.yaml
+++ b/projects/amiya.akn/dist/apps/vault/cilium.io.v2.CiliumNetworkPolicy.allow-openbao-to-lungmen-api.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows OpenBao to reach the lungmen.akn Kubernetes API server for Kubernetes
+      auth TokenReview validation. Required when ESO on lungmen.akn authenticates
+      to OpenBao via the auth/lungmen.akn backend.
+  labels:
+    app.kubernetes.io/name: vault
+  name: allow-openbao-to-lungmen-api
+  namespace: vault
+spec:
+  egress:
+  - toFQDNs:
+    - matchName: kubernetes.lungmen.akn.chezmoi.sh
+    toPorts:
+    - ports:
+      - port: "6443"
+        protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vault
+      component: server

--- a/projects/amiya.akn/src/apps/vault/security/kustomization.yaml
+++ b/projects/amiya.akn/src/apps/vault/security/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - network-policy.default-hardened.yaml
   - network-policy.allow-openbao-from-envoy-gateway.yaml
   - network-policy.allow-openbao-to-kubernetes-api.yaml
+  - network-policy.allow-openbao-to-lungmen-api.yaml
   - network-policy.allow-openbao-to-pocket-id.yaml
   - network-policy.allow-postgres-to-s3-backup.yaml

--- a/projects/amiya.akn/src/apps/vault/security/network-policy.allow-openbao-to-lungmen-api.yaml
+++ b/projects/amiya.akn/src/apps/vault/security/network-policy.allow-openbao-to-lungmen-api.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows OpenBao to reach the lungmen.akn Kubernetes API server for Kubernetes
+      auth TokenReview validation. Required when ESO on lungmen.akn authenticates
+      to OpenBao via the auth/lungmen.akn backend.
+  name: allow-openbao-to-lungmen-api
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vault
+      component: server
+  egress:
+    - toFQDNs:
+        - matchName: kubernetes.lungmen.akn.chezmoi.sh
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP


### PR DESCRIPTION
## Summary

The vault namespace on `amiya.akn` recently received a `default-hardened` CiliumNetworkPolicy
baseline that blocks all egress by default. The existing `allow-openbao-to-kubernetes-api` policy
only permitted port 6443 toward the local kube-apiserver, leaving OpenBao unable to reach remote
cluster API servers. As a result, all ESO PushSecrets in the `databases` namespace on `lungmen.akn`
failed with a 504 upstream timeout when attempting Kubernetes auth.

**Related Issue:** N/A — incident response

## Root Cause

When ESO on `lungmen.akn` authenticates to OpenBao via the `auth/lungmen.akn` Kubernetes auth
backend, OpenBao must call the Kubernetes TokenReview API on the remote cluster
(`kubernetes.lungmen.akn.chezmoi.sh:6443`) to validate the JWT. Cilium classifies this destination
as the `world` entity, which was blocked by `default-hardened`.

ESO error observed:

```
set secret failed: could not get secrets client for store vault.chezmoi.sh:
unable to log in to auth method: unable to log in with Kubernetes auth:
Error making API request. URL: PUT https://vault.chezmoi.sh/v1/auth/lungmen.akn/login
Code: 504. Raw Message: upstream request timeout
```

## Fix

### vault namespace — amiya.akn

- **[`projects/amiya.akn/src/apps/vault/security/network-policy.allow-openbao-to-lungmen-api.yaml`](projects/amiya.akn/src/apps/vault/security/network-policy.allow-openbao-to-lungmen-api.yaml)** — New CiliumNetworkPolicy allowing OpenBao server pods to reach `kubernetes.lungmen.akn.chezmoi.sh:6443` via `toFQDNs`, scoped to the exact hostname rather than a blanket `world` egress on port 6443
- **[`projects/amiya.akn/src/apps/vault/security/kustomization.yaml`](projects/amiya.akn/src/apps/vault/security/kustomization.yaml)** — Registers the new policy in the security kustomization
- **[`projects/amiya.akn/dist/apps/vault/cilium.io.v2.CiliumNetworkPolicy.allow-openbao-to-lungmen-api.yaml`](projects/amiya.akn/dist/apps/vault/cilium.io.v2.CiliumNetworkPolicy.allow-openbao-to-lungmen-api.yaml)** — Rendered dist artifact

### Incident documentation

- **[`docs/incidents/2026-05-30-lungmen-databases-pushsecrets-504-vault-netpol.md`](docs/incidents/2026-05-30-lungmen-databases-pushsecrets-504-vault-netpol.md)** — Post-mortem covering root cause, 5 Whys analysis, and follow-up actions

## Technical Impact

### Behavioural Changes

OpenBao server pods in the `vault` namespace can now reach `kubernetes.lungmen.akn.chezmoi.sh:6443`
for JWT TokenReview. No other egress is widened — the policy is FQDN-scoped and port-specific.
All databases PushSecrets on `lungmen.akn` resume syncing credentials to OpenBao.

### Regression Risk

**Low.** The new policy is additive and narrowly scoped (`toFQDNs` to a single hostname, TCP 6443
only, restricted to `app.kubernetes.io/name: vault, component: server` pods). No existing policies
are modified.

### Observability

- All databases PushSecrets (`n8n`, `atuin`, `forgejo`, `immich`, `linkding`, `paperless`) reach `Synced` status in the `databases` namespace
- No 504 errors in ESO logs on `auth/lungmen.akn/login`
- `cilium monitor` on the vault pod should show allowed traffic to `kubernetes.lungmen.akn.chezmoi.sh:6443`

## Testing Validation

- [ ] ArgoCD syncs the vault security kustomization on `amiya.akn`
- [ ] All databases PushSecrets on `lungmen.akn` transition to `Synced`
- [ ] No new 504 errors on `PUT https://vault.chezmoi.sh/v1/auth/lungmen.akn/login`

## Related Issues

N/A — incident response; see post-mortem for follow-up tracking.

---
<sub>AI-assisted with anthropic:claude-sonnet-4-6 under human supervision</sub>
