### PR TITLE
Add agents:* scope labels mirroring the .agents/ subtree

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -176,6 +176,15 @@
 - name: catalog:opa
   description: OPA/Rego policies for CI-time manifest validation
   color: 8B5CF6
+- name: agents:knowledge
+  description: Operational knowledge distilled from incidents (.agents/knowledge/)
+  color: F9D0C4
+- name: agents:sessions
+  description: Agent session documents (.agents/sessions/)
+  color: F9D0C4
+- name: agents:skills
+  description: Agent skill definitions (.agents/skills/)
+  color: F9D0C4
 - name: gh
   description: GitHub workflows, issue/PR templates, root config files, cross-cutting
   color: 6E5494


### PR DESCRIPTION
## Summary

Adds three scope labels (`agents:knowledge`, `agents:sessions`, `agents:skills`) that mirror the three subdirectories of `.agents/`. Closes a gap surfaced while reviewing the label taxonomy on main: recent commits use `agents:knowledge` and `agents:postmortem` as scopes but the label set stopped at `catalog:*` and `project:*`, so issues and PRs touching agent tooling had no scope label to apply.

**Related context:** the rest of the label taxonomy redesign landed on `main` directly in commits `8f10a292`, `6b08624e`, `a816dffb` (no PR — accidentally pushed; see commit messages for the full rationale).

## Changes Made

### Label additions (`.github/labels.yaml`)

- **`agents:knowledge`** — operational knowledge docs under `.agents/knowledge/`
- **`agents:sessions`** — agent session documents under `.agents/sessions/`
- **`agents:skills`** — agent skill definitions under `.agents/skills/`

All three use color `F9D0C4` (peach) to distinguish the agents category from `catalog:*` (purple) and `project:*` (blue) at a glance.

## Technical Impact

### Convention

The agents category follows the same directory-mirroring pattern as `catalog:*` (mirrors `catalog/<area>/`) and `project:*` (mirrors `projects/<cluster>/`). Sub-skill commit scopes (`agents:postmortem`, `agents:create-pr`, …) remain valid in commit subjects via the warn-level `scope-enum` in commitlint and aggregate to `agents:skills` at the label level — keeps the label set bounded while preserving fine-grained scope in `git log`.

### State

Live labels were created via `gh label create` ahead of this commit, so the sync workflow run on merge will be a no-op against the existing state.

### Follow-up not in scope

`.commitlintrc.js` still lacks an explicit `agents:*` entry in its scope enum. Since `scope-enum` is set to `warn` (not `error`), commits with `agents:knowledge` / `agents:postmortem` already pass — but adding them to the enum would surface them in the `cz-git` autocomplete prompt. Worth a separate PR once we decide whether to enumerate sub-skills or stop at the three directory-level scopes.

## Testing Validation

- [x] Live labels (`gh label list | grep ^agents:`) match the three new entries in `.github/labels.yaml`
- [ ] On merge, the label sync workflow runs as a no-op (verify with `gh run watch` after merge)

## Related Issues

None — surfaced during the post-label-taxonomy review on main.

---

<sub>AI-assisted with anthropic:claude-opus-4-7 under human supervision</sub>
