### PR TITLE
Align ADR-013 with implementation and fix mp0 mount path in observability LXC

### DIFF
--- a/docs/decisions/013-centralized-observability-victoriametrics-lxc.md
+++ b/docs/decisions/013-centralized-observability-victoriametrics-lxc.md
@@ -307,10 +307,11 @@ a workload Kubernetes did not serve well.
 * ⚙️ **Alertmanager must be exposed** — `/alerts` is reachable through Caddy
   (CIDR-restricted, no auth) so cluster vmalerts can notify it; one more surface to
   keep behind the firewall.
-* ⚙️ **Tailscale needs `/dev/net/tun` in the LXC** — the unprivileged container is
-  granted the TUN device (a benign, standard relaxation — not full privilege) so
-  tailscaled runs in kernel mode. tailscaled state on the stateless root disk means
-  a rebuild re-registers the node.
+* ⚙️ **Tailscale via caddy-tailscale (tsnet, no kernel TUN)** — Tailscale is
+  embedded in the Caddy process using userspace networking; no `/dev/net/tun`
+  passthrough and no `tailscaled` daemon required. tsnet state persists on the mp0
+  data volume (`/persistent/caddy`), so image rebuilds do not re-register the
+  tailnet node.
 * ⚠️ **Tooling split** — observability backend lives outside the Kubernetes/ArgoCD
   workflow (consistent with the `oci.chezmoi.sh` and `kazimierz` precedents).
 
@@ -332,32 +333,37 @@ a workload Kubernetes did not serve well.
 flowchart LR
   subgraph sources["Sources (push)"]
     LA["lungmen / amiya<br/>VMAgent (+streamAggr) + Vector<br/>VMAlert (VMRule: records + page alerts)"]
-    KZ["kazimierz (VPS)<br/>vmagent + Vector (Docker)<br/>via Tailscale"]
+    KZ["kazimierz (VPS)<br/>vmagent + Vector (Docker)<br/>via Tailscale (caddy-tailscale tsnet)"]
     OTEL["Proxmox host<br/>OTEL metric server"]
+    PVEXP["pve-exporter LXC<br/>Vector (syslog → SemConv)"]
   end
 
   subgraph lxc["NixOS LXC — o11y.chezmoi.sh (Proxmox)"]
-    CADDY["Caddy :443<br/>TLS (ACME) + path routing"]
+    CADDY["Caddy :443<br/>TLS (ACME) + path routing<br/>(+ tailnet via tsnet)"]
+    VECTOR["Vector :4317/:4318/:6000<br/>OTLP + Vector native → VLogs"]
     VM["VictoriaMetrics :8428<br/>(+ OTLP)"]
     VL["VictoriaLogs :9428"]
     VT["VictoriaTraces :10428<br/>(OTLP/Jaeger)"]
     VMALERT["vmalert :8880<br/>cluster/Grafana down + watchdog"]
     AM["Alertmanager :9093<br/>/alerts"]
+    CADDY -->|"/logs/otlp/*"| VECTOR
     CADDY -->|"/logs/*"| VL
     CADDY -->|"/traces/*"| VT
     CADDY -->|"/alerts/*"| AM
     CADDY -->|"/metrics/* (+OTLP)"| VM
+    VECTOR --> VL
     VMALERT --> VM
     VMALERT --> AM
   end
 
   GRAF["Grafana on amiya<br/>(OIDC Pocket-Id)<br/>dashboards + non-paging alerts"]
-  EXT["page channel (ntfy / Slack)<br/>+ deadman monitor — service TBD"]
+  EXT["page channel (Slack #notifications)<br/>+ deadman monitor — service TBD"]
 
-  LA -->|"remote_write + logs"| CADDY
+  LA -->|"remote_write + logs (Vector :6000)"| CADDY
   LA -->|"query + records + page alerts"| CADDY
-  KZ -->|"over Tailscale"| CADDY
+  KZ -->|"over tailnet"| CADDY
   OTEL -->|"OTLP metrics"| CADDY
+  PVEXP -->|"logs (Vector :6000)"| CADDY
   GRAF -->|"query"| CADDY
   AM -->|"page alerts + 1 min heartbeat"| EXT
   GRAF -->|"deadman heartbeat"| EXT
@@ -383,6 +389,9 @@ they shape the security and reliability posture:
 * **Clean, versioned, signal-typed paths.** Caddy owns ACME DNS-01 and routes a
   `/<signal>/*` scheme: `/metrics/*` → VictoriaMetrics, `/logs/*` →
   VictoriaLogs, `/traces/*` → VictoriaTraces, `/alerts/*` → Alertmanager.
+  Within `/logs/*`, the more-specific `/logs/otlp/*` sub-route is intercepted by
+  the appliance-side Vector (OTLP HTTP ingest on `:4318`) before the generic
+  `/logs/*` path reaches VictoriaLogs.
   VM/VLogs/VTraces prefixes are stripped (they serve at root); Alertmanager keeps
   its prefix via `--web.route-prefix`. Same Caddy module as the `oci.chezmoi.sh` LXC.
 * **Three signals from day one (metrics, logs, traces).** VictoriaTraces is
@@ -413,23 +422,31 @@ they shape the security and reliability posture:
   *Residual trade-off: a cluster's vmalert queries the central VM, so a cluster↔LXC
   partition pauses that cluster's rule evaluation — but the LXC's "cluster absent"
   rule still pages.*
-* **Tailscale membership (OAuth, `tag:o11y`).** The LXC joins the tailnet so
-  off-LAN sources — notably the `kazimierz.akn` VPS — push metrics/logs and notify
-  Alertmanager over the encrypted tailnet rather than a public endpoint. tailscaled
-  runs in kernel TUN mode (the unprivileged LXC is granted `/dev/net/tun`), giving
-  the appliance a tailnet IP; `tailscale0` is a trusted firewall interface so
-  tailnet clients reach Caddy while the loopback backends stay unreachable. The
-  OAuth client secret is a baked secret, mirroring the Cloudflare-token pattern.
+* **Tailscale membership via caddy-tailscale (OAuth, `tag:o11y`).** The LXC joins
+  the tailnet so off-LAN sources — notably the `kazimierz.akn` VPS — push
+  metrics/logs and notify Alertmanager over the encrypted tailnet rather than a
+  public endpoint. Tailscale is embedded directly in Caddy using
+  **caddy-tailscale** (tsnet, userspace networking): no separate `tailscaled`
+  daemon and no kernel `/dev/net/tun` passthrough required. The tsnet listener runs
+  inside the Caddy process; the loopback backends remain unreachable over the
+  tailnet. tsnet state is stored at `/persistent/caddy` (the mp0 data volume) and
+  survives image rebuilds — the node does not re-register on a rebuild. The OAuth
+  client secret is a baked secret, mirroring the Cloudflare-token pattern.
 * **Alertmanager is centralized and exposed under `/alerts` (no auth).** The
   LXC's existential vmalert and every cluster's vmalert notify the same
   Alertmanager (routed via Caddy, CIDR-restricted). Notification routing is thus
   cluster-independent — more resilient than evaluating alerts inside `amiya`.
   Grafana auth remains Pocket-Id OIDC (ADR-005) with a local admin fallback.
-* **Vector for logs, vmagent for metrics.** Vector is the log transfer/conversion
-  pipeline (edge DaemonSet → VictoriaLogs), satisfying the stated objective.
-  Metrics deliberately stay on vmagent (not routed through Vector) to preserve
-  native `ServiceMonitor` discovery; Vector can be inserted for metrics later with
-  nothing lost.
+* **Vector for logs, vmagent for metrics.** Vector operates at two levels: (1) an
+  **edge agent** (DaemonSet on Kubernetes clusters, Docker on kazimierz) forwards
+  logs to the appliance via the Vector native protocol (`:6000`); (2) an
+  **appliance-side Vector** receives structured events (OTLP HTTP/gRPC and Vector
+  native from cluster agents and the `pve-exporter` LXC), runs SemConv validation,
+  converts to a loki-like format, and pushes to VictoriaLogs. The appliance does not
+  run a syslog listener — that role belongs to the dedicated `pve-exporter` LXC,
+  which parses RFC 5424 into SemConv fields and forwards events here over Vector
+  native. Metrics deliberately stay on vmagent (not routed through Vector) to
+  preserve native `ServiceMonitor` discovery.
 * **Two Dead-Man's-Switches (external service TBD).** The LXC Alertmanager
   heartbeats an external monitor every minute — appliance death stops it. A Grafana
   always-on rule heartbeats the same monitor — `amiya`/Grafana death stops it.
@@ -452,20 +469,20 @@ A terse normative checklist (the *why* is in Supporting design decisions above):
 
 * **Completed (scaffolded, not yet deployed):** NixOS flake, service modules
   (VictoriaMetrics + OTLP, VictoriaLogs, VictoriaTraces, existential vmalert,
-  Alertmanager exposed under `/alerts`, Caddy with `/<signal>` path routing,
-  Tailscale, hardening), existential alert rules (watchdog, self,
-  cluster-availability incl. Grafana-down), mise build/push/upgrade tasks, and the
-  Crossplane Cloudflare APIToken + Tailscale OAuth client
+  Alertmanager exposed under `/alerts`, Caddy with `/<signal>` path routing +
+  caddy-tailscale tsnet, appliance-side Vector pipeline, hardening), existential
+  alert rules (watchdog, self, cluster-availability incl. Grafana-down, disk via
+  pve-exporter, PVE host/guest, OCI registry), mise build/push/upgrade tasks, and
+  the Crossplane Cloudflare APIToken + Tailscale OAuth client
   (`cloudflare.iam.observability.yaml`, `tailscale.oauth.observability.yaml`).
 * **Pending:** verify nixpkgs package/attribute names (incl. `victoriatraces` + its
   port) on the pinned channel; `dist:render` the new Crossplane resources and let
-  them reconcile; deploy the LXC (with `/dev/net/tun` passthrough); set the Proxmox
-  firewall source-CIDR allowlist and the tailnet split-DNS override; deploy
-  cluster-side `VMAgent` (+ optional streamAggr), `VMAlert` + `VMRule`, Vector, and
-  trace export (and the `kazimierz` Docker equivalents); configure the Proxmox OTEL
-  push; wire Grafana datasources (metrics/logs/traces) + dashboards + non-paging
-  alert routing + the Grafana-side deadman on `amiya`; render `architecture.svg`.
-  Tracked under the phases of [#1018][].
+  them reconcile; deploy the LXC; set the Proxmox firewall source-CIDR allowlist;
+  deploy cluster-side `VMAgent` (+ optional streamAggr), `VMAlert` + `VMRule`,
+  Vector, and trace export (and the `kazimierz` Docker equivalents); configure the
+  Proxmox OTEL push; wire Grafana datasources (metrics/logs/traces) + dashboards +
+  non-paging alert routing + the Grafana-side deadman on `amiya`; render
+  `architecture.svg`. Tracked under the phases of [#1018][].
 
 ## References and Related Decisions
 
@@ -494,6 +511,13 @@ A terse normative checklist (the *why* is in Supporting design decisions above):
 
 ## Changelog
 
+* **2026-06-15**: Align with scaffold implementation: Tailscale via **caddy-tailscale
+  tsnet** (no `/dev/net/tun`, no `tailscaled`, state persisted at
+  `/persistent/caddy`); appliance-side Vector pipeline (OTLP + Vector native ingest,
+  SemConv validation); syslog listener moved to `pve-exporter` LXC; `/logs/otlp/*`
+  sub-route intercepted by Vector before `/logs/*` reaches VictoriaLogs; page
+  channel settled as Slack (ntfy dropped); `pve-exporter` source added to
+  architecture diagram; mermaid updated to show appliance-side Vector.
 * **2026-06-04**: **ACCEPTED**: VictoriaMetrics stack (metrics + logs + traces) on
   a centralized NixOS LXC; single-node + `cluster` label; no ingest auth (Proxmox
   firewall by source CIDR + tailnet); `/<signal>` Caddy routing; Proxmox

--- a/docs/decisions/013-centralized-observability-victoriametrics-lxc.md
+++ b/docs/decisions/013-centralized-observability-victoriametrics-lxc.md
@@ -332,10 +332,9 @@ a workload Kubernetes did not serve well.
 ```mermaid
 flowchart LR
   subgraph sources["Sources (push)"]
-    LA["lungmen / amiya<br/>VMAgent (+streamAggr) + Vector<br/>VMAlert (VMRule: records + page alerts)"]
-    KZ["kazimierz (VPS)<br/>vmagent + Vector (Docker)<br/>via Tailscale (caddy-tailscale tsnet)"]
-    OTEL["Proxmox host<br/>OTEL metric server"]
-    PVEXP["pve-exporter LXC<br/>Vector (syslog → SemConv)"]
+    LA["lungmen / amiya<br/>VMAgent (+streamAggr) + Vector<br/>VMAlert (VMRule: records + alerts) → per-cluster AM"]
+    KZ["kazimierz (VPS)<br/>vmagent + Vector (Docker)<br/>via tailnet (caddy-tailscale tsnet)"]
+    PVEXP["pve-exporter LXC<br/>pve_* metrics (remote_write)<br/>+ Vector logs (SemConv)"]
   end
 
   subgraph lxc["NixOS LXC — o11y.chezmoi.sh (Proxmox)"]
@@ -344,8 +343,8 @@ flowchart LR
     VM["VictoriaMetrics :8428<br/>(+ OTLP)"]
     VL["VictoriaLogs :9428"]
     VT["VictoriaTraces :10428<br/>(OTLP/Jaeger)"]
-    VMALERT["vmalert :8880<br/>cluster/Grafana down + watchdog"]
-    AM["Alertmanager :9093<br/>/alerts"]
+    VMALERT["vmalert :8880<br/>cluster-absent + Grafana down + watchdog"]
+    AM["Alertmanager :9093<br/>existential alerts + DMS heartbeat"]
     CADDY -->|"/logs/otlp/*"| VECTOR
     CADDY -->|"/logs/*"| VL
     CADDY -->|"/traces/*"| VT
@@ -357,16 +356,17 @@ flowchart LR
   end
 
   GRAF["Grafana on amiya<br/>(OIDC Pocket-Id)<br/>dashboards + non-paging alerts"]
-  EXT["page channel (Slack #notifications)<br/>+ deadman monitor — service TBD"]
+  EXT["Slack #notifications<br/>+ healthchecks.io (DMS)"]
+  CRAM["per-cluster AM<br/>(node / disk / PVC / crash-loop)"]
 
-  LA -->|"remote_write + logs (Vector :6000)"| CADDY
-  LA -->|"query + records + page alerts"| CADDY
+  LA -->|"remote_write + logs"| CADDY
+  LA -->|"query + records"| CADDY
+  LA -->|"cluster page alerts"| CRAM
   KZ -->|"over tailnet"| CADDY
-  OTEL -->|"OTLP metrics"| CADDY
-  PVEXP -->|"logs (Vector :6000)"| CADDY
+  PVEXP -->|"metrics + logs"| CADDY
   GRAF -->|"query"| CADDY
-  AM -->|"page alerts + 1 min heartbeat"| EXT
-  GRAF -->|"deadman heartbeat"| EXT
+  AM -->|"existential page alerts + 1 min DMS heartbeat"| EXT
+  CRAM -->|"cluster page alerts"| EXT
 ```
 
 ### Supporting design decisions
@@ -398,27 +398,32 @@ they shape the security and reliability posture:
   deployed alongside VM/VLogs now rather than deferred — the marginal cost on the
   appliance is one more single-binary service, and shipping all three avoids a
   later re-touch of the path scheme, firewall, and Grafana datasources.
-* **Proxmox host metrics via OTEL/OTLP.** The Proxmox OTEL metric server pushes to
-  `…/metrics/opentelemetry/v1/metrics` (VictoriaMetrics' native OTLP endpoint) —
-  the appliance observes its own substrate, not just the clusters.
-* **Routing rule: page → Alertmanager, everything else → Grafana.** Alertmanager
-  is reserved for the **page-tier** — the critical alerts that must wake the
-  operator (loss of a cluster, loss of Grafana, node/disk/PVC down). Everything
-  non-paging (warnings, FYI, per-app SLOs) is evaluated and routed by **Grafana**,
-  whose contact points / notification policies are markedly simpler to operate than
-  Alertmanager receivers. This keeps the heavyweight, code-reviewed alerting path
-  for what truly pages, and the convenient path for the rest.
-* **Recording rules + page-tier cluster alerts → per-cluster vmalert (`VMRule`).**
+* **Proxmox host and guest metrics via the `pve-exporter` LXC.** A dedicated
+  `pve-exporter` LXC runs prometheus-pve-exporter, scraping the Proxmox API for
+  `pve_*` metrics (host/guest disk, CPU, availability) and remote-writing them to
+  the appliance with `cluster=pve`. The same LXC handles syslog ingest (see the
+  Vector bullet). Proxmox OTEL push is not yet active; if enabled later it would
+  send OTLP to `…/metrics/opentelemetry/v1/metrics` with no further change needed.
+* **Routing rule: page → Alertmanager (two tiers); else → Grafana.** Each cluster
+  runs its **own** Alertmanager, receiving page-tier alerts from its vmalert
+  (node/disk/PVC/crash-loop etc.). The **LXC Alertmanager** is reserved for what
+  only the central vantage point can detect — **cluster absent, Grafana down, and
+  the watchdog/DMS** — so paging survives a cluster outage. Everything non-paging
+  (warnings, FYI, per-app SLOs) is evaluated and routed by **Grafana**, whose
+  contact points / notification policies are far simpler to operate than Alertmanager
+  receivers.
+* **Recording rules + page-tier cluster alerts → per-cluster vmalert + per-cluster AM.**
   Each cluster runs a vmalert (VictoriaMetrics Operator, reading
   `VMRule`/`PrometheusRule`) that evaluates the cluster's **recording rules**
   (Grafana cannot persist these) and its **page-worthy** alerts against the central
-  VM, writes records back, and notifies the central Alertmanager. Rules live in the
-  cluster's ArgoCD repo — a change is a normal GitOps commit, no LXC rebuild. Edge
-  cardinality reduction is `vmagent` stream aggregation, per cluster. The LXC's own
-  vmalert is kept *minimal* — only what requires the central vantage point and must
-  page even when the observed thing is gone: **cluster absent, Grafana down, and the
-  watchdog/deadman**. Node/disk/PVC/crash-loop guards (incl. the [#1013][] disk guard)
-  are per-cluster `VMRule`, evaluated cluster-side and paged via Alertmanager.
+  VM, writes records back, and notifies its **own Alertmanager** (not the central
+  LXC one). Rules live in the cluster's ArgoCD repo — a change is a normal GitOps
+  commit, no LXC rebuild. Edge cardinality reduction is `vmagent` stream
+  aggregation, per cluster. The LXC's own vmalert is kept *minimal* — only what
+  requires the central vantage point and must page even when the observed thing is
+  gone: **cluster absent, Grafana down, and the watchdog/DMS**. Node/disk/PVC/crash-
+  loop guards (incl. the [#1013][] disk guard) are per-cluster `VMRule`, evaluated
+  cluster-side and paged via the cluster's own Alertmanager.
   *Residual trade-off: a cluster's vmalert queries the central VM, so a cluster↔LXC
   partition pauses that cluster's rule evaluation — but the LXC's "cluster absent"
   rule still pages.*
@@ -432,11 +437,13 @@ they shape the security and reliability posture:
   tailnet. tsnet state is stored at `/persistent/caddy` (the mp0 data volume) and
   survives image rebuilds — the node does not re-register on a rebuild. The OAuth
   client secret is a baked secret, mirroring the Cloudflare-token pattern.
-* **Alertmanager is centralized and exposed under `/alerts` (no auth).** The
-  LXC's existential vmalert and every cluster's vmalert notify the same
-  Alertmanager (routed via Caddy, CIDR-restricted). Notification routing is thus
-  cluster-independent — more resilient than evaluating alerts inside `amiya`.
-  Grafana auth remains Pocket-Id OIDC (ADR-005) with a local admin fallback.
+* **Two Alertmanager tiers: one per cluster + one on the LXC.** Each cluster runs
+  its own Alertmanager for cluster-specific page-tier alerts (routed by the
+  cluster's vmalert). The LXC Alertmanager handles only what survives a cluster
+  outage: cluster-absent, Grafana down, and the watchdog DMS. It is exposed via
+  Caddy under `/alerts` (CIDR-restricted, no auth); the LXC's own vmalert reaches
+  it over loopback. Grafana auth remains Pocket-Id OIDC (ADR-005) with a local
+  admin fallback.
 * **Vector for logs, vmagent for metrics.** Vector operates at two levels: (1) an
   **edge agent** (DaemonSet on Kubernetes clusters, Docker on kazimierz) forwards
   logs to the appliance via the Vector native protocol (`:6000`); (2) an
@@ -447,13 +454,12 @@ they shape the security and reliability posture:
   which parses RFC 5424 into SemConv fields and forwards events here over Vector
   native. Metrics deliberately stay on vmagent (not routed through Vector) to
   preserve native `ServiceMonitor` discovery.
-* **Two Dead-Man's-Switches (external service TBD).** The LXC Alertmanager
-  heartbeats an external monitor every minute — appliance death stops it. A Grafana
-  always-on rule heartbeats the same monitor — `amiya`/Grafana death stops it.
-  Either silence pages the operator, covering the blind spot the appliance/Grafana
-  have on themselves. The external service is **not yet chosen** (candidates:
-  healthchecks.io, a Cloudflare-based check); `ALERTMANAGER_DEADMAN_URL` is the
-  placeholder.
+* **Dead-Man's-Switch: LXC Alertmanager → healthchecks.io.** The Watchdog alert
+  always fires; the LXC Alertmanager routes it to the `deadman` receiver which
+  pings healthchecks.io every minute. If the appliance, vmalert, or Alertmanager
+  dies, the heartbeat stops and healthchecks.io pages the operator. This is the
+  only DMS path — Grafana is not involved. The heartbeat URL is
+  `ALERTMANAGER_DEADMAN_URL` (baked at build time from `observability.sops.env`).
 
 A terse normative checklist (the *why* is in Supporting design decisions above):
 
@@ -461,8 +467,10 @@ A terse normative checklist (the *why* is in Supporting design decisions above):
   label / logs stream field). The self-scrape uses the reserved `cluster=o11y-appliance`.
 * **Entry paths** — `/metrics/*`, `/logs/*`, `/traces/*`, `/alerts/*`.
   One scheme, versioned, signal-typed.
-* **Alert routing** — *page → Alertmanager (via vmalert / `VMRule`); else → Grafana.*
-  Recording rules are always `VMRule`, never Grafana.
+* **Alert routing** — *cluster page alerts → per-cluster AM (via cluster vmalert /
+  `VMRule`); existential alerts (cluster absent, Grafana down, watchdog) → LXC AM
+  → healthchecks.io + Slack; non-paging → Grafana.* Recording rules are always
+  `VMRule`, never Grafana. Grafana plays no role in the DMS path.
 * **Tags** — the Tailscale node is `tag:o11y`.
 
 ### Status
@@ -511,13 +519,16 @@ A terse normative checklist (the *why* is in Supporting design decisions above):
 
 ## Changelog
 
-* **2026-06-15**: Align with scaffold implementation: Tailscale via **caddy-tailscale
-  tsnet** (no `/dev/net/tun`, no `tailscaled`, state persisted at
-  `/persistent/caddy`); appliance-side Vector pipeline (OTLP + Vector native ingest,
-  SemConv validation); syslog listener moved to `pve-exporter` LXC; `/logs/otlp/*`
-  sub-route intercepted by Vector before `/logs/*` reaches VictoriaLogs; page
-  channel settled as Slack (ntfy dropped); `pve-exporter` source added to
-  architecture diagram; mermaid updated to show appliance-side Vector.
+* **2026-06-15**: Align with scaffold implementation and correct architecture:
+  Tailscale via **caddy-tailscale tsnet** (no `/dev/net/tun`, no `tailscaled`,
+  state persisted at `/persistent/caddy`); appliance-side Vector pipeline (OTLP +
+  Vector native ingest, SemConv validation); syslog listener moved to
+  `pve-exporter` LXC; `/logs/otlp/*` sub-route intercepted by Vector; page channel
+  settled as Slack (#notifications); **per-cluster AM** for cluster-specific alerts
+  (cluster vmalert → own AM, not central); **LXC AM** handles only existential
+  alerts (cluster-absent, Grafana down, watchdog) + DMS heartbeat; **DMS: LXC AM
+  → healthchecks.io only** (Grafana not in DMS path); PVE metrics via
+  `pve-exporter` LXC (OTEL push not active); mermaid updated throughout.
 * **2026-06-04**: **ACCEPTED**: VictoriaMetrics stack (metrics + logs + traces) on
   a centralized NixOS LXC; single-node + `cluster` label; no ingest auth (Proxmox
   firewall by source CIDR + tailnet); `/<signal>` Caddy routing; Proxmox

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/README.md
@@ -40,12 +40,13 @@ flowchart LR
         vmagent["VMAgent<br/>(cluster metrics)"]
         clvector["Vector agents<br/>(cluster + pve-exporter logs)"]
         clalert["per-cluster vmalert<br/>(VMRule) → per-cluster AM"]
-        pvexp["pve-exporter LXC<br/>pve_* metrics + Vector logs"]
+        pvexp["pve-exporter LXC<br/>pve_* metrics + syslog→Vector"]
         kaz["kazimierz<br/>(over tailnet)"]
     end
 
     subgraph lxc["LXC appliance (Proxmox)"]
         caddy["Caddy :443<br/>path route, no auth<br/>(+ tailnet via tsnet)"]
+        vector["Vector<br/>:4317/:4318 OTLP (loopback)<br/>:6000 Vector native (bridge)"]
         vm["VictoriaMetrics :8428 (+OTLP)"]
         vl["VictoriaLogs :9428"]
         vt["VictoriaTraces :10428"]
@@ -59,14 +60,17 @@ flowchart LR
     grafana(["amiya Grafana<br/>dashboards + non-paging alerts"])
 
     vmagent -->|"/metrics"| caddy
-    clvector -->|"/logs (Vector :6000)"| caddy
-    pvexp -->|"metrics + logs"| caddy
+    clvector -->|"Vector native :6000"| vector
+    pvexp -->|"/metrics"| caddy
+    pvexp -.->|":6000 syslog→Vector"| vector
     kaz -.tailnet.-> caddy
 
-    caddy --> vm
-    caddy --> vl
-    caddy --> vt
-    caddy --> am
+    caddy -->|"/metrics/*"| vm
+    caddy -->|"/logs/otlp/*"| vector
+    caddy -->|"/logs/*"| vl
+    caddy -->|"/traces/*"| vt
+    caddy -->|"/alerts/*"| am
+    vector -->|"jsonline"| vl
     lxcalert --> am
     clalert --> clam
     clam --> page
@@ -75,6 +79,7 @@ flowchart LR
     vl -.-> data
     vt -.-> data
     am -.-> data
+    vector -.-> data
     grafana -->|query| vm
     grafana -->|query| vl
 ```
@@ -87,11 +92,21 @@ Grafana. The LXC Alertmanager handles only existential alerts and the
 healthchecks.io DMS heartbeat — Grafana is not in the DMS path. Access control is
 the **Proxmox host firewall by source CIDR** (LAN) plus the **tailnet** (off-LAN).
 
-> **Logs ingest** — the appliance ingests only already-structured events (Vector
-> native `:6000` and OTLP, all loopback behind Caddy). It no longer runs a syslog
-> listener: the [`pve-exporter`](../pve-exporter/README.md) LXC owns syslog ingest,
-> parses RFC 5424 into the OTLP-style format, and forwards it here. The appliance's
-> Vector pipeline is now validation + loki-like conversion only.
+> **Logs ingest** — three entry points:
+>
+> * **Vector native `:6000`** (exposed directly on the bridge network, **not**
+>   behind Caddy) — cluster and pve-exporter agents pushing pre-formatted
+>   OTLP-style events. This is the intended primary log path (ADR-013).
+> * **OTLP HTTP via Caddy `/logs/otlp/*`** → Vector `:4318` (loopback). OTLP
+>   gRPC `:4317` is loopback-only.
+> * **ES-compatible via Caddy `/logs/*`** → VictoriaLogs `:9428` (queries and
+>   direct ES insert — bypasses the appliance Vector pipeline).
+>
+> The appliance no longer runs a syslog listener: the
+> [`pve-exporter`](../pve-exporter/README.md) LXC owns syslog ingest, parses RFC
+> 5424 into the OTLP-style format, and forwards it here over Vector native. The
+> appliance's Vector pipeline (Vector native + OTLP sources) runs SemConv
+> validation and loki-like conversion before pushing to VictoriaLogs.
 
 Architecture diagram source: [`architecture.d2`](./architecture.d2).
 
@@ -357,7 +372,7 @@ ssh root@${NODE} pct start ${VMID}
 | Data volume (`mp0`) | 64 GiB at `/persistent` (raise per retention) |
 | Swap                | 0                                             |
 
-Retention defaults: metrics **6 months**, logs **30 days**.
+Retention defaults: metrics **18 months**, logs **30 days**, traces **2 days**.
 
 ## Proxmox host firewall
 
@@ -481,6 +496,25 @@ spec:
 > is enabled, so community mixin rule sets work unchanged.
 
 ### Kubernetes clusters — logs (Vector DaemonSet)
+
+**Recommended — Vector native `:6000`** (goes through the appliance Vector
+pipeline: SemConv validation + loki-like conversion):
+
+```toml
+[sinks.o11y_vector]
+type = "vector"
+inputs = ["kubernetes_logs"]            # add a transform to set cluster=<name>
+address = "o11y.chezmoi.sh:6000"
+mode = "grpc"
+```
+
+Events must arrive in the OTLP-like internal format (body, timestamp,
+resources, attributes …) — see the pipeline contract in
+[`config/vector/README.md`](./config/vector/README.md). Invalid events become
+queryable error records instead of being dropped silently.
+
+**Alternative — ES-compatible via Caddy** (simpler, but **bypasses** the
+appliance Vector pipeline — no SemConv validation):
 
 ```toml
 [sinks.victorialogs]
@@ -681,9 +715,9 @@ for tailnet clients — they connect to the MagicDNS name directly.
 
 4. **Cluster-side resources not included.** VMAgent (+ optional streamAggr),
    VMAlert + VMRule/PrometheusRule, Vector (logs + optional trace export), the
-   Proxmox OTEL push, and Grafana (datasources for metrics/logs/traces + dashboards
-   * the Grafana-side deadman) live in their own projects and are tracked as
-     separate phases of [#1018][].
+   Proxmox OTEL push, and Grafana (datasources for metrics/logs/traces +
+   dashboards + non-paging alert routing) live in their own projects and are
+   tracked as separate phases of [#1018][].
 
 5. **No HA.** Single LXC, single Proxmox node. If the node dies, the LXC deadman
    stops and the external monitor pages; collection halts until the LXC is

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/README.md
@@ -51,7 +51,7 @@ flowchart LR
         vt["VictoriaTraces :10428"]
         am["Alertmanager :9093"]
         lxcalert["LXC vmalert :8880<br/>(cluster/Grafana down + watchdog)"]
-        data[("/var/lib/victoria (mp0)")]
+        data[("/persistent (mp0)")]
     end
 
     page(["ntfy / Slack + deadman (TBD)"])
@@ -316,7 +316,7 @@ ssh root@${NODE} pct create ${VMID} local:vztmpl/${TEMPLATE} \
     --memory       4096 \
     --swap         0 \
     --rootfs       local-zfs:4 \
-    --mp0          local-zfs:64,mp=/var/lib/victoria \
+    --mp0          local-zfs:64,mp=/persistent \
     --net0         name=eth0,bridge=vmbr0,ip=dhcp,firewall=1 \
     --onboot       1
 
@@ -335,7 +335,7 @@ EOF"
 > VMID="<vmid>"
 > # Verify mapping: grep ^root /etc/subuid  (expect root:100000:65536)
 > pct mount ${VMID}
-> chown -R 100980:100980 /var/lib/lxc/${VMID}/rootfs/var/lib/victoria
+> chown -R 100980:100980 /var/lib/lxc/${VMID}/rootfs/persistent
 > pct unmount ${VMID}
 > ```
 
@@ -346,13 +346,13 @@ ssh root@${NODE} pct start ${VMID}
 
 ### Resource sizing — starting values
 
-| Workload            | Recommended                                         |
-| ------------------- | --------------------------------------------------- |
-| CPU                 | 2 vCPU                                              |
-| Memory              | 4 GiB (VM `-memory.allowedPercent=60`)              |
-| Root disk (OS only) | 4 GiB (stateless, rebuilt from flake)               |
-| Data volume (`mp0`) | 64 GiB at `/var/lib/victoria` (raise per retention) |
-| Swap                | 0                                                   |
+| Workload            | Recommended                                   |
+| ------------------- | --------------------------------------------- |
+| CPU                 | 2 vCPU                                        |
+| Memory              | 4 GiB (VM `-memory.allowedPercent=60`)        |
+| Root disk (OS only) | 4 GiB (stateless, rebuilt from flake)         |
+| Data volume (`mp0`) | 64 GiB at `/persistent` (raise per retention) |
+| Swap                | 0                                             |
 
 Retention defaults: metrics **6 months**, logs **30 days**.
 
@@ -597,9 +597,8 @@ type errors and transform regressions without a full Nix build.
 ### Backups
 
 * **Image / OS** — stateless: recreate from the flake for an identical config.
-* **Data** (`/var/lib/victoria`) — **stateful, back it up.** Daily Proxmox
-  snapshot of the `mp0` dataset minimum. Losing it loses history (alerting
-  recovers on restart).
+* **Data** (`/persistent`) — **stateful, back it up.** Daily Proxmox snapshot of
+  the `mp0` dataset minimum. Losing it loses history (alerting recovers on restart).
 * **Secrets** — age-encrypted in git.
 
 ### Upgrading
@@ -608,10 +607,10 @@ type errors and transform regressions without a full Nix build.
 
 Each LXC has two Proxmox LVM thin volumes:
 
-| Volume                                  | Size   | Content                                | On upgrade                                                |
-| --------------------------------------- | ------ | -------------------------------------- | --------------------------------------------------------- |
-| `rootfs` (`disk-0`)                     | 8 GiB  | NixOS system files                     | **replaced** — new template written to a fresh LVM volume |
-| `mp0` (`disk-1`) at `/var/lib/victoria` | 64 GiB | TSDB, logs, traces, Alertmanager state | **reattached** — same LVM volume, zero data copy          |
+| Volume                            | Size   | Content                                | On upgrade                                                |
+| --------------------------------- | ------ | -------------------------------------- | --------------------------------------------------------- |
+| `rootfs` (`disk-0`)               | 8 GiB  | NixOS system files                     | **replaced** — new template written to a fresh LVM volume |
+| `mp0` (`disk-1`) at `/persistent` | 64 GiB | TSDB, logs, traces, Alertmanager state | **reattached** — same LVM volume, zero data copy          |
 
 The upgrade script creates a new rootfs from the template and rewrites the
 container config so the new CT inherits the existing `mp0` volume. No `pvesm
@@ -636,7 +635,7 @@ mise run lxc:upgrade -- pve.lan <source_id> <target_id>
 | ------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------ |
 | Caddy `unauthorized` from Cloudflare        | Token expired/rotated                            | `lxc:secrets:sync` + rebuild + redeploy                                  |
 | remote\_write / query refused (timeout)     | Source IP not in the PVE firewall allowlist      | Add the source CIDR to `/etc/pve/firewall/<vmid>.fw`                     |
-| Component `Permission denied` on start      | `mp0` not chowned to `100980` before start       | `pct mount` → `chown -R 100980:100980 …/var/lib/victoria` → unmount      |
+| Component `Permission denied` on start      | `mp0` not chowned to `100980` before start       | `pct mount` → `chown -R 100980:100980 …/persistent` → unmount            |
 | Existential alerts never fire               | `ALERTMANAGER_NOTIFY_URL` empty at build         | Set it in `observability.sops.env`, rebuild                              |
 | External heartbeat keeps paging             | Watchdog not reaching `ALERTMANAGER_DEADMAN_URL` | Check egress (`policy_out: ACCEPT`) and the URL                          |
 | Tailnet clients can't reach appliance       | tsnet auth failed or TS\_AUTHKEY missing         | Check Caddy logs (`journalctl -u caddy`); verify `TS_AUTHKEY` in secrets |
@@ -660,10 +659,9 @@ mise run lxc:upgrade -- pve.lan <source_id> <target_id>
    `observability-tailscale-oauth-client`, `tag:o11y`) live in
    `projects/chezmoi.sh/src/infrastructure/crossplane/`. After they reconcile,
    `lxc:secrets:sync` fetches both tokens into `caddy.sops.env` automatically.
-   Run `scripts/dist:render` to regenerate the rendered manifests. *(Note:
-   caddy-tailscale's tsnet state is stored at `/var/lib/caddy` on the stateless
-   root disk, so a rebuild wipes it — use a non-ephemeral OAuth key so the node
-   re-registers on the next start without manual intervention.)*
+   Run `scripts/dist:render` to regenerate the rendered manifests. tsnet state is
+   stored at `/persistent/caddy/tsnet` (the mp0 data volume) and survives image
+   rebuilds — the OAuth key does not need to be non-ephemeral.
 
 2c. **Cert validity over the tailnet — resolved.** caddy-tailscale serves the
 tailnet listener at `observability.<tailnet>.ts.net` with TLS issued automatically

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/README.md
@@ -39,8 +39,8 @@ flowchart LR
     subgraph sources["Sources (push — LAN by source CIDR, or tailnet)"]
         vmagent["VMAgent<br/>(cluster metrics)"]
         clvector["Vector agents<br/>(cluster + pve-exporter logs)"]
-        clalert["per-cluster vmalert<br/>(VMRule alerts)"]
-        otlp["OTEL/OTLP<br/>(Proxmox host metrics)"]
+        clalert["per-cluster vmalert<br/>(VMRule) → per-cluster AM"]
+        pvexp["pve-exporter LXC<br/>pve_* metrics + Vector logs"]
         kaz["kazimierz<br/>(over tailnet)"]
     end
 
@@ -49,18 +49,18 @@ flowchart LR
         vm["VictoriaMetrics :8428 (+OTLP)"]
         vl["VictoriaLogs :9428"]
         vt["VictoriaTraces :10428"]
-        am["Alertmanager :9093"]
-        lxcalert["LXC vmalert :8880<br/>(cluster/Grafana down + watchdog)"]
+        am["Alertmanager :9093<br/>(existential + DMS)"]
+        lxcalert["LXC vmalert :8880<br/>(cluster-absent + Grafana down + watchdog)"]
         data[("/persistent (mp0)")]
     end
 
-    page(["ntfy / Slack + deadman (TBD)"])
-    grafana(["amiya Grafana<br/>dashboards + non-paging alerts<br/>+ its own deadman heartbeat"])
+    page(["Slack #notifications<br/>+ healthchecks.io (DMS)"])
+    clam(["per-cluster AM"])
+    grafana(["amiya Grafana<br/>dashboards + non-paging alerts"])
 
     vmagent -->|"/metrics"| caddy
     clvector -->|"/logs (Vector :6000)"| caddy
-    clalert -->|"/alerts"| caddy
-    otlp -->|"/metrics (OTLP)"| caddy
+    pvexp -->|"metrics + logs"| caddy
     kaz -.tailnet.-> caddy
 
     caddy --> vm
@@ -68,6 +68,8 @@ flowchart LR
     caddy --> vt
     caddy --> am
     lxcalert --> am
+    clalert --> clam
+    clam --> page
     am --> page
     vm -.-> data
     vl -.-> data
@@ -78,11 +80,12 @@ flowchart LR
 ```
 
 The LXC vmalert evaluates only the existential page-tier (cluster absent, Grafana
-down, watchdog/deadman). Per-cluster `vmalert` evaluates that cluster's
+down, watchdog/DMS). Per-cluster `vmalert` evaluates that cluster's
 `VMRule`/`PrometheusRule` (records + page-worthy alerts) against the central VM and
-notifies the central Alertmanager through Caddy; non-paging alerts are routed by
-Grafana. Access control is the **Proxmox host firewall by source CIDR** (LAN) plus
-the **tailnet** (off-LAN).
+notifies the cluster's **own Alertmanager**; non-paging alerts are routed by
+Grafana. The LXC Alertmanager handles only existential alerts and the
+healthchecks.io DMS heartbeat — Grafana is not in the DMS path. Access control is
+the **Proxmox host firewall by source CIDR** (LAN) plus the **tailnet** (off-LAN).
 
 > **Logs ingest** — the appliance ingests only already-structured events (Vector
 > native `:6000` and OTLP, all loopback behind Caddy). It no longer runs a syslog
@@ -110,25 +113,27 @@ Architecture diagram source: [`architecture.d2`](./architecture.d2).
   `/<signal>/*` scheme: `/metrics/*` → VictoriaMetrics, `/logs/*` →
   VictoriaLogs, `/traces/*` → VictoriaTraces, `/alerts/*` → Alertmanager.
   VM/VLogs/VTraces prefixes are stripped; Alertmanager keeps its prefix.
-* **Proxmox host metrics via OTEL/OTLP** — the Proxmox OTEL metric server pushes
-  to `…/metrics/opentelemetry/v1/metrics` (VictoriaMetrics' native OTLP endpoint).
-* **Routing rule: if it pages → Alertmanager, otherwise → Grafana.** Alertmanager
-  is reserved for the **page-tier** — the critical alerts that wake you up (loss of
-  a cluster, loss of Grafana, node/disk/PVC down). Everything else (warnings, FYI,
-  per-app SLOs) is evaluated and routed by **Grafana**, whose contact points /
-  notification policies are far simpler to manage than Alertmanager receivers.
-* **Recording rules + page-tier cluster alerts → per-cluster vmalert (VMRule).**
+* **Proxmox host and guest metrics via the `pve-exporter` LXC** —
+  prometheus-pve-exporter scrapes the PVE API for `pve_*` metrics and
+  remote-writes them to the appliance (`cluster=pve`). Proxmox OTEL push is not
+  yet active.
+* **Routing rule: page → AM (two tiers); else → Grafana.** Each cluster has its
+  **own Alertmanager** for cluster-specific page alerts. The **LXC Alertmanager**
+  handles only what requires the central vantage point: cluster absent, Grafana
+  down, watchdog/DMS. Non-paging alerts are routed by Grafana. Grafana is not in
+  the DMS path.
+* **Recording rules + page-tier cluster alerts → per-cluster vmalert + per-cluster AM.**
   Each cluster runs a vmalert (VictoriaMetrics Operator, reading `VMRule` /
   `PrometheusRule`) that evaluates that cluster's **recording rules** (Grafana
   cannot persist these) and any **page-worthy** alerts against the central VM,
-  writes records back, and notifies the central Alertmanager. Rules live in the
+  writes records back, and notifies its **own Alertmanager**. Rules live in the
   cluster's ArgoCD repo — no LXC rebuild. Edge cardinality reduction is `vmagent`
   stream aggregation. The LXC keeps a *minimal* set of **existential,
-  cluster-independent** page rules (cluster absent, node/disk/PVC, self, Watchdog)
-  so paging survives even an amiya outage.
-* **Alertmanager is centralized and exposed under `/alerts`** — both the
-  LXC's existential vmalert and each cluster's vmalert reach it, so paging is
-  cluster-independent. Grafana never gates paging.
+  cluster-independent** page rules so paging survives even an amiya outage.
+* **Two Alertmanager tiers: per-cluster AM + LXC AM** — per-cluster AM handles
+  cluster-specific alerts; LXC AM handles existential alerts and the DMS heartbeat
+  to healthchecks.io. LXC AM exposed under `/alerts` (CIDR-restricted) for
+  loopback access from the LXC vmalert. Grafana never gates paging.
 * **Tailscale membership via caddy-tailscale** — Tailscale is embedded directly
   in Caddy using [caddy-tailscale](https://github.com/tailscale/caddy-tailscale)
   (tsnet, userspace networking). No separate `tailscaled` daemon and no kernel
@@ -137,12 +142,10 @@ Architecture diagram source: [`architecture.d2`](./architecture.d2).
   automatically by Tailscale's ACME. The loopback backends remain unreachable over
   the tailnet — the tsnet listener runs inside the Caddy process, not via a kernel
   interface.
-* **Two Dead-Man's-Switches (external service TBD)** — the LXC Alertmanager
-  heartbeats an external monitor every minute (catches appliance death); a Grafana
-  always-on rule heartbeats it too (catches amiya/Grafana death). If either stops,
-  the external monitor pages. The external service is **not yet chosen** — candidates
-  include healthchecks.io or a Cloudflare-based check; `ALERTMANAGER_DEADMAN_URL` is
-  the placeholder for whatever we land on.
+* **Dead-Man's-Switch: LXC AM → healthchecks.io** — the Watchdog alert always
+  fires; the LXC Alertmanager pings healthchecks.io every minute. Appliance death
+  stops the heartbeat and healthchecks.io pages. Grafana is not involved in the DMS
+  path. URL: `ALERTMANAGER_DEADMAN_URL` in `observability.sops.env`.
 
 ### Ports
 
@@ -154,7 +157,7 @@ Architecture diagram source: [`architecture.d2`](./architecture.d2).
 | Vector (native)     | `:6000`           | **Yes** — Vector-native log ingest from cluster + pve-exporter agents (bridge/tailnet) |
 | VictoriaTraces      | `127.0.0.1:10428` | No (behind Caddy; OTLP/Jaeger ingest)                                                  |
 | vmalert             | `127.0.0.1:8880`  | No (self-scrape only)                                                                  |
-| Alertmanager        | `127.0.0.1:9093`  | Via Caddy `/alerts/*` (cluster vmalert → notify); egress for notifications + heartbeat |
+| Alertmanager        | `127.0.0.1:9093`  | Via Caddy `/alerts/*` (LXC loopback only); egress for Slack + healthchecks.io DMS      |
 
 ## What's in this directory
 
@@ -447,7 +450,7 @@ spec:
   remoteWrite:  { url: https://o11y.chezmoi.sh/metrics/api/v1/write } # recording-rule results
   remoteRead:   { url: https://o11y.chezmoi.sh/metrics }            # restore alert state
   notifiers:
-    - url: https://o11y.chezmoi.sh/alerts                          # central Alertmanager
+    - url: http://alertmanager.monitoring.svc:9093                 # per-cluster AM
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
@@ -501,11 +504,17 @@ https://o11y.chezmoi.sh/traces/insert/opentelemetry/v1/traces
 Set a `cluster=<name>` resource attribute for correlation. Query from Grafana via
 the Jaeger/VictoriaTraces datasource at `https://o11y.chezmoi.sh/traces`.
 
-### Proxmox host — metrics (OTEL)
+### Proxmox host — metrics (pve-exporter LXC)
 
-Configure the Proxmox OTEL metric server to push OTLP/HTTP to
-`https://o11y.chezmoi.sh/metrics/opentelemetry/v1/metrics` with an external
-label `cluster=proxmox`.
+PVE host and guest metrics (`pve_*`) are collected by the
+[`pve-exporter`](../pve-exporter/README.md) LXC, which scrapes the PVE API via
+prometheus-pve-exporter and remote-writes to the appliance at
+`https://o11y.chezmoi.sh/metrics/api/v1/write` with `cluster=pve`. No
+configuration is needed on the appliance side. See the pve-exporter README for
+the scrape config and the required PVE API token.
+
+> Proxmox OTEL push (`/metrics/opentelemetry/v1/metrics`) is not yet active;
+> VictoriaMetrics already exposes that endpoint if it is enabled later.
 
 ### Proxmox host — logs (rsyslog → pve-exporter)
 
@@ -528,15 +537,14 @@ it over the encrypted tailnet — `externalLabels: { cluster: kazimierz }`. Poin
 them at `https://observability.<tailnet>.ts.net` directly; TLS is valid for that
 MagicDNS name without any split-DNS override.
 
-### Grafana (amiya) — dashboards + the Grafana-side deadman
+### Grafana (amiya) — dashboards
 
 Two datasources (no auth): Prometheus-type → `https://o11y.chezmoi.sh/metrics`,
 VictoriaLogs-type → `https://o11y.chezmoi.sh/logs` *(verify the query path for
 the installed VictoriaLogs version — see Known gaps)*. Grafana is for
 **dashboards** and **non-paging alert routing** — page-tier alerting/recording
-rules live in VMRule per cluster (above). The
-one alerting Grafana keeps: a single **always-firing rule wired to the external
-heartbeat**, so an amiya/Grafana outage is detected independently of the LXC.
+rules live in VMRule per cluster (above). Grafana is not wired to the DMS
+heartbeat; the LXC Alertmanager owns that path entirely.
 
 ## Hardening reference
 

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/modules/alertmanager.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/modules/alertmanager.nix
@@ -1,17 +1,20 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Alertmanager — existential alert routing + the Dead-Man's-Switch
 # ─────────────────────────────────────────────────────────────────────────────
-# The central, cluster-independent notification hub (ADR-013). It receives alerts
-# from BOTH the LXC's existential vmalert AND every cluster's vmalert (which
-# notifies it through Caddy under /alerts), routes on the `cluster` label,
-# and runs the Dead-Man's-Switch. Centralizing notification here keeps paging
-# independent of any single cluster — more resilient than alerting inside amiya.
+# The LXC Alertmanager handles ONLY existential, cluster-independent alerts
+# (ADR-013 two-tier model): cluster-absent, Grafana-down, and the Watchdog/DMS.
+# It receives alerts exclusively from the LXC's own vmalert (loopback).
+#
+# Per-cluster page-tier alerts (node/disk/PVC/crash-loop) are routed by each
+# cluster's OWN Alertmanager, fed by that cluster's vmalert. The LXC AM is NOT
+# in that path — centralizing only the existential layer here keeps paging
+# independent of any single cluster outage.
 #
 # Notification channels
 # ──────────────────────
-#   default  — Slack incoming webhook (#notifications). Fires on any page-tier
-#               alert (severity=page) including cluster-absent, Grafana-down,
-#               node/disk/PVC events sent by per-cluster vmalert.
+#   default  — Slack incoming webhook (#notifications). Fires on existential
+#               page-tier alerts: cluster-absent, Grafana-down, appliance
+#               component down, PVE host/guest down.
 #   deadman  — HTTP webhook pinging an external heartbeat service (e.g.
 #               healthchecks.io). Always fires the Watchdog alert on a 1-minute
 #               cadence. If the heartbeat stops, the external service pages —
@@ -101,10 +104,11 @@ in
         "--config.file=/etc/alertmanager/alertmanager.yml"
         "--storage.path=${dataDir}"
         "--web.listen-address=${listenAddr}"
-        # Served under /alerts/* so per-cluster vmalert instances can notify
-        # it through Caddy (the only exposed surface). The route-prefix applies to
-        # ALL paths: API at /alerts/api/v2, metrics at /alerts/metrics —
-        # kept consistent in vmalert.nix and the VM self-scrape config.
+        # Exposed under /alerts/* via Caddy for operator UI/API access. The LXC
+        # vmalert reaches it over loopback (127.0.0.1:9093/alerts). Per-cluster
+        # vmalerts notify their OWN Alertmanager — NOT this one. The route-prefix
+        # applies to ALL paths: API at /alerts/api/v2, metrics at /alerts/metrics
+        # — kept consistent in vmalert.nix and the VM self-scrape config.
         "--web.route-prefix=/alerts"
         "--web.external-url=https://o11y.chezmoi.sh/alerts"
         "--log.format=json"

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/modules/caddy.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/modules/caddy.nix
@@ -110,7 +110,7 @@ in
           }
         }
 
-        # All other /logs/* (queries, ES ingest via Vector, health) → VictoriaLogs :9428
+        # All other /logs/* (queries, ES-compatible ingest, health) → VictoriaLogs :9428
         handle_path /logs/* {
           reverse_proxy localhost:9428 {
             flush_interval -1

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/modules/vmalert.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/modules/vmalert.nix
@@ -2,19 +2,22 @@
 # vmalert — EXISTENTIAL rule evaluation only
 # ─────────────────────────────────────────────────────────────────────────────
 # Scope (ADR-013): this evaluates ONLY the small, stable set of existential,
-# cluster-independent rules in ../alerts/ — node/disk/PVC down, appliance
-# self-monitoring, and the Watchdog. These must fire even when amiya is down.
-# Each cluster's own alerting AND recording rules live as VMRule/PrometheusRule
-# CRDs evaluated by that cluster's vmalert (VM Operator), notifying this same
-# central Alertmanager — managed as-code per cluster, with no LXC rebuild.
+# cluster-independent rules in ../alerts/ — cluster-absent, Grafana-down,
+# appliance self-monitoring, PVE host/guest/disk, OCI registry, and the Watchdog.
+# These must fire even when amiya (or any observed cluster) is down.
+#
+# Per-cluster alerting AND recording rules (node/disk/PVC/crash-loop, recording
+# rules) live as VMRule/PrometheusRule CRDs evaluated by that cluster's OWN
+# vmalert (VM Operator), notifying the cluster's OWN Alertmanager — NOT this
+# central one. Managed as-code per cluster, with no LXC rebuild.
 #
 # Because this existential rule set is rare-changing, it is baked into the image
 # (code-reviewed, GPG-signed) rather than hot-loaded — the "rebuild to add a rule"
 # cost that pushed per-cluster rules out to VMRule does not apply here.
 #
-# vmalert cannot notify on its own; it pushes firing alerts to the local
-# Alertmanager. Alert state is written back to VictoriaMetrics so it survives a
-# restart and is queryable from Grafana.
+# vmalert pushes firing alerts to the LOCAL Alertmanager (loopback). Alert state
+# is written back to VictoriaMetrics so it survives a restart and is queryable
+# from Grafana.
 #
 # Binds 127.0.0.1:8880 (loopback) — exposed for self-scrape only.
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The observability LXC scaffold (PR #1029) diverged from ADR-013 on three fronts: the alerting topology (two-tier AM vs. single hub), log-ingest routing (Vector native `:6000` as primary path, not Caddy-only), and the Tailscale integration (tsnet vs. tailscaled). Separately, the `pct create` command in the README had `mp0` mounted at `/var/lib/victoria` while every NixOS module writes to `/persistent` — deploying as-written would silently place all state on the volatile rootfs. Inline module comments also reflected the old single-AM design, which would have misled operators debugging alert routing.

**Related Issue:** #1018

## Root Cause

### ADR-013 / architecture drift

ADR-013 was drafted before the scaffold was written. Four design decisions changed during implementation without a corresponding update:

- **Tailscale**: the ADR described a standalone `tailscaled` daemon in kernel TUN mode; the scaffold uses `caddy-tailscale` (tsnet, userspace) — no `/dev/net/tun` needed, state at `/persistent/caddy` survives rebuilds.
- **Alerting topology**: the ADR and module comments described the LXC AM as a central hub receiving alerts from every cluster's vmalert via Caddy. The implemented two-tier model has each cluster notify its **own** Alertmanager; the LXC AM handles only existential, cluster-independent alerts (cluster-absent, Grafana-down, PVE host/guest/disk, OCI registry, Watchdog) via loopback from the LXC vmalert.
- **Log ingest paths**: the ADR only documented `/logs/*` → VictoriaLogs. The scaffold adds a `Vector native :6000` entry point (on the bridge, not behind Caddy) as the recommended primary path, plus a `/logs/otlp/*` sub-route → Vector `:4318` intercepted before the generic VictoriaLogs path.
- **Page channel**: settled as Slack `#notifications`; ntfy was never implemented.

### README deployment bug

The `pct create` snippet used `--mp0 local-zfs:64,mp=/var/lib/victoria`. Every NixOS module (`victoriametrics.nix`, `victorialogs.nix`, `victoriatraces.nix`, `vector.nix`, `alertmanager.nix`, `caddy.nix`) writes to `/persistent` or subdirectories under it. A mismatch silently places all state on the rootfs, which is replaced wholesale on each image upgrade. The same error propagated to the pre-start chown command, sizing table, upgrade table, troubleshooting table, backups section, mermaid node label, and the known-gaps note referencing tsnet state at `/var/lib/caddy`.

### Module comment drift

After the architecture was corrected in the diagrams, `alertmanager.nix`, `vmalert.nix`, and `caddy.nix` still carried header comments describing the old single-AM hub and Caddy-mediated routing — creating a contradiction between the README/ADR and the code an operator would read first.

## Fix

### ADR-013 ([`docs/decisions/013-centralized-observability-victoriametrics-lxc.md`](docs/decisions/013-centralized-observability-victoriametrics-lxc.md))

- Rewrote the Tailscale paragraph: `caddy-tailscale` tsnet, userspace, no `/dev/net/tun`, state at `/persistent/caddy`.
- Updated the mermaid diagram: `pve-exporter LXC` source node, appliance-side `Vector` node, `/logs/otlp/*` edge, tailnet label on kazimierz, page channel corrected to `Slack #notifications`, per-cluster AM shown separately from the LXC AM.
- Expanded the Vector paragraph: edge DaemonSet role + appliance-side pipeline (OTLP + Vector native → SemConv → VictoriaLogs); syslog responsibility moved to pve-exporter.
- Documented the `/logs/otlp/*` → Vector sub-route and the two-tier AM model.
- Updated *Status* to reflect full scaffold scope; added 2026-06-15 changelog entry.

### README ([`projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/README.md`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/README.md))

- `mp=/var/lib/victoria` → `mp=/persistent` in the `pct create` command; pre-start chown path corrected; all six other `/var/lib/victoria` references updated to `/persistent`; known-gaps note 2 corrected (`/var/lib/caddy` → `/persistent/caddy/tsnet`).
- Architecture diagram: added `Vector` node inside the LXC subgraph; cluster agents now route to Vector native `:6000` (not through Caddy); pve-exporter syslog routed to Vector native, metrics to Caddy `/metrics/*`; Caddy edges labeled with explicit path prefixes.
- Log ingest prose replaced with three documented entry points: Vector native `:6000` (bridge, primary), OTLP via Caddy `/logs/otlp/*`, ES-compat via Caddy `/logs/*`. Kubernetes cluster integration example updated to show Vector native sink first.
- Retention corrected: metrics 18 months (was 6), traces 2 days added.

### Module comments

- **[`modules/alertmanager.nix`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/modules/alertmanager.nix)** — header rewritten: LXC AM is existential-only; per-cluster vmalerts notify their own AM, not this one; LXC vmalert reaches AM over loopback, not through Caddy.
- **[`modules/vmalert.nix`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/modules/vmalert.nix)** — rule scope clarified: cluster-absent, Grafana-down, PVE host/guest/disk, OCI registry, Watchdog; per-cluster recording and alerting rules live as VMRule CRDs evaluated by each cluster's own vmalert, notifying that cluster's own AM.
- **[`modules/caddy.nix`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/modules/caddy.nix)** — `/alerts/*` comment corrected: LXC vmalert reaches AM over loopback (`127.0.0.1:9093`); Caddy exposes the path for operator UI/API access only; per-cluster vmalerts do not use this path.

## Technical Impact

### Behavioural Changes

No runtime behaviour changes — all commits are documentation and comment corrections only. No NixOS module logic was modified.

### Regression Risk

Low. Documentation and comment changes only. No scripts in the repo parse the `pct create` snippet.

### Observability

N/A — documentation changes only. The correct `mp=/persistent` mount will be verified at first deploy by checking that `/persistent/o11y/metrics` is populated on the data volume rather than the rootfs.

## Testing Validation

- [ ] ADR-013 mermaid renders correctly in GitHub
- [ ] `pct create` command with `mp=/persistent` produces a container whose data volume is at `/persistent` inside the LXC
- [ ] Pre-start chown path (`rootfs/persistent`) targets the correct directory
- [ ] No remaining `/var/lib/victoria` references in the README
- [ ] Module comments accurately describe the two-tier AM topology after review

## Related Issues

Addresses #1018 (Phase — documentation alignment before first deploy)

---
<sub>AI-assisted with anthropic:claude-sonnet-4-6 under human supervision</sub>
