### PR TITLE
Add trunk check to create-pr skill pre-flight and follow-up commit workflow

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -57,6 +57,20 @@ Before pushing anything:
      a DCO legal attestation that only the human committer can make. Surface the warning to the user and
      let them decide. Do not add `-s` to any commit command yourself.
 
+5. Run trunk check on the changed files and fix all issues before pushing:
+
+   ```sh
+   trunk check --filter=-conftest
+   ```
+
+   * **`ISSUES` reported** — fix every lint/format error before creating the PR. Do not suppress
+     trunk warnings with `trunk-ignore` unless the warning is a known false positive; explain why
+     in a comment when you do.
+   * **`No issues`** — proceed to push.
+
+   Run trunk check locally rather than relying on the CI to catch it: a failed CI run after
+   the PR is open costs a round-trip and blocks review.
+
 ## Branch naming
 
 | Type          | Pattern                 | Example                     |
@@ -70,12 +84,29 @@ Before pushing anything:
 
 ## Workflow
 
+### Opening a new PR
+
 1. Create a branch following the naming conventions above.
-2. Push: `git push -u origin <branch-name>`
-3. Run the commit validator (step 4 above) and fix any `FAIL` items; surface `WARN` items to the user.
-4. Draft the PR body following the selected template — see `.github/PULL_REQUEST_TEMPLATE/<type>.md` and `references/pr-examples.md`.
-5. Create the PR with a **sentence-form** title that says what changes (no symbol prefix, no bracketed scope — the commit symbol format is for git log, not for PR titles).
-6. Apply labels: one `type::*` + the scope label (`project:*`, `catalog:*`, `gh`, `deps`). The PR auto-labeler will add `pr::*` based on changed files / branch name.
+2. Run the commit validator (step 4 above) and fix any `FAIL` items; surface `WARN` items to the user.
+3. Run `trunk check --filter=-conftest` (step 5 above) and fix all issues.
+4. Push: `git push -u origin <branch-name>`
+5. Draft the PR body following the selected template — see `.github/PULL_REQUEST_TEMPLATE/<type>.md` and `references/pr-examples.md`.
+6. Create the PR with a **sentence-form** title that says what changes (no symbol prefix, no bracketed scope — the commit symbol format is for git log, not for PR titles).
+7. Apply labels: one `type::*` + the scope label (`project:*`, `catalog:*`, `gh`, `deps`). The PR auto-labeler will add `pr::*` based on changed files / branch name.
+
+### Pushing follow-up commits to an existing PR
+
+When adding a commit to a branch that already has an open PR:
+
+1. Run the commit validator and trunk check as above.
+2. Push the commit.
+3. **Ask the user** whether the PR body needs updating to reflect the new changes:
+
+   > A follow-up commit was just pushed to PR #N. Do you want me to review the PR body and update it to reflect the new changes?
+
+   If the user says yes, fetch the current body with `gh pr view --json body`, diff it against the new
+   commits, and propose targeted edits to the Summary, Changes Made, and Testing Validation sections.
+   Never silently rewrite the PR body — always show the diff to the user before applying.
 
 ## PR title format
 
@@ -327,6 +358,7 @@ gh pr create \
 
 * [ ] Branch name follows convention
 * [ ] Commit validator shows no `FAIL` lines; `WARN` lines surfaced to user
+* [ ] `trunk check --filter=-conftest` reports `No issues` locally
 * [ ] PR title is a sentence — verb-first, no symbol prefix, no bracketed scope
 * [ ] PR labels include one `type::*` + the scope label
 * [ ] PR body matches the selected template skeleton: Summary, Changes Made (with subsystem headings),


### PR DESCRIPTION
## Summary

Adds a trunk check step to the create-pr skill pre-flight checklist and documents the behavior expected when pushing follow-up commits to an existing PR. This prevents the recurring pattern where a lint failure is only caught by CI after the PR is already open for review.

## Rationale

The create-pr skill previously had no local quality gate beyond the commit validator. Trunk check failures discovered by CI after the PR is open cost an extra round-trip and block review. Running `trunk check` locally before pushing is the natural fix — it's fast, already installed in the dev environment, and catches the same issues CI checks.

The follow-up commit question was missing from the workflow: when pushing a fix commit to an existing PR, the PR body often becomes stale (Summary and Changes Made sections may no longer reflect the full set of changes). The skill now explicitly asks the user before silently letting the body drift.

## Changes Made

### create-pr skill

- **[`.agents/skills/create-pr/SKILL.md`](.agents/skills/create-pr/SKILL.md)** — three additions:
  - Pre-flight **step 5**: run `trunk check --filter=-conftest`; fix all issues before pushing; guidance on when `trunk-ignore` is acceptable
  - **Workflow section**: split into "Opening a new PR" and "Pushing follow-up commits to an existing PR"; the follow-up path requires asking the user whether to update the PR body, and never updates it silently
  - **Review checklist**: new item "`trunk check --filter=-conftest` reports `No issues` locally"

## Technical Impact

### Behavioural Changes

Before: no local trunk check step; trunk errors discovered only after CI runs on the open PR.

After: trunk check is a mandatory pre-flight gate before pushing. Follow-up commits to an existing PR explicitly surface the question of whether the PR body needs updating.

## Testing Validation

- [ ] Read `.agents/skills/create-pr/SKILL.md` — pre-flight step 5 is present and correctly numbered
- [ ] Read the Workflow section — "Pushing follow-up commits" subsection is present and accurate

## Related Issues

Addresses #1034 (root cause: no trunk check before PR creation)

---
<sub>AI-assisted with anthropic:claude-sonnet-4-6 under human supervision</sub>
