### PR TITLE
Clarify Assisted-by trailer version format uses dots not hyphens

### DIFF
--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -175,6 +175,10 @@ sole author, the AI is acknowledged as an assistant, not a co-author with legal 
 Format: `Assisted-by: <provider>:<model-id>` — use the identifier of the model powering
 the current session (e.g. `Assisted-by: github-copilot:claude-sonnet-4.6`).
 
+Version numbers always use a dot separator: `4.6`, `4.8` — never a hyphen (`4-6`).
+The system's internal model ID format uses hyphens (`claude-sonnet-4-6`), but the
+`Assisted-by` trailer always uses the public model name with dots.
+
 ### Signing and DCO — the AI must stay out of this
 
 The `git commit -s` flag adds a `Signed-off-by:` trailer. This is the committer's


### PR DESCRIPTION
## Summary

Clarifies that version numbers in the `Assisted-by` trailer always use a dot separator (`4.6`, `4.8`), not a hyphen. The system's internal model ID format uses hyphens (`claude-sonnet-4-6`), which can be mistaken for the correct trailer format. Provider examples remain unchanged (`github-copilot` is also a valid provider for Claude Sonnet models).

## Rationale

Without an explicit note, agents reading the system's model ID (`claude-sonnet-4-6`) write the trailer with hyphens, producing `Assisted-by: github-copilot:claude-sonnet-4-6` instead of the correct `github-copilot:claude-sonnet-4.6`. Adding one clear sentence removes the ambiguity.

## Changes Made

### git-commit skill

- **[`.agents/skills/git-commit/SKILL.md`](.agents/skills/git-commit/SKILL.md)** — added explicit note under the `Assisted-by` section: version numbers use dots (`4.6`), never hyphens (`4-6`), and this differs from the system's internal model ID format

## Technical Impact

### Behavioural Changes

Future commits from AI assistants using this skill will use dot-separated version numbers in the `Assisted-by` trailer.

## Testing Validation

- [ ] Read `.agents/skills/git-commit/SKILL.md` — the `Assisted-by` section explicitly states dots, not hyphens, for version numbers

## Related Issues

None

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
