### PR TITLE
Migrate Cloudflare Crossplane provider to wildbitca family

### DIFF
--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/cloudflare/default.providerconfig.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/cloudflare/default.providerconfig.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cloudflare.crossplane.io/v1beta1
+apiVersion: upjet-cloudflare.upbound.io/v1beta1
 kind: ProviderConfig
 metadata:
   name: default

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/cloudflare/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/cloudflare/provider.yaml
@@ -2,8 +2,26 @@
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: provider-cloudflare
+  name: wildbitca-provider-family-cloudflare
 spec:
-  package: xpkg.upbound.io/chezmoi-sh/provider-cloudflare:v0.1.0
+  package: xpkg.upbound.io/wildbitca/provider-family-cloudflare:v0.2.6
+  runtimeConfigRef:
+    name: hardened
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: wildbitca-provider-cloudflare-account
+spec:
+  package: xpkg.upbound.io/wildbitca/provider-cloudflare-account:v0.2.6
+  runtimeConfigRef:
+    name: hardened
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: wildbitca-provider-cloudflare-zone
+spec:
+  package: xpkg.upbound.io/wildbitca/provider-cloudflare-zone:v0.2.6
   runtimeConfigRef:
     name: hardened


### PR DESCRIPTION
The `chezmoi-sh/provider-cloudflare` was a standalone community provider built against Crossplane v1 APIs. The wildbitca provider family adopts the upjet-based provider-family pattern, splitting Cloudflare resources across three sub-providers (family, account, zone) and is the actively maintained option for Cloudflare resources on Crossplane v2.

**Related Issue:** #1025 (Phase 1 — provider upgrade)

## Rationale

The chezmoi-sh standalone provider predates the upjet provider-family model and does not support Crossplane v2. Migrating to the wildbitca provider family unblocks the resource schema migration (issue #1025) and aligns the Cloudflare provider with the same pattern used by other Upbound-managed providers.

## Changes Made

### Provider packages

- **[`providers/cloudflare/provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/cloudflare/provider.yaml)** — Replaces the single `chezmoi-sh/provider-cloudflare:v0.1.0` package with three wildbitca sub-providers: `provider-family-cloudflare`, `provider-cloudflare-account`, and `provider-cloudflare-zone` at v0.2.6
- **[`providers/cloudflare/default.providerconfig.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/cloudflare/default.providerconfig.yaml)** — Updates the apiVersion from `cloudflare.crossplane.io/v1beta1` to `upjet-cloudflare.upbound.io/v1beta1`
- `-`: `chezmoi-sh/provider-cloudflare:v0.1.0` — replaced by the wildbitca provider family

## Technical Impact

### Architecture Simplification

| Before | After |
|---|---|
| Single `chezmoi-sh/provider-cloudflare:v0.1.0` | Three `wildbitca` sub-providers: family, account, zone at v0.2.6 |
| `cloudflare.crossplane.io/v1beta1` ProviderConfig API | `upjet-cloudflare.upbound.io/v1beta1` ProviderConfig API |
| Crossplane v1 provider model | upjet-based provider-family model (Crossplane v2 compatible) |

### Security Boundary Preservation

Provider credentials remain referenced from the same secret in `crossplane-secrets`. The `hardened` RuntimeConfig is preserved on all three sub-providers. No changes to secret handling.

### Behavioural Changes

Existing Cloudflare managed resources using the old `cloudflare.crossplane.io` API group will stop reconciling once this provider replaces the old one. The resource migration (phase 2, issue #1025) must be applied to restore reconciliation.

### Migration Path

1. Apply this PR to install the wildbitca provider family and update the ProviderConfig
2. Apply the resource migration (phase 2) to switch all managed resources to the new API schemas

## Testing Validation

- [ ] All three wildbitca provider pods (`family`, `account`, `zone`) reach `Healthy` status
- [ ] ProviderConfig `default` shows `Ready` condition under `upjet-cloudflare.upbound.io`
- [ ] ArgoCD diff shows only provider package and ProviderConfig changes

## Related Issues

Addresses #1025 (Phase 1)

<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
