### PR TITLE
Migrate Cloudflare IAM resources to upjet-cloudflare API

### DIFF
--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.observability.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.observability.yaml
@@ -16,20 +16,20 @@
 #     kubectl get secret -n crossplane-secrets chezmoi.sh-cloudflare-token-o11y \
 #       -o jsonpath='{.data.attribute\.value}' | base64 -d
 ---
-apiVersion: account.cloudflare.crossplane.io/v1alpha1
-kind: APIToken
+apiVersion: account.upjet-cloudflare.upbound.io/v1alpha1
+kind: Token
 metadata:
   name: chezmoi-sh-caddy-dns01-o11y
 spec:
   forProvider:
     name: (chezmoi.sh) - caddy-dns01/observability
-    policy:
+    accountId: 00736631322131f61ce95f2c235143da
+    policies:
       - effect: allow
         permissionGroups:
-          - c8fed203ed3043cba015a93ad1616f1f # Zone Read (Zone)
-          - 4755a26eedb94da69e1066d98aa820be # Zone DNS Edit (Zone)
-        resources:
-          com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94: "*"
+          - id: c8fed203ed3043cba015a93ad1616f1f # Zone Read (Zone)
+          - id: 4755a26eedb94da69e1066d98aa820be # Zone DNS Edit (Zone)
+        resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-o11y
     namespace: crossplane-secrets

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.oci-registry.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.oci-registry.yaml
@@ -16,20 +16,20 @@
 #     kubectl get secret -n crossplane-secrets chezmoi.sh-cloudflare-token-caddy-dns01-zot \
 #       -o jsonpath='{.data.attribute\.value}' | base64 -d
 ---
-apiVersion: account.cloudflare.crossplane.io/v1alpha1
-kind: APIToken
+apiVersion: account.upjet-cloudflare.upbound.io/v1alpha1
+kind: Token
 metadata:
   name: chezmoi-sh-caddy-dns01-zot
 spec:
   forProvider:
     name: (chezmoi.sh) - caddy-dns01/zot-registry
-    policy:
+    accountId: 00736631322131f61ce95f2c235143da
+    policies:
       - effect: allow
         permissionGroups:
-          - c8fed203ed3043cba015a93ad1616f1f # Zone Read (Zone)
-          - 4755a26eedb94da69e1066d98aa820be # Zone DNS Edit (Zone)
-        resources:
-          com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94: "*"
+          - id: c8fed203ed3043cba015a93ad1616f1f # Zone Read (Zone)
+          - id: 4755a26eedb94da69e1066d98aa820be # Zone DNS Edit (Zone)
+        resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-caddy-dns01-zot
     namespace: crossplane-secrets

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.omni.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.omni.yaml
@@ -16,20 +16,20 @@
 #     kubectl get secret -n crossplane-secrets chezmoi.sh-cloudflare-token-caddy-dns01-omni \
 #       -o jsonpath='{.data.attribute\.value}' | base64 -d
 ---
-apiVersion: account.cloudflare.crossplane.io/v1alpha1
-kind: APIToken
+apiVersion: account.upjet-cloudflare.upbound.io/v1alpha1
+kind: Token
 metadata:
   name: chezmoi-sh-caddy-dns01-omni
 spec:
   forProvider:
     name: (chezmoi.sh) - caddy-dns01/omni
-    policy:
+    accountId: 00736631322131f61ce95f2c235143da
+    policies:
       - effect: allow
         permissionGroups:
-          - c8fed203ed3043cba015a93ad1616f1f # Zone Read (Zone)
-          - 4755a26eedb94da69e1066d98aa820be # Zone DNS Edit (Zone)
-        resources:
-          com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94: "*"
+          - id: c8fed203ed3043cba015a93ad1616f1f # Zone Read (Zone)
+          - id: 4755a26eedb94da69e1066d98aa820be # Zone DNS Edit (Zone)
+        resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-caddy-dns01-omni
     namespace: crossplane-secrets

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.terraform-provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.terraform-provider.yaml
@@ -14,25 +14,24 @@
 # Security:
 #   The secret is synchronized to Vault (vault.chezmoi.sh) using PushSecret.
 ---
-apiVersion: account.cloudflare.crossplane.io/v1alpha1
-kind: APIToken
+apiVersion: account.upjet-cloudflare.upbound.io/v1alpha1
+kind: Token
 metadata:
   name: chezmoi-sh-terraform-provider
 spec:
   forProvider:
     name: (chezmoi.sh) - terraform-provider
-    policy:
+    accountId: 00736631322131f61ce95f2c235143da
+    policies:
       - effect: allow
         permissionGroups:
-          - c8fed203ed3043cba015a93ad1616f1f # Zone Read (Zone)
-          - 4755a26eedb94da69e1066d98aa820be # Zone DNS Edit (Zone)
-          - 3030687196b94b638145a3953da2b699 # Zone Settings Edit (Zone)
-          - c1fde68c7bcc44588cbb6ddbc16d6480 # Account Settings Read (Account)
-          - 56907406c3d548ed902070ec4df0e328 # Account Rulesets Write (Account)
-          - fb6778dc191143babbfaa57993f1d275 # Zone WAF Edit (Zone)
-        resources:
-          com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94: "*"
-          com.cloudflare.api.account.*: "*"
+          - id: c8fed203ed3043cba015a93ad1616f1f # Zone Read (Zone)
+          - id: 4755a26eedb94da69e1066d98aa820be # Zone DNS Edit (Zone)
+          - id: 3030687196b94b638145a3953da2b699 # Zone Settings Edit (Zone)
+          - id: c1fde68c7bcc44588cbb6ddbc16d6480 # Account Settings Read (Account)
+          - id: 56907406c3d548ed902070ec4df0e328 # Account Rulesets Write (Account)
+          - id: fb6778dc191143babbfaa57993f1d275 # Zone WAF Edit (Zone)
+        resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*","com.cloudflare.api.account.*":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-terraform-provider
     namespace: crossplane-secrets

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.zone.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.zone.yaml
@@ -3,39 +3,25 @@
 # Description:
 #   These resources will add the chezmoi.sh zone and account to Cloudflare in
 #   order to use them lately with other Cloudflare resources.
-apiVersion: account.cloudflare.crossplane.io/v1alpha1
+apiVersion: account.upjet-cloudflare.upbound.io/v1alpha1
 kind: Account
 metadata:
   annotations:
-    crossplane.io/external-name: ENC[AES256_GCM,data:qUjnktsEH+WbCBAgxKe38Kc8fIeErQ84cYYparH2qKk=,iv:5YMKQccLOxKOasQSnkodNF6Iag0GKZwkPwpq8DJ0K78=,tag:6ANZ9VCBJ8hJolyOs3TEuQ==,type:str]
+    crossplane.io/external-name: 00736631322131f61ce95f2c235143da
   labels:
     cf.chezmoi.sh/account: main
   name: chezmoi-sh
 spec:
   managementPolicies:
     - Observe
-  forProvider: {}
-sops:
-  age:
-    - recipient: age1fj0yj3na3n5udfjmnxfwrlkp80tvj49w80wh699x33dh48clnvnshtjxe9
-      enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwTTZObVdlUy9QNUJDOUhD
-        WTAwaFg5S2MrcFRUTnlZQytrREZIaWVLajFrClNoSmZTOFlWTEo3dVltMDhqKzEw
-        NFEwdktQN3dpMllXWGY5Ykt3aXNZWVEKLS0tIEpJUUJna1htajZaeDhDV0ZKWnVy
-        TStGcUkrRWMycDRDSUowS3hOdWx2dG8KXWrx4Zf5vFV9ZY3WkzY+R/65n4Th0Pq0
-        zkN8aA6a+QPM5NRGyxXzaHRPQIB1cVecUXPWdoEJLpi4y4/YCnhVkQ==
-        -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2025-04-23T17:59:25Z"
-  mac: ENC[AES256_GCM,data:CpN4i20CRKwb9Phha1gOZuQ0cMNNLhGYZ153igX4qUzi296dmxpIlExbm6wzzu1hEhK3Z7Ah5rAbrqrqDWpuSDD2mmsRzbDvSt+z/41uX51Hh3Ai000kQmivZJjOcXLvGm2RteDT5SioQ5dW5dwKor0fmy2L7oDgKBdwvhU1duc=,iv:/qcacsTeSMqIqQ7wJw1a3JX0wmDvA7IV4jF6iWuqfd4=,tag:ABocpdxuxtZdlNyPYnZxAw==,type:str]
-  encrypted_regex: crossplane.io/external-name
-  version: 3.10.2
+  forProvider:
+    name: chezmoi.sh
 ---
-apiVersion: zone.cloudflare.crossplane.io/v1alpha1
+apiVersion: zone.upjet-cloudflare.upbound.io/v1alpha1
 kind: Zone
 metadata:
   annotations:
-    crossplane.io/external-name: ENC[AES256_GCM,data:0h8myJQnV71kQ5Rlm0kcRxunaB7DTQADCdcHEoAlvAA=,iv:tkJdjF9VPuVdVy4iVG4HKNfN1A/QtIVdKCMayzGam1Y=,tag:YqtkAHYM9Mf9UELCNF53CA==,type:str]
+    crossplane.io/external-name: 2734d7b22cf00222046320ed3187cb94
   labels:
     cf.chezmoi.sh/zone: chezmoi.sh
   name: chezmoi-sh
@@ -43,21 +29,6 @@ spec:
   managementPolicies:
     - Observe
   forProvider:
-    accountIdSelector:
-      matchLabels:
-        cf.chezmoi.sh/account: main
-sops:
-  age:
-    - recipient: age1fj0yj3na3n5udfjmnxfwrlkp80tvj49w80wh699x33dh48clnvnshtjxe9
-      enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwTTZObVdlUy9QNUJDOUhD
-        WTAwaFg5S2MrcFRUTnlZQytrREZIaWVLajFrClNoSmZTOFlWTEo3dVltMDhqKzEw
-        NFEwdktQN3dpMllXWGY5Ykt3aXNZWVEKLS0tIEpJUUJna1htajZaeDhDV0ZKWnVy
-        TStGcUkrRWMycDRDSUowS3hOdWx2dG8KXWrx4Zf5vFV9ZY3WkzY+R/65n4Th0Pq0
-        zkN8aA6a+QPM5NRGyxXzaHRPQIB1cVecUXPWdoEJLpi4y4/YCnhVkQ==
-        -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2025-04-23T17:59:25Z"
-  mac: ENC[AES256_GCM,data:CpN4i20CRKwb9Phha1gOZuQ0cMNNLhGYZ153igX4qUzi296dmxpIlExbm6wzzu1hEhK3Z7Ah5rAbrqrqDWpuSDD2mmsRzbDvSt+z/41uX51Hh3Ai000kQmivZJjOcXLvGm2RteDT5SioQ5dW5dwKor0fmy2L7oDgKBdwvhU1duc=,iv:/qcacsTeSMqIqQ7wJw1a3JX0wmDvA7IV4jF6iWuqfd4=,tag:ABocpdxuxtZdlNyPYnZxAw==,type:str]
-  encrypted_regex: crossplane.io/external-name
-  version: 3.10.2
+    name: chezmoi.sh
+    account:
+      id: 00736631322131f61ce95f2c235143da

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
   - providers/vault/provider.yaml
 
   # Cloudflare resources
+  - cloudflare.zone.yaml
   - cloudflare.iam.observability.yaml
   - cloudflare.iam.oci-registry.yaml
   - cloudflare.iam.omni.yaml
@@ -44,18 +45,3 @@ patches:
         value: "-1"
     target:
       group: apiextensions.crossplane.io
-
-generators:
-  - # Cloudflare resources need to provide the external-name annotation,
-    # which is encrypted.
-    |-
-    apiVersion: viaduct.ai/v1
-    kind: ksops
-    metadata:
-      name: crossplane-external-name
-      annotations:
-        config.kubernetes.io/function: |
-          exec:
-            path: ksops
-    files:
-      - cloudflare.zone.yaml


### PR DESCRIPTION
Migrates all Cloudflare Crossplane managed resources to the new `upjet-cloudflare.upbound.io` API schemas introduced by the wildbitca provider family. The `APIToken` kind is renamed to `Token`, permission groups now require an explicit `id` field, and Account/Zone resources accept inline `forProvider` fields rather than resolving via selectors. This resolves issue #1025 and requires the provider migration from PR #1040 to be applied first.

**Related Issue:** #1025

## Rationale

The wildbitca provider family changes the API group and resource schemas for all Cloudflare resources. The old `account.cloudflare.crossplane.io/v1alpha1` API group is no longer served once the new provider family is installed. All managed resources must be updated to the new schemas before they can reconcile against the wildbitca provider.

## Changes Made

### IAM tokens

- **[`cloudflare.iam.observability.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.observability.yaml)** — Migrates the caddy-dns01/observability token: `APIToken` → `Token`, apiVersion to `account.upjet-cloudflare.upbound.io/v1alpha1`, adds `accountId`, wraps permission group references with an `id` field, converts `resources` map to inline JSON string
- **[`cloudflare.iam.oci-registry.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.oci-registry.yaml)** — Same migration for the caddy-dns01/zot-registry token
- **[`cloudflare.iam.omni.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.omni.yaml)** — Same migration for the caddy-dns01/omni token
- **[`cloudflare.iam.terraform-provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.terraform-provider.yaml)** — Same migration for the terraform-provider token (6 permission groups)

### Account and Zone

- **[`cloudflare.zone.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.zone.yaml)** — Migrates Account and Zone resources to `account.upjet-cloudflare.upbound.io/v1alpha1` and `zone.upjet-cloudflare.upbound.io/v1alpha1`. Account ID and zone ID are now set as plaintext `crossplane.io/external-name` annotations and as inline `forProvider` fields; removes the SOPS-encrypted external-name and the `accountIdSelector` cross-resource reference.
- **[`kustomization.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/kustomization.yaml)** — Adds `cloudflare.zone.yaml` to the resources list (was previously missing, the resource was only provided through the ksops generator); removes the ksops generator block now that `cloudflare.zone.yaml` contains no encrypted values.

## Technical Impact

### Architecture Simplification

| Before | After |
|---|---|
| `account.cloudflare.crossplane.io/v1alpha1` | `account.upjet-cloudflare.upbound.io/v1alpha1` |
| Kind `APIToken` | Kind `Token` |
| Permission groups as bare strings | Permission groups with explicit `id:` field |
| `resources` as YAML map | `resources` as inline JSON string |
| SOPS-encrypted `crossplane.io/external-name` for Account/Zone | Plaintext IDs in annotation and `forProvider` |
| `accountIdSelector` cross-resource label selector | Inline `account.id` field |
| ksops generator decrypting `cloudflare.zone.yaml` | Removed (no encrypted values remain) |

### Security Boundary Preservation

Connection secrets remain written to the `crossplane-secrets` namespace via `writeConnectionSecretToRef`. The Cloudflare account ID and zone ID are no longer SOPS-encrypted: these identifiers appear in Cloudflare dashboard URLs and API responses and are not treated as secrets. The new provider schema does not use encrypted external-name annotations for these IDs.

### Behavioural Changes

Existing `APIToken` managed resources will stop reconciling once the old provider is replaced. ArgoCD will create the new `Token` resources; old `APIToken` objects must be deleted manually or will be garbage-collected when the old provider CRDs are removed. Connection secrets will be regenerated on the first reconcile of each new `Token` resource.

### Migration Path

1. Merge and apply PR #1040 (wildbitca provider family) first
2. Apply this PR — ArgoCD creates the new `Token` resources
3. Manually delete old `APIToken` objects from the cluster (or let them be removed with the old provider CRDs)
4. Verify connection secrets in `crossplane-secrets` are regenerated

## Testing Validation

- [ ] All four `Token` managed resources show `Ready: True` condition
- [ ] Account and Zone resources reconcile in `Observe` mode without errors
- [ ] Connection secrets regenerated in `crossplane-secrets` namespace
- [ ] cert-manager DNS-01 tokens remain accessible (caddy observability, oci-registry, omni)

## Related Issues

Closes #1025

<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
