### PR TITLE
Upgrade Crossplane to v2.3.2 stable and align all providers

### DIFF
--- a/projects/amiya.akn/dist/apps/crossplane/apps.v1.Deployment.crossplane-rbac-manager.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/apps.v1.Deployment.crossplane-rbac-manager.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: crossplane
   name: crossplane-rbac-manager
   namespace: crossplane
@@ -33,8 +33,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-        helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: crossplane
     spec:
       containers:
@@ -57,7 +57,7 @@ spec:
               resource: limits.memory
         - name: LEADER_ELECTION
           value: "true"
-        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v1.20.0-rc.0.140.g629ca2e2f
+        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v2.3.2
         imagePullPolicy: IfNotPresent
         name: crossplane
         resources:
@@ -93,7 +93,7 @@ spec:
               containerName: crossplane-init
               divisor: "1"
               resource: limits.memory
-        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v1.20.0-rc.0.140.g629ca2e2f
+        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v2.3.2
         imagePullPolicy: IfNotPresent
         name: crossplane-init
         resources:

--- a/projects/amiya.akn/dist/apps/crossplane/apps.v1.Deployment.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/apps.v1.Deployment.crossplane.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: crossplane
   name: crossplane
   namespace: crossplane
@@ -33,8 +33,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-        helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: crossplane
     spec:
       containers:
@@ -72,7 +72,7 @@ spec:
           value: crossplane-tls-client
         - name: TLS_CLIENT_CERTS_DIR
           value: /tls/client
-        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v1.20.0-rc.0.140.g629ca2e2f
+        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v2.3.2
         imagePullPolicy: IfNotPresent
         name: crossplane
         ports:
@@ -115,6 +115,8 @@ spec:
       - args:
         - core
         - init
+        - --activation
+        - '*'
         env:
         - name: GOMAXPROCS
           valueFrom:
@@ -150,7 +152,7 @@ spec:
           value: crossplane-tls-server
         - name: TLS_CLIENT_SECRET_NAME
           value: crossplane-tls-client
-        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v1.20.0-rc.0.140.g629ca2e2f
+        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v2.3.2
         imagePullPolicy: IfNotPresent
         name: crossplane-init
         resources:

--- a/projects/amiya.akn/dist/apps/crossplane/core.v1.Service.crossplane-webhooks.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/core.v1.Service.crossplane-webhooks.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: crossplane
   name: crossplane-webhooks
   namespace: crossplane

--- a/projects/amiya.akn/dist/apps/crossplane/core.v1.ServiceAccount.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/core.v1.ServiceAccount.crossplane.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   labels:
@@ -9,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
   namespace: crossplane

--- a/projects/amiya.akn/dist/apps/crossplane/core.v1.ServiceAccount.rbac-manager.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/core.v1.ServiceAccount.rbac-manager.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   labels:
@@ -9,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: rbac-manager
   namespace: crossplane

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-admin.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-admin.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-admin.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-admin.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-admin: "true"
   name: crossplane:aggregate-to-admin
 rules:
@@ -71,3 +71,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - protection.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ops.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-browse.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-browse.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-browse: "true"
   name: crossplane:aggregate-to-browse
 rules:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-edit.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-edit.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-edit: "true"
   name: crossplane:aggregate-to-edit
 rules:
@@ -50,6 +50,18 @@ rules:
   - '*'
 - apiGroups:
   - secrets.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - protection.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ops.crossplane.io
   resources:
   - '*'
   verbs:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-view.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-view.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-view: "true"
   name: crossplane:aggregate-to-view
 rules:
@@ -48,6 +48,22 @@ rules:
   - watch
 - apiGroups:
   - secrets.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - protection.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ops.crossplane.io
   resources:
   - '*'
   verbs:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-allowed-provider-permissions.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-allowed-provider-permissions.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane:allowed-provider-permissions

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-browse.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-browse.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-browse

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-edit.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-edit.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-edit

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-rbac-manager.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-rbac-manager.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 rules:
 - apiGroups:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-system-aggregate-to-crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-system-aggregate-to-crossplane.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-crossplane: "true"
   name: crossplane:system:aggregate-to-crossplane
 rules:
@@ -52,8 +52,9 @@ rules:
   - '*'
 - apiGroups:
   - apiextensions.crossplane.io
+  - ops.crossplane.io
   - pkg.crossplane.io
-  - secrets.crossplane.io
+  - protection.crossplane.io
   resources:
   - '*'
   verbs:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-view.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-view.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-view

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane-admin.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane-admin.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane-rbac-manager.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane-rbac-manager.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/projects/amiya.akn/src/apps/crossplane/kustomization.yaml
+++ b/projects/amiya.akn/src/apps/crossplane/kustomization.yaml
@@ -17,9 +17,9 @@ resources:
   - crossplane.applicationset.yaml
 
 helmCharts:
-  - repo: https://charts.crossplane.io/master/
+  - repo: https://charts.crossplane.io/stable
     name: crossplane
-    version: 1.20.0-rc.0.140.g629ca2e2f
+    version: 2.3.2
 
     releaseName: crossplane
     namespace: crossplane

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/functions.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/functions.yaml
@@ -4,7 +4,7 @@ kind: Function
 metadata:
   name: function-go-templating
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.6.0
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.12.1
   runtimeConfigRef:
     name: hardened
 ---
@@ -13,7 +13,7 @@ kind: Function
 metadata:
   name: function-auto-ready
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.3.0
+  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.6.5
   runtimeConfigRef:
     name: hardened
 ---
@@ -22,6 +22,6 @@ kind: Function
 metadata:
   name: function-extra-resources
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.1.0
+  package: xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.3.0
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/provider.yaml
@@ -4,7 +4,7 @@ kind: Provider
 metadata:
   name: upbound-provider-family-aws
 spec:
-  package: xpkg.upbound.io/upbound/provider-family-aws:v1.16.0
+  package: xpkg.upbound.io/upbound/provider-family-aws:v2.6.0
   runtimeConfigRef:
     name: hardened
 ---
@@ -13,7 +13,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v1.14.0
+  package: xpkg.upbound.io/upbound/provider-aws-iam:v2.6.0
   runtimeConfigRef:
     name: hardened
 ---
@@ -22,6 +22,6 @@ kind: Provider
 metadata:
   name: provider-aws-ses
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-ses:v1.14.0
+  package: xpkg.upbound.io/upbound/provider-aws-ses:v2.6.0
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/provider.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: provider-terraform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.0.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.1.1
   runtimeConfigRef:
     name: hardened-for-terraform

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/provider.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: upbound-provider-vault
 spec:
-  package: xpkg.upbound.io/upbound/provider-vault:v2.2.2
+  package: xpkg.upbound.io/upbound/provider-vault:v3.0.7
   runtimeConfigRef:
     name: hardened


### PR DESCRIPTION
Upgrades Crossplane from a pre-release master-channel build (`1.20.0-rc.0.140.g629ca2e2f`) to the current stable release v2.3.2, and aligns all providers and functions to versions that target Crossplane v2. This is a prerequisite for the Cloudflare provider migration (PR #1040) which uses `wildbitca/provider-family-cloudflare:v0.2.6` — a package that explicitly requires Crossplane 2.0+.

**Related Issue:** #1025 (Phase 0 — control plane prerequisite)

## Rationale

The install was pinned to an unstable SHA build from `charts.crossplane.io/master/`. Crossplane v2.0 shipped in 2025 and the v1.x line is now in maintenance mode (security backports only). All Upbound-managed providers (AWS, Vault) have published v2-aligned major releases that require Crossplane v2 to function correctly. The wildbitca Cloudflare provider, which resolves issue #1025, hard-requires Crossplane 2.0+.

## Changes Made

### Crossplane control plane

- **[`projects/amiya.akn/src/apps/crossplane/kustomization.yaml`](projects/amiya.akn/src/apps/crossplane/kustomization.yaml)** — Switches Helm repo from `charts.crossplane.io/master/` to `charts.crossplane.io/stable` and pins version to `2.3.2`

### AWS providers

- **[`providers/aws/provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/provider.yaml)** — Bumps `provider-family-aws`, `provider-aws-iam`, and `provider-aws-ses` from v1.14–v1.16 to **v2.6.0** (Upbound v2 provider line targets Crossplane v2)

### Vault provider

- **[`providers/vault/provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/provider.yaml)** — Bumps `provider-vault` from v2.2.2 to **v3.0.7**

### Terraform provider

- **[`providers/terraform/provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/provider.yaml)** — Bumps `provider-terraform` from v1.0.0 to **v1.1.1**

### Functions

- **[`functions.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/functions.yaml)** — Bumps `function-go-templating` v0.6.0 → **v0.12.1**, `function-auto-ready` v0.3.0 → **v0.6.5** (both include security fixes released May 2026), and `function-extra-resources` v0.1.0 → **v0.3.0**

## Technical Impact

### Architecture Simplification

| Component | Before | After |
|---|---|---|
| Crossplane | `1.20.0-rc.0.140.g629ca2e2f` (pre-release, master channel) | `2.3.2` (stable channel) |
| Helm repo | `charts.crossplane.io/master/` | `charts.crossplane.io/stable` |
| provider-family-aws | v1.16.0 | v2.6.0 |
| provider-aws-iam / ses | v1.14.0 | v2.6.0 |
| provider-vault | v2.2.2 | v3.0.7 |
| provider-terraform | v1.0.0 | v1.1.1 |
| function-go-templating | v0.6.0 | v0.12.1 |
| function-auto-ready | v0.3.0 | v0.6.5 |
| function-extra-resources | v0.1.0 | v0.3.0 |

### Security Boundary Preservation

`DeploymentRuntimeConfig` resources (`hardened`, `hardened-for-terraform`) are unchanged — this is the correct mechanism in v2 (`ControllerConfig` was fully removed in v2.0, but this repo was already using `DeploymentRuntimeConfig`). Helm values for pod security contexts (`podSecurityContextCrossplane`, `securityContextCrossplane`, `podSecurityContextRBACManager`, `securityContextRBACManager`) are structurally unchanged in v2.

### Behavioural Changes

Crossplane v2 creates a default `ManagedResourceActivationPolicy` (MRAP) activating all managed resources cluster-wide. Existing managed resources continue to reconcile without intervention. The ArgoCD health check Lua script references `CompositionRevision` and `ControllerConfig` in its `has_no_status` list — these kinds no longer exist in v2 but the entries are harmless (they will simply never match). Cleanup can happen in a follow-up.

### Migration Path

1. **Before syncing**: ensure the OCI mirror at `oci.chezmoi.sh` serves the `crossplane/crossplane:v2.3.2` image (the `images` transformer in the kustomization redirects to this mirror)
2. **Merge this PR first**, then PR #1040 (Cloudflare provider → wildbitca), then PR #1041 (Cloudflare resource schema migration)
3. ArgoCD will perform an in-place Helm upgrade; existing managed resources remain active during the upgrade
4. Monitor provider pod restarts — providers will re-install their CRDs on first boot

## Testing Validation

- [ ] Crossplane pods (`crossplane`, `crossplane-rbac-manager`) reach `Running` status after Helm upgrade
- [ ] All provider packages show `Healthy: True` and `Installed: True` conditions
- [ ] All function packages show `Healthy: True` and `Installed: True` conditions
- [ ] Existing managed resources (AWS IAM, SES, Tailscale OAuth, Vault) remain `Ready: True`
- [ ] ArgoCD reports the `crossplane-chezmoi.sh` application as `Synced` and `Healthy`

## Related Issues

Addresses #1025 (Phase 0 — Crossplane control plane prerequisite)

<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
