### PR TITLE
Fix kube API proxy backend scheme to HTTPS on Omni

### DIFF
--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/configuration.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/configuration.nix
@@ -132,7 +132,9 @@
     machineApiBindAddr = "127.0.0.1:9090";
 
     # Kubernetes proxy on loopback — Caddy terminates TLS externally on
-    # kube.omni.chezmoi.sh:443 and proxies here. Plain HTTP on the backend.
+    # kube.omni.chezmoi.sh:443 and proxies here. The backend also serves
+    # TLS (Omni inherits the main API cert/key for the k8s proxy listener),
+    # so Caddy uses tls_insecure_skip_verify just like the UI/API vhost.
     k8sProxyBindAddr = "127.0.0.1:8100";
 
     # Advertised URLs — must match the Caddy subdomains in modules/caddy.nix.

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/flake.nix
@@ -46,7 +46,7 @@
       # version itself is tracked in catalog/nix/siderolabs/omni/omni.nix
       # and bumped by Renovate. Bump this date before every `mise run
       # lxc:build`; append -N for multiple builds on the same day.
-      version = "2026.06.14-2";
+      version = "2026.06.16";
 
       # -----------------------------------------------------------------------
       # Build-time secrets, forwarded to the modules via _module.args.

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/modules/caddy.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/modules/caddy.nix
@@ -13,7 +13,7 @@
 #
 #   api.omni.chezmoi.sh    — SideroLink Machine API (gRPC, loopback HTTPS :9090)
 #
-#   kube.omni.chezmoi.sh   — Kubernetes API proxy  (HTTP, loopback :8100)
+#   kube.omni.chezmoi.sh   — Kubernetes API proxy  (HTTPS, loopback :8100)
 #
 # No non-standard TCP ports are opened externally. The event sink (:8091)
 # and SideroLink WireGuard (:50180/UDP) keep their direct bindings.
@@ -106,10 +106,14 @@ in
 
       # ─── kube.omni.chezmoi.sh — Kubernetes API proxy ───────────────────
       # omnictl / kubectl connects here to reach managed cluster APIs.
-      # Omni's k8s proxy binds on loopback (k8sProxyBindAddr) over plain
-      # HTTP; Caddy provides the external TLS layer.
+      # Omni's k8s proxy binds on loopback (k8sProxyBindAddr) with its own
+      # PKI TLS cert (inherited from the main API cert/key); Caddy proxies
+      # with tls_insecure_skip_verify, matching the UI/API and Machine API.
       https://kube.${domain} {
-        reverse_proxy http://${cfg.k8sProxyBindAddr} {
+        reverse_proxy https://${cfg.k8sProxyBindAddr} {
+          transport http {
+            tls_insecure_skip_verify
+          }
           flush_interval -1
         }
 


### PR DESCRIPTION
## Summary

The `kube.omni.chezmoi.sh` Caddy vhost was reverse-proxying to Omni's Kubernetes API proxy over plain HTTP, but the backend listener serves TLS (it inherits the main API cert/key). Every request returned a `400 Client sent an HTTP request to an HTTPS server.` error, breaking `kubectl` access through the Omni-generated kubeconfig.

**Related Issue:** #1043

## Root Cause

Omni's Kubernetes proxy listener (`k8sProxyBindAddr = "127.0.0.1:8100"`) has no dedicated `--k8s-proxy-cert`/`--k8s-proxy-key` CLI flag. Omni's `PopulateFallbacks()` makes it inherit the main API cert/key, so it serves TLS, not plain HTTP.

The `kube.${domain}` Caddy vhost was written assuming a plain-HTTP backend (matching Sidero's official nginx guide), but that guide's Omni instance never passes `--cert`/`--key` — a different setup that happens to leave the proxy insecure by omission.

Confirmation:

```text
$ curl https://kube.omni.chezmoi.sh -Lvvv
< TLS handshake with Caddy succeeds (valid cert, ALPN h2) >
> HTTP/2 400
> via: 1.0 Caddy
Client sent an HTTP request to an HTTPS server.
```

The existing UI/API and Machine API vhosts already solve this with `reverse_proxy https://... { transport http { tls_insecure_skip_verify } }` — the Kubernetes proxy vhost was the only one not following that pattern.

## Fix

### Caddy module (Omni LXC)

- **[`projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/modules/caddy.nix`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/modules/caddy.nix)** — Changed the `kube.${domain}` vhost `reverse_proxy` from `http://` to `https://` with `transport http { tls_insecure_skip_verify }`, matching the UI/API and Machine API vhosts
- **[`projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/configuration.nix`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/configuration.nix)** — Updated the comment on `k8sProxyBindAddr` to reflect that the backend serves TLS

## Technical Impact

### Behavioural Changes

`kubectl` commands through the Omni-generated kubeconfig (`server: https://kube.omni.chezmoi.sh/`) now succeed instead of returning HTTP 400. No client-side changes required — Caddy's publicly-trusted cert covers the external TLS termination.

### Regression Risk

**Low** — the change only affects the `kube.${domain}` vhost's upstream scheme. The UI/API and Machine API vhosts already use the same `https://` + `tls_insecure_skip_verify` pattern, so this brings the third vhost in line with the established, working configuration.

### Observability

- `curl -v https://kube.omni.chezmoi.sh/` returns a normal Kubernetes API response (auth challenge or cluster info), not the Go plaintext error
- `kubectl get nodes` through the Omni kubeconfig succeeds with no `--insecure-skip-tls-verify`
- Caddy access logs for `kube.omni.chezmoi.sh` show `200`/`401` instead of `400`

## Testing Validation

- [ ] `curl -v https://kube.omni.chezmoi.sh/` returns a normal response, not `400 Client sent an HTTP request to an HTTPS server.`
- [ ] `kubectl get nodes` against the Omni-generated kubeconfig works through `https://kube.omni.chezmoi.sh/`
- [ ] No regressions on the UI/API (`omni.chezmoi.sh`) or Machine API vhosts

## Related Issues

Closes #1043

---

<sub>AI-assisted with Z.ai:GLM-5.1 under human supervision</sub>
