### PR TITLE
Revert Crossplane v2.3.2 upgrade — breaks OpenBao integration

### DIFF
--- a/projects/amiya.akn/dist/apps/crossplane/apps.v1.Deployment.crossplane-rbac-manager.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/apps.v1.Deployment.crossplane-rbac-manager.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
     release: crossplane
   name: crossplane-rbac-manager
   namespace: crossplane
@@ -33,8 +33,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.3.2
-        helm.sh/chart: crossplane-2.3.2
+        app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+        helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
         release: crossplane
     spec:
       containers:
@@ -57,7 +57,7 @@ spec:
               resource: limits.memory
         - name: LEADER_ELECTION
           value: "true"
-        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v2.3.2
+        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v1.20.0-rc.0.140.g629ca2e2f
         imagePullPolicy: IfNotPresent
         name: crossplane
         resources:
@@ -93,7 +93,7 @@ spec:
               containerName: crossplane-init
               divisor: "1"
               resource: limits.memory
-        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v2.3.2
+        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v1.20.0-rc.0.140.g629ca2e2f
         imagePullPolicy: IfNotPresent
         name: crossplane-init
         resources:

--- a/projects/amiya.akn/dist/apps/crossplane/apps.v1.Deployment.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/apps.v1.Deployment.crossplane.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
     release: crossplane
   name: crossplane
   namespace: crossplane
@@ -33,8 +33,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 2.3.2
-        helm.sh/chart: crossplane-2.3.2
+        app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+        helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
         release: crossplane
     spec:
       containers:
@@ -72,7 +72,7 @@ spec:
           value: crossplane-tls-client
         - name: TLS_CLIENT_CERTS_DIR
           value: /tls/client
-        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v2.3.2
+        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v1.20.0-rc.0.140.g629ca2e2f
         imagePullPolicy: IfNotPresent
         name: crossplane
         ports:
@@ -115,8 +115,6 @@ spec:
       - args:
         - core
         - init
-        - --activation
-        - '*'
         env:
         - name: GOMAXPROCS
           valueFrom:
@@ -152,7 +150,7 @@ spec:
           value: crossplane-tls-server
         - name: TLS_CLIENT_SECRET_NAME
           value: crossplane-tls-client
-        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v2.3.2
+        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v1.20.0-rc.0.140.g629ca2e2f
         imagePullPolicy: IfNotPresent
         name: crossplane-init
         resources:

--- a/projects/amiya.akn/dist/apps/crossplane/core.v1.Service.crossplane-webhooks.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/core.v1.Service.crossplane-webhooks.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
     release: crossplane
   name: crossplane-webhooks
   namespace: crossplane

--- a/projects/amiya.akn/dist/apps/crossplane/core.v1.ServiceAccount.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/core.v1.ServiceAccount.crossplane.yaml
@@ -1,6 +1,5 @@
 ---
 apiVersion: v1
-automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   labels:
@@ -10,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
   name: crossplane
   namespace: crossplane

--- a/projects/amiya.akn/dist/apps/crossplane/core.v1.ServiceAccount.rbac-manager.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/core.v1.ServiceAccount.rbac-manager.yaml
@@ -1,6 +1,5 @@
 ---
 apiVersion: v1
-automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   labels:
@@ -10,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
   name: rbac-manager
   namespace: crossplane

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-admin.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-admin.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
   name: crossplane-admin

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-admin.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-admin.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
     rbac.crossplane.io/aggregate-to-admin: "true"
   name: crossplane:aggregate-to-admin
 rules:
@@ -71,15 +71,3 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - protection.crossplane.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - ops.crossplane.io
-  resources:
-  - '*'
-  verbs:
-  - '*'

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-browse.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-browse.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
     rbac.crossplane.io/aggregate-to-browse: "true"
   name: crossplane:aggregate-to-browse
 rules:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-edit.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-edit.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
     rbac.crossplane.io/aggregate-to-edit: "true"
   name: crossplane:aggregate-to-edit
 rules:
@@ -50,18 +50,6 @@ rules:
   - '*'
 - apiGroups:
   - secrets.crossplane.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - protection.crossplane.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - ops.crossplane.io
   resources:
   - '*'
   verbs:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-view.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-view.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
     rbac.crossplane.io/aggregate-to-view: "true"
   name: crossplane:aggregate-to-view
 rules:
@@ -48,22 +48,6 @@ rules:
   - watch
 - apiGroups:
   - secrets.crossplane.io
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - protection.crossplane.io
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ops.crossplane.io
   resources:
   - '*'
   verbs:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-allowed-provider-permissions.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-allowed-provider-permissions.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
   name: crossplane:allowed-provider-permissions

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-browse.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-browse.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
   name: crossplane-browse

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-edit.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-edit.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
   name: crossplane-edit

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-rbac-manager.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-rbac-manager.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
   name: crossplane-rbac-manager
 rules:
 - apiGroups:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-system-aggregate-to-crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-system-aggregate-to-crossplane.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-2.3.2
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
     rbac.crossplane.io/aggregate-to-crossplane: "true"
   name: crossplane:system:aggregate-to-crossplane
 rules:
@@ -52,9 +52,8 @@ rules:
   - '*'
 - apiGroups:
   - apiextensions.crossplane.io
-  - ops.crossplane.io
   - pkg.crossplane.io
-  - protection.crossplane.io
+  - secrets.crossplane.io
   resources:
   - '*'
   verbs:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-view.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-view.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
   name: crossplane-view

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
   name: crossplane

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane-admin.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane-admin.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane-rbac-manager.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane-rbac-manager.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 2.3.2
-    helm.sh/chart: crossplane-2.3.2
+    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/projects/amiya.akn/src/apps/crossplane/kustomization.yaml
+++ b/projects/amiya.akn/src/apps/crossplane/kustomization.yaml
@@ -17,9 +17,9 @@ resources:
   - crossplane.applicationset.yaml
 
 helmCharts:
-  - repo: https://charts.crossplane.io/stable
+  - repo: https://charts.crossplane.io/master/
     name: crossplane
-    version: 2.3.2
+    version: 1.20.0-rc.0.140.g629ca2e2f
 
     releaseName: crossplane
     namespace: crossplane

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/functions.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/functions.yaml
@@ -4,7 +4,7 @@ kind: Function
 metadata:
   name: function-go-templating
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.12.1
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.6.0
   runtimeConfigRef:
     name: hardened
 ---
@@ -13,7 +13,7 @@ kind: Function
 metadata:
   name: function-auto-ready
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.6.5
+  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.3.0
   runtimeConfigRef:
     name: hardened
 ---
@@ -22,6 +22,6 @@ kind: Function
 metadata:
   name: function-extra-resources
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.3.0
+  package: xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.1.0
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/provider.yaml
@@ -4,7 +4,7 @@ kind: Provider
 metadata:
   name: upbound-provider-family-aws
 spec:
-  package: xpkg.upbound.io/upbound/provider-family-aws:v2.6.0
+  package: xpkg.upbound.io/upbound/provider-family-aws:v1.16.0
   runtimeConfigRef:
     name: hardened
 ---
@@ -13,7 +13,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v2.6.0
+  package: xpkg.upbound.io/upbound/provider-aws-iam:v1.14.0
   runtimeConfigRef:
     name: hardened
 ---
@@ -22,6 +22,6 @@ kind: Provider
 metadata:
   name: provider-aws-ses
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-ses:v2.6.0
+  package: xpkg.upbound.io/upbound/provider-aws-ses:v1.14.0
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/provider.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: provider-terraform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.1.1
+  package: xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.0.0
   runtimeConfigRef:
     name: hardened-for-terraform

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/provider.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: upbound-provider-vault
 spec:
-  package: xpkg.upbound.io/upbound/provider-vault:v3.0.7
+  package: xpkg.upbound.io/upbound/provider-vault:v2.2.2
   runtimeConfigRef:
     name: hardened


### PR DESCRIPTION
## Summary

PR #1042 upgraded Crossplane to v2.3.2 stable and aligned all providers to the
v2-targeting line, including `provider-vault` v2.2.2 → v3.0.7. After this
landed on `main`, the live OpenBao integration broke. `provider-vault` v3.0.7
targets Crossplane's v2 managed-resource model and is not compatible with the
OpenBao deployment running in this cluster. This PR reverts #1042 in full to
restore a working Vault integration while the incompatibility is investigated.

## Root Cause

`provider-vault` v3.0.7 is built against the Crossplane v2 API surface
(managed-resource activation policies, v2 runtime config wiring). The
production OpenBao integration relies on behavior/CRDs from the v2.2.2 line
that are not preserved across that major bump. The break was reported
directly by the maintainer immediately after the upgrade synced — Vault
resources stopped reconciling against OpenBao. No targeted compatibility
testing was done against this specific OpenBao deployment before merging
#1042, only generic "Ready: True" checks across providers.

## Fix

### Crossplane control plane

- **[`projects/amiya.akn/src/apps/crossplane/kustomization.yaml`](projects/amiya.akn/src/apps/crossplane/kustomization.yaml)** — Reverts Helm repo from `charts.crossplane.io/stable` back to `charts.crossplane.io/master/` pinned at `1.20.0-rc.0.140.g629ca2e2f`
- **[`projects/amiya.akn/dist/apps/crossplane/`](projects/amiya.akn/dist/apps/crossplane/)** — Regenerated rendered manifests matching the prior Crossplane build

### Providers and functions

- **[`projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/provider.yaml)** — `provider-vault` v3.0.7 → v2.2.2 (restores OpenBao compatibility)
- **[`projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/provider.yaml)** — `provider-family-aws` / `provider-aws-iam` / `provider-aws-ses` v2.6.0 → v1.x
- **[`projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/provider.yaml)** — `provider-terraform` v1.1.1 → v1.0.0
- **[`projects/chezmoi.sh/src/infrastructure/crossplane/functions.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/functions.yaml)** — `function-go-templating`, `function-auto-ready`, `function-extra-resources` reverted to their pre-#1042 versions

## Technical Impact

### Behavioural Changes

Crossplane control plane goes back to the pre-release master-channel build
and all providers/functions return to the versions running before #1042.
Existing managed resources (AWS IAM, SES, Tailscale OAuth, Vault) continue to
reconcile under the prior provider versions — this restores the
last known-good state for the OpenBao integration.

### Regression Risk

Low. This is a straight revert of a merge commit (`git revert -m 1`) back to
the state that was already running in production before #1042, with no new
code paths introduced. The only residual risk is the OCI mirror at
`oci.chezmoi.sh` needing to still serve the pre-release Crossplane image —
this was the running version until #1042 merged, so it should already be
cached.

### Observability

- `crossplane` and `crossplane-rbac-manager` pods reach `Running` on the
  prior image
- `provider-vault` package reports `Healthy: True` / `Installed: True` at
  v2.2.2
- OpenBao-backed managed resources (Vault `Secret`/`Mount`/etc.) report
  `Ready: True` again
- ArgoCD reports the `crossplane-chezmoi.sh` application as `Synced` and
  `Healthy`

## Testing Validation

- [ ] Crossplane pods reach `Running` status after the Helm downgrade
- [ ] `provider-vault` package shows `Healthy: True` and `Installed: True` at v2.2.2
- [ ] Vault-managed resources reconcile against OpenBao without errors
- [ ] ArgoCD reports the `crossplane-chezmoi.sh` application as `Synced` and `Healthy`

## Related Issues

Addresses the regression introduced by #1042 (Crossplane v2.3.2 / provider-vault v3.0.7 upgrade)

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
