### PR TITLE
Allow Crossplane to reach OpenBao over the cluster network

### DIFF
--- a/projects/amiya.akn/src/apps/vault/security/kustomization.yaml
+++ b/projects/amiya.akn/src/apps/vault/security/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - network-policy.default-hardened.yaml
   - network-policy.allow-openbao-from-cilium-gateway.yaml
+  - network-policy.allow-openbao-from-crossplane.yaml
   - network-policy.allow-openbao-to-kubernetes-api.yaml
   - network-policy.allow-openbao-to-lungmen-api.yaml
   - network-policy.allow-openbao-to-pocket-id.yaml

--- a/projects/amiya.akn/src/apps/vault/security/network-policy.allow-openbao-from-crossplane.yaml
+++ b/projects/amiya.akn/src/apps/vault/security/network-policy.allow-openbao-from-crossplane.yaml
@@ -1,0 +1,23 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows Crossplane (running in the crossplane namespace) to reach OpenBao directly
+      over the cluster-internal service. The Vault provider authenticates via the
+      Kubernetes auth backend (role crossplane-provisioning) to manage mounts, policies
+      and auth backends declaratively.
+  name: allow-openbao-from-crossplane
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vault
+      component: server
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: crossplane
+      toPorts:
+        - ports:
+            - port: "8200"
+              protocol: TCP


### PR DESCRIPTION
## Summary

Crossplane's Vault provider (`projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/default.providerconfig.yaml`) already targets OpenBao at `openbao.vault.svc.cluster.local:8200` and authenticates via the `crossplane-provisioning` Kubernetes auth role, but the `vault` namespace's hardened CiliumNetworkPolicy only allowed ingress from the Cilium Gateway and from pods in the same namespace. Calls from the `crossplane` namespace were silently dropped at the network layer, so Crossplane could never reach OpenBao to manage mounts, policies, and auth backends declaratively — including the existing Pocket-Id OIDC `AuthBackend`/`AuthBackendRole` resources in `projects/amiya.akn/src/infrastructure/crossplane/vault/pocket-id.authbackend.yaml`, which were defined but unreachable.

## Changes Made

### Vault namespace network policy

- **[`network-policy.allow-openbao-from-crossplane.yaml`](projects/amiya.akn/src/apps/vault/security/network-policy.allow-openbao-from-crossplane.yaml)** — New CiliumNetworkPolicy allowing ingress from the `crossplane` namespace to the OpenBao server pods on port 8200.
- **[`kustomization.yaml`](projects/amiya.akn/src/apps/vault/security/kustomization.yaml)** — Registers the new policy alongside the existing OpenBao network policies.

## Technical Impact

### Security Implementation

Ingress is scoped to the `crossplane` namespace only, on port 8200 (OpenBao's API/UI port), matching the selector style (`app.kubernetes.io/name: vault`, `component: server`) used by the other OpenBao network policies in this directory. Crossplane still must authenticate via the existing Kubernetes auth backend (role `crossplane-provisioning`, least-privilege policy) — this change only unblocks the network path, it does not grant any new OpenBao permissions.

### Integration Points

Unblocks the Vault provider already configured in `projects/chezmoi.sh`, and the OpenBao mounts/policies/auth-backend resources already declared under `projects/amiya.akn/src/infrastructure/crossplane/vault/` (including the Pocket-Id OIDC auth backend), which depended on this connectivity to ever reconcile.

## Testing Validation

- [ ] `kustomize build projects/amiya.akn/src/apps/vault/security` renders without error (verified locally)
- [ ] Crossplane `ProviderConfig` for Vault reports `Healthy`/ready status after sync
- [ ] `AuthBackend`/`AuthBackendRole` resources for Pocket-Id reconcile successfully (no longer stuck pending)
- [ ] No unintended ingress allowed to OpenBao from outside the `crossplane` namespace (spot-check with `cilium policy get` or `hubble observe`)

---
<sub>AI-assisted with claude-code:claude-sonnet-4.6 under human supervision</sub>
