### PR TITLE
Fix OpenBao OIDC NetworkPolicy dropped by Cilium Gateway

### DIFF
--- a/projects/amiya.akn/dist/apps/vault/cilium.io.v2.CiliumNetworkPolicy.allow-openbao-to-pocket-id.yaml
+++ b/projects/amiya.akn/dist/apps/vault/cilium.io.v2.CiliumNetworkPolicy.allow-openbao-to-pocket-id.yaml
@@ -4,23 +4,22 @@ kind: CiliumNetworkPolicy
 metadata:
   annotations:
     policy.networking.k8s.io/description: |
-      Allows OpenBao to reach Pocket-ID OIDC endpoints for user authentication.
-      OpenBao uses Pocket-ID as its OIDC provider (oidcDiscoveryUrl: https://auth.chezmoi.sh)
-      for both UI login and CLI authentication flows.
+      Allows OpenBao to reach Pocket-ID OIDC endpoints via the in-cluster Cilium Gateway.
+      auth.chezmoi.sh resolves to the Gateway's cluster IP, so we must use toEndpoints
+      (not toFQDNs, which only matches IPs outside the cluster).
   labels:
     app.kubernetes.io/name: vault
   name: allow-openbao-to-pocket-id
   namespace: vault
 spec:
   egress:
-  - toFQDNs:
-    - matchName: auth.chezmoi.sh
+  - toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: in-gateway-system
     toPorts:
     - ports:
       - port: "443"
         protocol: TCP
-      serverNames:
-      - auth.chezmoi.sh
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: vault

--- a/projects/amiya.akn/src/apps/vault/security/network-policy.allow-openbao-to-pocket-id.yaml
+++ b/projects/amiya.akn/src/apps/vault/security/network-policy.allow-openbao-to-pocket-id.yaml
@@ -3,9 +3,9 @@ kind: CiliumNetworkPolicy
 metadata:
   annotations:
     policy.networking.k8s.io/description: |
-      Allows OpenBao to reach Pocket-ID OIDC endpoints for user authentication.
-      OpenBao uses Pocket-ID as its OIDC provider (oidcDiscoveryUrl: https://auth.chezmoi.sh)
-      for both UI login and CLI authentication flows.
+      Allows OpenBao to reach Pocket-ID OIDC endpoints via the in-cluster Cilium Gateway.
+      auth.chezmoi.sh resolves to the Gateway's cluster IP, so we must use toEndpoints
+      (not toFQDNs, which only matches IPs outside the cluster).
   name: allow-openbao-to-pocket-id
 spec:
   endpointSelector:
@@ -13,11 +13,10 @@ spec:
       app.kubernetes.io/name: vault
       component: server
   egress:
-    - toFQDNs:
-        - matchName: auth.chezmoi.sh
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: in-gateway-system
       toPorts:
         - ports:
             - port: "443"
               protocol: TCP
-          serverNames:
-            - auth.chezmoi.sh


### PR DESCRIPTION
## Summary

Fix Cilium dropping OIDC token requests from OpenBao to Pocket-Id.

## Problem

Hubble showed `vault/openbao-0 (ingress) -> in-gateway-system/cilium-gateway-default:443 http-request DROPPED (POST https://auth.chezmoi.sh/api/oidc/token)`.

The CiliumNetworkPolicy used `toFQDNs` with `matchName: auth.chezmoi.sh`. Cilium's `toFQDNs` selector only matches DNS names resolving to IPs **outside** the cluster. Since `auth.chezmoi.sh` resolves to the in-cluster Cilium Gateway IP, the rule never matched and the deny-all baseline dropped the traffic.

## Fix

Replace `toFQDNs` with `toEndpoints` targeting `in-gateway-system` namespace (port 443). This matches how other in-cluster egress policies work in this codebase.

## Changes

- `toFQDNs` → `toEndpoints` with `io.kubernetes.pod.namespace: in-gateway-system`
- Removed `serverNames` L7 rule (not applicable with toEndpoints)
- Updated annotation to document the root cause

---

Assisted-by: opencode:glm-5-turbo