### PR TITLE
Fix OpenBao OIDC NetworkPolicy egress to use toCIDR for Gateway LB IP

### DIFF
--- a/projects/amiya.akn/dist/apps/vault/cilium.io.v2.CiliumNetworkPolicy.allow-openbao-to-pocket-id.yaml
+++ b/projects/amiya.akn/dist/apps/vault/cilium.io.v2.CiliumNetworkPolicy.allow-openbao-to-pocket-id.yaml
@@ -4,18 +4,19 @@ kind: CiliumNetworkPolicy
 metadata:
   annotations:
     policy.networking.k8s.io/description: |
-      Allows OpenBao to reach Pocket-ID OIDC endpoints via the in-cluster Cilium Gateway.
-      auth.chezmoi.sh resolves to the Gateway's cluster IP, so we must use toEndpoints
-      (not toFQDNs, which only matches IPs outside the cluster).
+      Allows OpenBao to reach Pocket-ID OIDC endpoints via the Cilium Gateway.
+      auth.chezmoi.sh resolves to the Gateway's LoadBalancer IP (from the
+      10.0.2.0/28 pool). Both toFQDNs (only matches external IPs) and
+      toEndpoints (no Gateway pods in in-gateway-system) fail for this
+      destination, so toCIDR targeting the LB pool is used instead.
   labels:
     app.kubernetes.io/name: vault
   name: allow-openbao-to-pocket-id
   namespace: vault
 spec:
   egress:
-  - toEndpoints:
-    - matchLabels:
-        io.kubernetes.pod.namespace: in-gateway-system
+  - toCIDR:
+    - 10.0.2.0/28
     toPorts:
     - ports:
       - port: "443"

--- a/projects/amiya.akn/src/apps/vault/security/network-policy.allow-openbao-to-pocket-id.yaml
+++ b/projects/amiya.akn/src/apps/vault/security/network-policy.allow-openbao-to-pocket-id.yaml
@@ -3,9 +3,11 @@ kind: CiliumNetworkPolicy
 metadata:
   annotations:
     policy.networking.k8s.io/description: |
-      Allows OpenBao to reach Pocket-ID OIDC endpoints via the in-cluster Cilium Gateway.
-      auth.chezmoi.sh resolves to the Gateway's cluster IP, so we must use toEndpoints
-      (not toFQDNs, which only matches IPs outside the cluster).
+      Allows OpenBao to reach Pocket-ID OIDC endpoints via the Cilium Gateway.
+      auth.chezmoi.sh resolves to the Gateway's LoadBalancer IP (from the
+      10.0.2.0/28 pool). Both toFQDNs (only matches external IPs) and
+      toEndpoints (no Gateway pods in in-gateway-system) fail for this
+      destination, so toCIDR targeting the LB pool is used instead.
   name: allow-openbao-to-pocket-id
 spec:
   endpointSelector:
@@ -13,9 +15,8 @@ spec:
       app.kubernetes.io/name: vault
       component: server
   egress:
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: in-gateway-system
+    - toCIDR:
+        - 10.0.2.0/28
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

Fixes the CiliumNetworkPolicy allowing OpenBao to reach Pocket-ID OIDC endpoints.
The previous fix (PR #1047, already merged) used `toEndpoints` targeting the
`in-gateway-system` namespace, but Cilium Gateway API does not create pods in that
namespace — listeners are handled by Cilium agents running as a DaemonSet elsewhere.
Both `toFQDNs` and `toEndpoints` fail for cluster-managed LoadBalancer IPs, so
`toCIDR` targeting the Gateway's IP pool (`10.0.2.0/28`) is used instead.

## Root Cause

`auth.chezmoi.sh` resolves to the Cilium Gateway's LoadBalancer IP (allocated from
the `CiliumLoadBalancerIPPool.primary` pool, CIDR `10.0.2.0/28`). Two selector types
fail for this destination:

- **`toFQDNs`**: Cilium's FQDN proxy only creates identity mappings for DNS
  resolutions to external IPs. The LB pool is a cluster-internal range managed by
  Cilium, so no FQDN identity is created.
- **`toEndpoints`**: Matches Kubernetes pods by label. Cilium Gateway API has no
  dedicated pods in `in-gateway-system`; the LoadBalancer service is a virtual IP
  backed by Cilium agents, not a pod endpoint.

## Fix

Replace `toEndpoints` with `toCIDR` targeting `10.0.2.0/28`. This matches the
destination IP range directly, bypassing identity classification entirely.

### Network policy

- **[`network-policy.allow-openbao-to-pocket-id.yaml`](projects/amiya.akn/src/apps/vault/security/network-policy.allow-openbao-to-pocket-id.yaml)** — Switch egress selector from `toEndpoints` to `toCIDR: 10.0.2.0/28`; remove `serverNames` L7 rule; update annotation with root cause documentation.

### Regenerated dist artifact

- **[`cilium.io.v2.CiliumNetworkPolicy.allow-openbao-to-pocket-id.yaml`](projects/amiya.akn/dist/apps/vault/cilium.io.v2.CiliumNetworkPolicy.allow-openbao-to-pocket-id.yaml)** — Auto-regenerated by `dist:render`.

## Technical Impact

### Behavioural Changes

OpenBao OIDC token requests to `auth.chezmoi.sh` are no longer dropped by the
default-hardened deny-all baseline.

### Regression Risk

Low. The `toCIDR` rule is broader than necessary (covers all 16 IPs in the LB pool
rather than just the one Gateway IP) but the pool is exclusively used for cluster
Gateway services. All other services in the vault namespace already have their own
egress policies and the default-deny baseline prevents unintended communication.

### Observability

After deploying, verify with:
```sh
hubble observe --since 1m -n vault --identity vault/openbao-0 | grep auth.chezmoi.sh
```
Traffic should show `FORWARD` instead of `DROPPED`.

## Testing Validation

- [ ] `hubble observe` shows OIDC POST requests to `auth.chezmoi.sh` as `FORWARD`
- [ ] OpenBao UI login via Pocket-ID succeeds
- [ ] `vault login -method=oidc` succeeds

## Related Issues

Replaces #1047

---
<sub>AI-assisted with opencode:glm-5-turbo under human supervision</sub>
