### PR TITLE
Re-apply Crossplane v2.3.2 upgrade now that Crossplane-OpenBao network policies are in place

### DIFF
--- a/projects/amiya.akn/dist/apps/crossplane/apps.v1.Deployment.crossplane-rbac-manager.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/apps.v1.Deployment.crossplane-rbac-manager.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: crossplane
   name: crossplane-rbac-manager
   namespace: crossplane
@@ -33,8 +33,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-        helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: crossplane
     spec:
       containers:
@@ -57,7 +57,7 @@ spec:
               resource: limits.memory
         - name: LEADER_ELECTION
           value: "true"
-        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v1.20.0-rc.0.140.g629ca2e2f
+        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v2.3.2
         imagePullPolicy: IfNotPresent
         name: crossplane
         resources:
@@ -93,7 +93,7 @@ spec:
               containerName: crossplane-init
               divisor: "1"
               resource: limits.memory
-        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v1.20.0-rc.0.140.g629ca2e2f
+        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v2.3.2
         imagePullPolicy: IfNotPresent
         name: crossplane-init
         resources:

--- a/projects/amiya.akn/dist/apps/crossplane/apps.v1.Deployment.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/apps.v1.Deployment.crossplane.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: crossplane
   name: crossplane
   namespace: crossplane
@@ -33,8 +33,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-        helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+        app.kubernetes.io/version: 2.3.2
+        helm.sh/chart: crossplane-2.3.2
         release: crossplane
     spec:
       containers:
@@ -72,7 +72,7 @@ spec:
           value: crossplane-tls-client
         - name: TLS_CLIENT_CERTS_DIR
           value: /tls/client
-        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v1.20.0-rc.0.140.g629ca2e2f
+        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v2.3.2
         imagePullPolicy: IfNotPresent
         name: crossplane
         ports:
@@ -115,6 +115,8 @@ spec:
       - args:
         - core
         - init
+        - --activation
+        - '*'
         env:
         - name: GOMAXPROCS
           valueFrom:
@@ -150,7 +152,7 @@ spec:
           value: crossplane-tls-server
         - name: TLS_CLIENT_SECRET_NAME
           value: crossplane-tls-client
-        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v1.20.0-rc.0.140.g629ca2e2f
+        image: oci.chezmoi.sh/xpkg.crossplane.io/crossplane/crossplane:v2.3.2
         imagePullPolicy: IfNotPresent
         name: crossplane-init
         resources:

--- a/projects/amiya.akn/dist/apps/crossplane/core.v1.Service.crossplane-webhooks.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/core.v1.Service.crossplane-webhooks.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     release: crossplane
   name: crossplane-webhooks
   namespace: crossplane

--- a/projects/amiya.akn/dist/apps/crossplane/core.v1.ServiceAccount.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/core.v1.ServiceAccount.crossplane.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   labels:
@@ -9,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
   namespace: crossplane

--- a/projects/amiya.akn/dist/apps/crossplane/core.v1.ServiceAccount.rbac-manager.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/core.v1.ServiceAccount.rbac-manager.yaml
@@ -1,5 +1,6 @@
 ---
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   labels:
@@ -9,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: rbac-manager
   namespace: crossplane

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-admin.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-admin.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-admin.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-admin.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-admin: "true"
   name: crossplane:aggregate-to-admin
 rules:
@@ -71,3 +71,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - protection.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ops.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-browse.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-browse.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-browse: "true"
   name: crossplane:aggregate-to-browse
 rules:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-edit.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-edit.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-edit: "true"
   name: crossplane:aggregate-to-edit
 rules:
@@ -50,6 +50,18 @@ rules:
   - '*'
 - apiGroups:
   - secrets.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - protection.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ops.crossplane.io
   resources:
   - '*'
   verbs:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-view.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-aggregate-to-view.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-view: "true"
   name: crossplane:aggregate-to-view
 rules:
@@ -48,6 +48,22 @@ rules:
   - watch
 - apiGroups:
   - secrets.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - protection.crossplane.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ops.crossplane.io
   resources:
   - '*'
   verbs:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-allowed-provider-permissions.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-allowed-provider-permissions.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane:allowed-provider-permissions

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-browse.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-browse.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-browse

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-edit.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-edit.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-edit

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-rbac-manager.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-rbac-manager.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 rules:
 - apiGroups:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-system-aggregate-to-crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-system-aggregate-to-crossplane.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    helm.sh/chart: crossplane-2.3.2
     rbac.crossplane.io/aggregate-to-crossplane: "true"
   name: crossplane:system:aggregate-to-crossplane
 rules:
@@ -52,8 +52,9 @@ rules:
   - '*'
 - apiGroups:
   - apiextensions.crossplane.io
+  - ops.crossplane.io
   - pkg.crossplane.io
-  - secrets.crossplane.io
+  - protection.crossplane.io
   resources:
   - '*'
   verbs:

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-view.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane-view.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-view

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRole.crossplane.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane-admin.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane-admin.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane-rbac-manager.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane-rbac-manager.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/rbac.authorization.k8s.io.v1.ClusterRoleBinding.crossplane.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.20.0-rc.0.140.g629ca2e2f
-    helm.sh/chart: crossplane-1.20.0-rc.0.140.g629ca2e2f
+    app.kubernetes.io/version: 2.3.2
+    helm.sh/chart: crossplane-2.3.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/projects/amiya.akn/src/apps/crossplane/kustomization.yaml
+++ b/projects/amiya.akn/src/apps/crossplane/kustomization.yaml
@@ -17,9 +17,9 @@ resources:
   - crossplane.applicationset.yaml
 
 helmCharts:
-  - repo: https://charts.crossplane.io/master/
+  - repo: https://charts.crossplane.io/stable
     name: crossplane
-    version: 1.20.0-rc.0.140.g629ca2e2f
+    version: 2.3.2
 
     releaseName: crossplane
     namespace: crossplane

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/functions.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/functions.yaml
@@ -4,7 +4,7 @@ kind: Function
 metadata:
   name: function-go-templating
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.6.0
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.12.1
   runtimeConfigRef:
     name: hardened
 ---
@@ -13,7 +13,7 @@ kind: Function
 metadata:
   name: function-auto-ready
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.3.0
+  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.6.5
   runtimeConfigRef:
     name: hardened
 ---
@@ -22,6 +22,6 @@ kind: Function
 metadata:
   name: function-extra-resources
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.1.0
+  package: xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.3.0
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/provider.yaml
@@ -4,7 +4,7 @@ kind: Provider
 metadata:
   name: upbound-provider-family-aws
 spec:
-  package: xpkg.upbound.io/upbound/provider-family-aws:v1.16.0
+  package: xpkg.upbound.io/upbound/provider-family-aws:v2.6.0
   runtimeConfigRef:
     name: hardened
 ---
@@ -13,7 +13,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v1.14.0
+  package: xpkg.upbound.io/upbound/provider-aws-iam:v2.6.0
   runtimeConfigRef:
     name: hardened
 ---
@@ -22,6 +22,6 @@ kind: Provider
 metadata:
   name: provider-aws-ses
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-ses:v1.14.0
+  package: xpkg.upbound.io/upbound/provider-aws-ses:v2.6.0
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/provider.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: provider-terraform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.0.0
+  package: xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.1.1
   runtimeConfigRef:
     name: hardened-for-terraform

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/provider.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: upbound-provider-vault
 spec:
-  package: xpkg.upbound.io/upbound/provider-vault:v2.2.2
+  package: xpkg.upbound.io/upbound/provider-vault:v3.0.7
   runtimeConfigRef:
     name: hardened


### PR DESCRIPTION
## Summary

Re-applies the Crossplane v2.3.2 upgrade that was reverted in PR #1045. The original
failure was not a `provider-vault` v3.0.7 / Crossplane v2 API incompatibility — it was
OpenBao's hardened NetworkPolicy silently dropping all inbound traffic from
`crossplane-system`. PR #1046 added the missing `CiliumNetworkPolicy`, giving the
Crossplane Vault provider a network path to OpenBao.

**Related Issue:** #1045

## Root Cause

OpenBao's `hardened` NetworkPolicy baseline only permitted ingress from the Cilium
Gateway and same-namespace traffic. `provider-vault` runs in `crossplane-system` and
authenticates via the Kubernetes auth backend
(`openbao.vault.svc.cluster.local`), but those calls were dropped before
reaching OpenBao — Cilium's default-deny policy applies to all namespaces by default.

The reconciliation failures looked like an API incompatibility because no
`connection refused` error surfaced; requests simply never arrived. PR #1046 confirms
the diagnosis: adding an explicit ingress rule from `crossplane-system` restored
reconciliation without any changes to provider versions.

PRs #1047 and #1049 fixed a separate OpenBao → Pocket-Id OIDC issue (in-cluster
Cilium Gateway not matched by `toFQDNs`) discovered during the same investigation,
but that is unrelated to Crossplane reconciliation.

## Fix

### Crossplane control plane — `projects/amiya.akn/`

- **[`src/apps/crossplane/kustomization.yaml`](projects/amiya.akn/src/apps/crossplane/kustomization.yaml)** — Helm repo back to `charts.crossplane.io/stable`, version `2.3.2`
- **`dist/apps/crossplane/`** — Regenerated rendered manifests for Crossplane v2.3.2

### Providers and functions — `projects/chezmoi.sh/`

- **[`src/infrastructure/crossplane/providers/vault/provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/provider.yaml)** — `provider-vault` v2.2.2 → v3.0.7
- **[`src/infrastructure/crossplane/providers/aws/provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/provider.yaml)** — `provider-family-aws`, `provider-aws-iam`, `provider-aws-ses` v1.x → v2.6.0
- **[`src/infrastructure/crossplane/providers/terraform/provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/provider.yaml)** — `provider-terraform` v1.0.0 → v1.1.1
- **[`src/infrastructure/crossplane/functions.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/functions.yaml)** — `function-go-templating` v0.6.0 → v0.12.1, `function-auto-ready` v0.3.0 → v0.6.5, `function-extra-resources` v0.1.0 → v0.3.0

## Technical Impact

### Behavioural Changes

Crossplane moves from the pre-release master build (`1.20.0-rc.0.140.g629ca2e2f`) to
the stable `2.3.2` release. All providers and functions align with the Crossplane v2
managed-resource model. No visible change for end-users; only operators managing AWS,
Vault, or Terraform Crossplane resources are affected.

### Regression Risk

**Low.** The previous failure was caused by a missing network policy, not a version
incompatibility. That policy is now in place (PR #1046, already merged). The upgrade
path itself was validated before the rollback; the only untested variable was the
OpenBao network path, which is now confirmed open.

### Observability

- `kubectl get provider -n crossplane-system` — all providers should reach `Healthy: True`
- `kubectl logs -n crossplane-system -l pkg.crossplane.io/revision=upbound-provider-vault-*` — no `connection refused` to OpenBao
- Existing Vault `ManagedResource` objects should reconcile without `ReconcileError`

## Testing Validation

- [ ] All Crossplane provider pods reach `Healthy: True` in `crossplane-system`
- [ ] `provider-vault` reconciles existing OpenBao `ManagedResource` objects without errors
- [ ] AWS and Terraform providers report healthy status
- [ ] No `ReconcileError` on existing Crossplane claims after sync

## Related Issues

Addresses #1045 (root cause identified and fixed by #1046)

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
