### PR TITLE
Replace type and status labels with GitHub-native Issue Types and project fields

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -78,31 +78,28 @@ When in doubt: read the title cold without the body. If it doesn't answer
 
 ## Labels
 
-The title doesn't carry type or scope — **labels do**. Apply at least one from
-each mandatory group:
+The title doesn't carry type or scope — **labels and Issue Type do**. Apply one Issue Type and at least one label from each mandatory group:
 
-| Group         | Mandatory            | Apply                                                                                                                                                                             |
+| Field / Group | Mandatory            | Apply                                                                                                                                                                             |
 | ------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type::*`     | **yes**              | One of `type::bug`, `type::feature`, `type::improve`, `type::refactor`, `type::docs`, `type::security`, `type::chore`, `type::question`                                           |
+| Issue Type    | **yes**              | One of `Bug`, `Feature`, `Improvement`, `Task`, `Docs`, `Security`, `Question` — set with `--type <Name>`                                                                         |
 | scope         | **yes**              | The repository area as a label (`project:amiya.akn`, `project:lungmen.akn`, `catalog:crossplane`, `gh`, `deps`, …) — same identifiers used as commit scopes in `.commitlintrc.js` |
 | `size::*`     | yes when known       | `size::XS`, `size::S`, `size::M`, `size::L`, `size::XL`. If you cannot estimate, leave it off rather than guessing.                                                               |
 | `priority::*` | yes when non-default | `priority::critical` (outage / data loss / active security), `priority::high` (this week), `priority::medium` (default — omit unless explicit), `priority::low` (nice-to-have)    |
-| `status::*`   | optional             | `status::triage` (default for new issues — picked up by templates), `status::blocked`, `status::in-progress`, `status::needs-info`                                                |
 
-### Type-label decision tree
+### Issue Type decision tree
 
 What does the issue ask for?
 
-| Intent                                                    | Label            |
-| --------------------------------------------------------- | ---------------- |
-| Repair broken behavior                                    | `type::bug`      |
-| Add a new capability, service, or initial deployment      | `type::feature`  |
-| Improve existing behavior (perf, config, UX) — not a bug  | `type::improve`  |
-| Restructure without observable change                     | `type::refactor` |
-| Documentation only (ADRs, READMEs, procedures)            | `type::docs`     |
-| Security hardening, vulnerability, secret management      | `type::security` |
-| Tooling, CI, dependencies, repo maintenance               | `type::chore`    |
-| Clarification or discussion, no concrete change requested | `type::question` |
+| Intent                                                    | Type          |
+| --------------------------------------------------------- | ------------- |
+| Repair broken behavior                                    | `Bug`         |
+| Add a new capability, service, or initial deployment      | `Feature`     |
+| Improve existing behavior (perf, config, UX) — not a bug  | `Improvement` |
+| Tooling, CI, refactoring, or repository maintenance       | `Task`        |
+| Documentation only (ADRs, READMEs, procedures)            | `Docs`        |
+| Security hardening, vulnerability, secret management      | `Security`    |
+| Clarification or discussion, no concrete change requested | `Question`    |
 
 Breaking variants of any change add the `breaking-change` label.
 
@@ -198,9 +195,9 @@ exists, decide: comment on it, or file a distinct one and cross-link.
 
 Apply the rules above. Read the title aloud — does it say what changes?
 
-### 3. Pick labels
+### 3. Pick Issue Type and labels
 
-Mandatory: one `type::*` + the scope label. Add `size::*` and `priority::*`
+Mandatory: `--type <Name>` + the scope label. Add `size::*` and `priority::*`
 when you have signal for them.
 
 ### 4. Create the issue
@@ -239,7 +236,7 @@ gh issue create \
   --repo chezmoidotsh/arcane \
   --title "Sentence describing the outcome" \
   --body-file /tmp/issue_body.md \
-  --label "type::feature" \
+  --type "Feature" \
   --label "gh" \
   --label "size::M"
 
@@ -257,7 +254,7 @@ that post-mortem. If it parks scope deferred from a PR, link both ways.
 
 **Title:** `Set up cluster observability stack (metrics, logs, alerting)`
 
-**Labels:** `type::feature`, `gh`, `size::XL`, `priority::high`
+**Type:** `Feature` — **Labels:** `gh`, `size::XL`, `priority::high`
 
 **Body skeleton (excerpt):**
 
@@ -303,7 +300,7 @@ operational baseline exists.
 
 **Title:** `WAL volume full on apps-secured cluster — immich and paperless unavailable`
 
-**Labels:** `type::bug`, `project:lungmen.akn`, `priority::critical`, `size::M`
+**Type:** `Bug` — **Labels:** `project:lungmen.akn`, `priority::critical`, `size::M`
 
 **Body (excerpt):**
 
@@ -338,12 +335,12 @@ operational baseline exists.
 * Gitmoji + parens — looks like a commit, not a title
 * Repeats `project:lungmen.akn` (which the body says is just the first deploy target — scope is actually cross-cutting)
 * Body has 12 sections, 250 lines, "Pain Points / Motivation / Background" repeating themselves, an empty Risk table, an empty "AI Analysis Placeholder" — none of which a reader can act on
-* No labels beyond `size::XL` — no `type::*`, no scope label
+* No `--type`, no scope label, no `size::*`
 
 ## Rules summary
 
 * **Title**: sentence-case, ≤100 chars, no trailing period, no symbol prefix, no bracketed scope. Carries the outcome — not the type, not the scope.
-* **Type and scope live in labels**, not in the title. One `type::*` + scope label mandatory.
+* **Issue Type** (`--type`) is mandatory — it replaces `type::*` labels. Scope label is also mandatory.
 * **Labels**: add `size::*` / `priority::*` when you have signal.
 * **Body**: TL;DR + Context + Proposal/Reproduction + Acceptance criteria + Notes. Drop sections that don't apply.
 * **Attribution**: end with `<sub>AI-assisted with <provider>:<model-id> under human supervision</sub>`

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -15,14 +15,16 @@
 #
 # Label taxonomy
 # --------------
-# Six orthogonal groups, applied independently:
+# Four orthogonal groups, applied independently:
 #
-#   type::<x>        What kind of work is this?      (issues + PRs)
 #   pr::<x>          PR auto-labeler categorization  (PRs only, set by labeler.yml)
 #   size::<x>        Effort estimate                  (issues + PRs)
 #   priority::<x>    Urgency                          (issues only)
-#   status::<x>      Workflow state                   (issues only)
 #   <scope>          Where in the repo               (mirrors commit scopes verbatim)
+#
+# Type and status are now GitHub-native fields:
+#   Issue Type       Bug / Feature / Improvement / Task / Docs / Security / Question
+#   Status           Triage / In Progress / Blocked / Done  (project field, not label)
 #
 # Plus a small set of bare meta labels (`stale`, `breaking-change`, …).
 #
@@ -36,34 +38,6 @@
 # (`.github/workflows/push,schedule.sync-labels.yaml`) uses `prune: true`, so any
 # label not declared here will be deleted on the next sync.
 ---
-# ----------------------------------------------------------------------------
-# type:: — what kind of work is this?
-# ----------------------------------------------------------------------------
-- name: type::bug
-  description: Something is broken or behaves incorrectly
-  color: D73A4A
-- name: type::feature
-  description: New capability, service, or initial deployment
-  color: 0E8A16
-- name: type::improve
-  description: Improve existing behavior (perf, config, UX) — not a bug fix
-  color: 86CB55
-- name: type::refactor
-  description: Restructure without observable behavior change
-  color: 1F77B4
-- name: type::docs
-  description: Documentation only (ADRs, READMEs, procedures, comments)
-  color: 0075CA
-- name: type::security
-  description: Security hardening, vulnerability, or secret management
-  color: 8B0000
-- name: type::chore
-  description: Tooling, CI, dependencies, repository maintenance
-  color: CFD3D7
-- name: type::question
-  description: Clarification or discussion, no concrete change requested
-  color: D876E3
-
 # ----------------------------------------------------------------------------
 # pr:: — PR auto-labeler (consumed by .github/labeler.yml — do not rename)
 # ----------------------------------------------------------------------------
@@ -117,22 +91,6 @@
 - name: priority::low
   description: Nice to have, no time pressure
   color: 0E8A16
-
-# ----------------------------------------------------------------------------
-# status:: — workflow state
-# ----------------------------------------------------------------------------
-- name: status::triage
-  description: Needs initial review, categorization, or scope decision
-  color: CFD3D7
-- name: status::blocked
-  description: Waiting on an external dependency or decision
-  color: B60205
-- name: status::in-progress
-  description: Actively being worked on
-  color: 1D76DB
-- name: status::needs-info
-  description: Waiting on more information from the reporter
-  color: D4C5F9
 
 # ----------------------------------------------------------------------------
 # Scope — mirrors commit scopes in .commitlintrc.js verbatim

--- a/.github/workflows/issues.sync-project-fields.yaml
+++ b/.github/workflows/issues.sync-project-fields.yaml
@@ -1,0 +1,74 @@
+---
+name: 🔄 Sync issue labels to project fields
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+permissions:
+  issues: read
+  repository-projects: write
+
+jobs:
+  sync:
+    name: 🔄 Sync labels to Arcane Roadmap fields
+    runs-on: ubuntu-latest
+    steps:
+      - name: "🔄 Sync priority:: and size:: labels to project fields"
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const OWNER       = 'chezmoidotsh';
+            const PROJECT_NUM = 1;
+            const PRIORITY_FIELD = 'IFSS_kgDOAYM1Jg';
+            const EFFORT_FIELD   = 'IFSS_kgDOAYM1KQ';
+
+            // priority:: label → Priority field option ID
+            const PRIORITY_MAP = {
+              'priority::critical': 'IFSSO_kgDOAqWFjg',
+              'priority::high':     'IFSSO_kgDOAqWFjw',
+              'priority::medium':   'IFSSO_kgDOAqWFkA',
+              'priority::low':      'IFSSO_kgDOAqWFkQ',
+            };
+
+            // size:: label → Effort field option ID
+            const EFFORT_MAP = {
+              'size::XS': 'IFSSO_kgDOBIV_Fw',
+              'size::S':  'IFSSO_kgDOAqWFlA',
+              'size::M':  'IFSSO_kgDOAqWFkw',
+              'size::L':  'IFSSO_kgDOAqWFkg',
+              'size::XL': 'IFSSO_kgDOBIV_Fg',
+            };
+
+            const label = context.payload.label.name;
+            const issueId = context.payload.issue.node_id;
+            const isRemove = context.eventName === 'issues' && context.payload.action === 'unlabeled';
+
+            let fieldId, optionId;
+
+            if (PRIORITY_MAP[label] !== undefined) {
+              fieldId  = PRIORITY_FIELD;
+              optionId = isRemove ? null : PRIORITY_MAP[label];
+            } else if (EFFORT_MAP[label] !== undefined) {
+              fieldId  = EFFORT_FIELD;
+              optionId = isRemove ? null : EFFORT_MAP[label];
+            } else {
+              core.info(`Label "${label}" is not mapped — skipping.`);
+              return;
+            }
+
+            const issueFields = optionId
+              ? [{ fieldId, singleSelectOptionId: optionId }]
+              : [{ fieldId, delete: true }];
+
+            const mutation = `
+              mutation($issueId: ID!, $issueFields: [IssueFieldCreateOrUpdateInput!]!) {
+                setIssueFieldValue(input: { issueId: $issueId, issueFields: $issueFields }) {
+                  issue { number }
+                }
+              }`;
+
+            const result = await github.graphql(mutation, { issueId, issueFields });
+            const num = result.setIssueFieldValue?.issue?.number;
+            core.info(`✓ #${num} — "${label}" → ${fieldId} = ${optionId ?? 'cleared'}`);


### PR DESCRIPTION
## Summary

Replaces the `type::*` and `status::*` label groups with GitHub-native
mechanisms: Issue Types (Bug, Feature, Improvement, Task, Docs, Security,
Question) for issue classification, and the project Status field for workflow
state. Labels now cover only what GitHub doesn't handle natively — `priority::*`,
`size::*`, and scope labels. A new Actions workflow keeps the Arcane Roadmap
project fields in sync with those labels automatically.

## Rationale

`type::*` labels duplicated information that GitHub now expresses natively through
Issue Types, and were invisible in the project board view anyway. `status::*`
labels were redundant with the project Status field and created divergence (an
issue could be `status::in-progress` without the board reflecting it). Removing
both groups reduces the label taxonomy to four orthogonal groups, each covering
one dimension that GitHub doesn't already own.

## Changes Made

### Label taxonomy

- **[`.github/labels.yaml`](.github/labels.yaml)** — removed the entire
  `type::*` section (8 labels: bug, feature, improve, refactor, docs, security,
  chore, question) and the entire `status::*` section (4 labels: triage,
  blocked, in-progress, needs-info); updated header comment from "Six orthogonal
  groups" to "Four orthogonal groups" with a note that type and status are now
  GitHub-native fields

### Agent skill

- **[`.agents/skills/create-issue/SKILL.md`](.agents/skills/create-issue/SKILL.md)** —
  replaced `type::*` label row with Issue Type (`--type <Name>`) in the mandatory
  labels table; removed `status::*` row; replaced the "Type-label decision tree"
  with an "Issue Type decision tree" (7 types); updated the `gh issue create`
  example and rules summary

### New workflow

- **[`.github/workflows/issues.sync-project-fields.yaml`](.github/workflows/issues.sync-project-fields.yaml)** —
  fires on `issues: labeled/unlabeled`; maps `priority::*` labels to the
  Priority org field and `size::*` labels to the Effort org field in the Arcane
  Roadmap project via `setIssueFieldValue` GraphQL mutation; uses
  `secrets.GITHUB_TOKEN` with `repository-projects: write` permission

### Removed

- All 8 `type::*` labels — replaced by GitHub Issue Types (set via `--type`)
- All 4 `status::*` labels — replaced by the project Status field

## Technical Impact

### Architecture Simplification

| Before | After |
| ------ | ----- |
| 6 label groups (pr::, size::, priority::, type::, status::, scope) | 4 label groups (pr::, size::, priority::, scope) |
| type::* labels on every issue | `--type <Name>` on `gh issue create/edit` |
| status::* labels for workflow state | Project Status field (Triage / In Progress / Blocked / Done) |
| priority:: and size:: labels only visible in issue list | Labels synced to project Priority and Effort fields via workflow |

### Security Boundary Preservation

No secrets or network policies involved. The new workflow uses the default
`GITHUB_TOKEN` with `repository-projects: write` — no additional PAT required.

### Behavioural Changes

- `gh issue create` and `gh issue edit` must now use `--type <Name>` (the
  create-issue skill enforces this)
- `priority::*` and `size::*` label changes trigger automatic updates to the
  Arcane Roadmap project fields (previously manual)
- Label sync (`push,schedule.sync-labels.yaml`) will delete `type::*` and
  `status::*` labels from the repo on its next run

### Migration Path

All 14 open issues were populated with Issue Type, Priority, and Effort field
values via API before this PR was opened — no manual migration needed after merge.
The label sync workflow will remove the deprecated labels from the repo on its
next scheduled or push-triggered run.

### Next Steps

The sync workflow currently lives in this repo; once the `chezmoidotsh/.github`
org repo is created (tracked in issue #1055), the workflow should be migrated
there to apply across all org repositories.

## Testing Validation

- [ ] Label sync workflow (`push,schedule.sync-labels.yaml`) runs after merge
  and removes `type::*` / `status::*` labels from the repo
- [ ] Applying a `priority::high` label to an issue updates the Arcane Roadmap
  Priority field to "High" automatically
- [ ] Applying a `size::M` label updates the Effort field to "Medium"
- [ ] Removing a label clears the corresponding field
- [ ] `gh issue create --type Feature` works without a `type::feature` label

## Related Issues

Addresses #1055 (Phase 1 — local workflow; migration to .github org repo is Phase 2)

---
<sub>AI-assisted with anthropic:claude-opus-4.8 under human supervision</sub>
