### PR TITLE
Replace inline PyPI build of prometheus-pve-exporter with nixpkgs package

### DIFF
--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/README.md
@@ -16,9 +16,6 @@ This container holds **no persistent data** — it pushes outbound (metrics via
 remote\_write, logs via the Vector protocol) and can be rebuilt and replaced at any
 time without data loss. Its only inbound port is the syslog listener (`:5140`).
 
-> **Note** — `prometheus-pve-exporter` and its Python dependency `proxmoxer` are
-> not in nixpkgs; both are packaged inline from PyPI sdists in `modules/pve-exporter.nix`.
-
 ## Table of contents
 
 1. [Architecture](#architecture)
@@ -58,7 +55,7 @@ flowchart TB
     syslog -->|"parsed syslog (Vector :6000)"| o11y
 ```
 
-* **prometheus-pve-exporter** (`v3.9.0`) binds to `127.0.0.1:9221`. It
+* **prometheus-pve-exporter** binds to `127.0.0.1:9221`. It
   authenticates against the PVE API with the `prometheus@pve!exporter` token
   (read-only) and exposes metrics on demand via the multi-target `/pve` endpoint.
 * **Vector** (via `catalog.lxcAgent`) does three things: scrapes the exporter with
@@ -83,14 +80,14 @@ flowchart TB
 ```text
 .
 ├── README.md              ← you are here
-├── flake.nix              ← LXC image build (nixos-generators) + inline Python packages
+├── flake.nix              ← LXC image build (nixos-generators)
 ├── flake.lock             ← pinned inputs
 ├── configuration.nix      ← site identity, locale, console toolbox
 ├── .mise.toml             ← mise tasks (secrets / build)
 ├── .mise/tasks/lxc/       ← build / push / upgrade scripts
 ├── modules/
 │   ├── default.nix        ← module aggregator
-│   ├── pve-exporter.nix   ← prometheus-pve-exporter service (inline PyPI build)
+│   ├── pve-exporter.nix   ← prometheus-pve-exporter service (nixpkgs)
 │   ├── o11y.nix           ← catalog.lxcAgent (metrics scrape + journald + syslog → o11y)
 │   ├── o11y.extraTransforms/  ← Vector fragments injected into catalog.lxcAgent
 │   │   ├── sources.syslog.yaml      ← syslog :5140 source + syslog_to_o11y (parse + tests)
@@ -106,10 +103,6 @@ flowchart TB
 * Docker (used by `nix:build:lxc` to wrap the Nix build).
 * `sops` with the repo age key loaded (`SOPS_AGE_KEY_FILE` already set by mise).
 * SSH key-based root access to the Proxmox node you push to.
-
-The `prometheus-pve-exporter` and `proxmoxer` Python packages are built inline
-from PyPI sdists by Nix — no internet access is needed at runtime, but the build
-phase fetches from PyPI (or a local cache if one is configured).
 
 ## Proxmox user and API token setup
 
@@ -264,9 +257,9 @@ so no pre-start chown step is needed.
 \| Data volume         | None                                  |
 \| Swap                | 0 (let OOM kill on overrun)           |
 
-The root disk holds the NixOS closure + the inline Python environment for
-prometheus-pve-exporter. Keep 2 GiB; if a future rebuild exceeds it bump with
-`pct resize <vmid> rootfs +2G` before rebuilding.
+The root disk holds the NixOS closure for prometheus-pve-exporter. Keep 2 GiB;
+if a future rebuild exceeds it bump with `pct resize <vmid> rootfs +2G` before
+rebuilding.
 
 ## Proxmox host firewall
 
@@ -419,25 +412,18 @@ source CT. No `mp0` transfer needed.
    with `../observability`, so its lock was copied from there to give a valid pin.
    Run `nix flake lock` here to refresh it independently when bumping inputs.
 
-2. **PyPI hashes require manual updates on version bumps.** The `hash =` fields
-   for `proxmoxer` and `prometheus-pve-exporter` in `modules/pve-exporter.nix` are
-   not tracked by `flake.lock` (they are `fetchPypi` hashes). Renovate won't
-   propose bumps. When upgrading either package: update the version string, set
-   `hash = lib.fakeHash`, run a build, read the correct hash from the error, and
-   patch the file.
-
-3. **PVE token baked into image.** Rotating `prometheus@pve!exporter` requires a
+2. **PVE token baked into image.** Rotating `prometheus@pve!exporter` requires a
    rebuild and redeploy. There is no runtime secret injection. For a homelab this
    is acceptable; a production system would use OpenBao + a sidecar to inject the
    token at runtime without rebuilding.
 
-4. **No alert if the exporter goes silent.** If the LXC dies or the token is
+3. **No alert if the exporter goes silent.** If the LXC dies or the token is
    revoked, the o11y appliance stops receiving PVE metrics without notification.
    Adding `up{job="pve_exporter"} == 0` to
    [`../observability/alerts/pve.rules.yaml`](../observability/alerts/pve.rules.yaml)
    would close this gap.
 
-5. **Syslog parsing tests are not auto-run.** The `syslog_to_o11y` unit tests live
+4. **Syslog parsing tests are not auto-run.** The `syslog_to_o11y` unit tests live
    in `modules/o11y.extraTransforms/sources.syslog.yaml`, but `catalog.lxcAgent`
    only runs `vector validate` (not `vector test`) at build time, and the fragment
    isn't testable standalone (the journald passthrough references the catalog's
@@ -445,6 +431,6 @@ source CT. No `mp0` transfer needed.
    o11y transform. A future `vector test` harness over the assembled config would
    restore coverage.
 
-6. **No NixOS smoke test.** A `pkgs.testers.runNixOSTest` that boots the LXC,
+5. **No NixOS smoke test.** A `pkgs.testers.runNixOSTest` that boots the LXC,
    asserts `pve-exporter.service` is active, and curls `127.0.0.1:9221/metrics`
    would catch module regressions before they reach Proxmox.

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/configuration.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/configuration.nix
@@ -5,7 +5,7 @@
 # system identity, locale, the console shell, and the console toolbox.
 #
 # The modules in ./modules/ own all service configuration:
-#   * pve-exporter.nix — prometheus-pve-exporter (inline Python packages)
+#   * pve-exporter.nix — prometheus-pve-exporter (nixpkgs)
 #   * o11y.nix         — Vector agent (catalog.lxcAgent) shipping metrics + logs
 #   * hardening.nix    — sysctl, firewall default-deny, login surface, journald
 #

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/flake.nix
@@ -2,7 +2,7 @@
   description = "pve-exporter — Proxmox VE monitoring LXC image (Proxmox)";
 
   # ---------------------------------------------------------------------------
-  # All-in-one flake: inline Python packages + NixOS modules + site config.
+  # All-in-one flake: NixOS modules + site config.
   #
   # A single unprivileged LXC running:
   #
@@ -11,9 +11,6 @@
   #
   # No public services: the LXC only pushes outbound (metrics + logs). No Caddy,
   # no TLS termination, no ingress.
-  #
-  # Neither prometheus-pve-exporter nor proxmoxer are in nixpkgs, so both are
-  # packaged inline from PyPI sdists.
   #
   # Build (produces a Proxmox-importable .tar.xz):
   #
@@ -42,7 +39,7 @@
       # Proxmox template (pve-exporter.<date>-amd64.tar.xz). Component
       # versions track the nixpkgs pin. Bump this date before every
       # `mise run lxc:build`; append -N for multiple builds on the same day.
-      version = "2026.06.14-2";
+      version = "2026.06.18";
 
       # -----------------------------------------------------------------------
       # Build-time secrets, forwarded to the modules via _module.args.

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/modules/pve-exporter.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/modules/pve-exporter.nix
@@ -5,64 +5,9 @@
 # Exposes metrics at 127.0.0.1:9221. Vector scrapes the /pve endpoint with
 # ?target=<host>&cluster=1&node=1 and pushes via remote_write to the o11y
 # appliance.
-#
-# Neither prometheus-pve-exporter nor proxmoxer are in nixpkgs, so both are
-# packaged inline from PyPI sdists.
 # ─────────────────────────────────────────────────────────────────────────────
 { lib, pkgs, pveHost, pveTokenValue, ... }:
 
-let
-  pythonPkgs = pkgs.python312.pkgs;
-
-  proxmoxer = pythonPkgs.buildPythonPackage rec {
-    pname = "proxmoxer";
-    version = "2.3.0";
-    src = pkgs.fetchPypi {
-      inherit pname version;
-      hash = "sha256-CwsgZxh68fxtQlekasaMj9ecwl0oE2N82uepqY+/0R8=";
-    };
-    # nixpkgs ≥ 25.05 requires an explicit build format for buildPythonPackage.
-    pyproject = true;
-    build-system = [ pythonPkgs.setuptools ];
-    propagatedBuildInputs = [ pythonPkgs.requests ];
-    doCheck = false;
-  };
-
-  pveExporter = pythonPkgs.buildPythonPackage rec {
-    pname = "prometheus-pve-exporter";
-    version = "3.9.0";
-    src = pkgs.fetchPypi {
-      # PyPI normalises sdist filenames to underscores (PEP 625); the hyphenated
-      # URL 404s, so the fetch pname must use underscores.
-      pname = "prometheus_pve_exporter";
-      inherit version;
-      hash = "sha256-ctK2lf7GflF1T2evlwZBZ0xjkNbOHfKMTkaqzxb7TMg=";
-    };
-    # nixpkgs ≥ 25.05 requires an explicit build format for buildPythonPackage.
-    # The sdist's [build-system] requires setuptools + setuptools-scm.
-    pyproject = true;
-    build-system = [
-      pythonPkgs.setuptools
-      pythonPkgs.setuptools-scm
-    ];
-    # Runtime deps come from the sdist's requirements.in (dynamic dependencies):
-    # prometheus_client, proxmoxer, pyyaml, requests, Werkzeug, gunicorn,
-    # paramiko, wrapt. All must be present or pythonRuntimeDepsCheck fails.
-    propagatedBuildInputs = [
-      pythonPkgs.prometheus-client
-      proxmoxer
-      pythonPkgs.pyyaml
-      pythonPkgs.requests
-      pythonPkgs.werkzeug
-      pythonPkgs.gunicorn
-      pythonPkgs.paramiko
-      pythonPkgs.wrapt
-    ];
-    doCheck = false;
-  };
-
-  pythonEnv = pkgs.python312.withPackages (ps: [ pveExporter ]);
-in
 {
   environment.etc."pve-exporter/secrets".text = ''
     PVE_TOKEN_VALUE=${pveTokenValue}
@@ -77,7 +22,7 @@ in
 
     serviceConfig = {
       ExecStart = lib.concatStringsSep " " [
-        "${pythonEnv}/bin/pve_exporter"
+        "${pkgs.prometheus-pve-exporter}/bin/pve_exporter"
         "--web.listen-address=127.0.0.1:9221"
       ];
 


### PR DESCRIPTION
## Summary

Replaces the inline PyPI build of `prometheus-pve-exporter` and `proxmoxer` in the pve-exporter LXC appliance with the nixpkgs package, now available in NixOS 26.05. This removes ~60 lines of manual packaging — `fetchPypi` hash pinning, duplicate build-system declarations, and a hand-maintained runtime dependency list that could drift silently.

**Related Issue:** #1052

## Rationale

`prometheus-pve-exporter` was added to nixpkgs in the 26.05 cycle. The inline packaging was a stopgap from when neither `prometheus-pve-exporter` nor `proxmoxer` existed in nixpkgs. Keeping it now means maintaining PyPI hashes, build-system lists, and transitive dependencies by hand — all of which the nixpkgs derivation already handles and tracks via `flake.lock` / Renovate.

## Changes Made

### pve-exporter module

- **[`modules/pve-exporter.nix`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/modules/pve-exporter.nix)** — Replaced `pythonEnv` (built from inline `buildPythonPackage` derivations) with `pkgs.prometheus-pve-exporter`; removed the stale "not in nixpkgs" comment

### Build configuration

- **[`flake.nix`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/flake.nix)** — Removed the inline-packaging comment block; bumped image version to `2026.06.18`
- **[`configuration.nix`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/configuration.nix)** — Updated the module-listing comment from "(inline Python packages)" to "(nixpkgs)"

### Documentation

- **[`README.md`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/README.md)** — Removed all references to inline PyPI builds; dropped hardcoded version tag; removed Known Gap about manual PyPI hash updates; renumbered remaining gaps

### Removed

- Inline `proxmoxer` derivation (`buildPythonPackage` from `fetchPypi`, 13 lines)
- Inline `prometheus-pve-exporter` derivation (`buildPythonPackage` from `fetchPypi`, 32 lines)
- `pythonEnv` let-binding (`python312.withPackages` wrapper)
- `pythonPkgs` let-binding

## Technical Impact

### Architecture Simplification

| Before | After |
| ------ | ----- |
| 114-line module with 51 lines of inline Python packaging | 59-line module — declarative service config only |
| Manual `fetchPypi` hashes for 2 packages (drift risk) | Tracked by `flake.lock` + Renovate via nixpkgs `by-name` |
| Hand-maintained runtime dependency list (8 propagatedBuildInputs) | Dependencies resolved by the nixpkgs derivation |

### Security Boundary Preservation

No security-relevant changes. The systemd hardening (`NoNewPrivileges`, `RestrictSUIDSGID`, `RestrictRealtime`, `LockPersonality`, `SystemCallArchitectures`, `LimitNOFILE`), loopback-only binding, secrets handling, and firewall rules are all unchanged.

### Behavioural Changes

The exporter binary now comes from the nixpkgs derivation instead of an inline build. Runtime behaviour (PVE API scraping, metrics endpoint, Vector integration) is identical. The nixpkgs package bundles `proxmoxer` as a propagated dependency — the same one that was previously built inline.

### Migration Path

Standard LXC rebuild + rootfs swap — no data volume, no persistent state:

```sh
mise run lxc:build
mise run lxc:push -- pve.lan
mise run lxc:upgrade -- pve.lan
```

## Testing Validation

- [x] Nix expressions parse without errors (`nix-instantiate --parse`)
- [x] `pkgs.prometheus-pve-exporter` resolves in the pinned nixpkgs (`nix eval`)
- [x] No stale references to inline packaging remain (grep sweep)
- [ ] LXC image builds cleanly (`mise run lxc:build` — requires Linux builder)
- [ ] Exporter starts and `/pve?target=<host>` returns Prometheus metrics

## Related Issues

Closes #1052

---
<sub>AI-assisted with zai:glm-5.1 under human supervision</sub>
