### PR TITLE
Extend dist/ rendered manifests pattern to Crossplane infrastructure

### DIFF
--- a/.github/workflows/push,pull_request.compliance-partial.yaml
+++ b/.github/workflows/push,pull_request.compliance-partial.yaml
@@ -9,6 +9,7 @@ on:
       - "catalog/helm/**"
       - "projects/*/src/apps/**"
       - "projects/*/src/infrastructure/kubernetes/**"
+      - "projects/*/src/infrastructure/crossplane/**"
       - "projects/amiya.akn/dist/apps/zot-registry/**"
 
   pull_request:
@@ -18,6 +19,7 @@ on:
       - "catalog/helm/**"
       - "projects/*/src/apps/**"
       - "projects/*/src/infrastructure/kubernetes/**"
+      - "projects/*/src/infrastructure/crossplane/**"
       - "projects/amiya.akn/dist/apps/zot-registry/**"
 
 concurrency:

--- a/.github/workflows/push,pull_request.dist-staleness-check.yaml
+++ b/.github/workflows/push,pull_request.dist-staleness-check.yaml
@@ -5,12 +5,14 @@ on:
       - "projects/*/src/apps/**"
       - "projects/*/src/argocd/**"
       - "projects/*/src/infrastructure/kubernetes/**"
+      - "projects/*/src/infrastructure/crossplane/**"
       - "catalog/helm/**"
   pull_request:
     paths:
       - "projects/*/src/apps/**"
       - "projects/*/src/argocd/**"
       - "projects/*/src/infrastructure/kubernetes/**"
+      - "projects/*/src/infrastructure/crossplane/**"
       - "catalog/helm/**"
   merge_group: {}
 

--- a/projects/amiya.akn/dist/apps/crossplane/argoproj.io.v1alpha1.ApplicationSet.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/argoproj.io.v1alpha1.ApplicationSet.crossplane.yaml
@@ -15,7 +15,9 @@ spec:
   generators:
   - git:
       directories:
-      - path: projects/*/src/infrastructure/crossplane
+      - path: projects/*/dist/infrastructure/crossplane
+      - exclude: true
+        path: projects/*/dist/infrastructure/crossplane/*/*
       repoURL: https://github.com/chezmoidotsh/arcane.git
       revision: main
   goTemplate: true

--- a/projects/amiya.akn/src/apps/crossplane/crossplane.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/crossplane/crossplane.applicationset.yaml
@@ -21,7 +21,9 @@ spec:
         repoURL: https://github.com/chezmoidotsh/arcane.git
         revision: main
         directories:
-          - path: projects/*/src/infrastructure/crossplane
+          - path: projects/*/dist/infrastructure/crossplane
+          - path: projects/*/dist/infrastructure/crossplane/*/*
+            exclude: true
   syncPolicy:
     # Always preserve Applications on deletion of ApplicationSet
     preserveResourcesOnDeletion: true

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-o11y.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-o11y.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
+kind: Token
+metadata:
+  name: chezmoi-sh-caddy-dns01-o11y
+  namespace: crossplane
+spec:
+  forProvider:
+    accountId: 00736631322131f61ce95f2c235143da
+    name: (chezmoi.sh) - caddy-dns01/observability
+    policies:
+    - effect: allow
+      permissionGroups:
+      - id: c8fed203ed3043cba015a93ad1616f1f
+      - id: 4755a26eedb94da69e1066d98aa820be
+      resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
+  writeConnectionSecretToRef:
+    name: chezmoi.sh-cloudflare-token-o11y

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-omni.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-omni.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
+kind: Token
+metadata:
+  name: chezmoi-sh-caddy-dns01-omni
+  namespace: crossplane
+spec:
+  forProvider:
+    accountId: 00736631322131f61ce95f2c235143da
+    name: (chezmoi.sh) - caddy-dns01/omni
+    policies:
+    - effect: allow
+      permissionGroups:
+      - id: c8fed203ed3043cba015a93ad1616f1f
+      - id: 4755a26eedb94da69e1066d98aa820be
+      resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
+  writeConnectionSecretToRef:
+    name: chezmoi.sh-cloudflare-token-caddy-dns01-omni

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-zot.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-zot.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
+kind: Token
+metadata:
+  name: chezmoi-sh-caddy-dns01-zot
+  namespace: crossplane
+spec:
+  forProvider:
+    accountId: 00736631322131f61ce95f2c235143da
+    name: (chezmoi.sh) - caddy-dns01/zot-registry
+    policies:
+    - effect: allow
+      permissionGroups:
+      - id: c8fed203ed3043cba015a93ad1616f1f
+      - id: 4755a26eedb94da69e1066d98aa820be
+      resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
+  writeConnectionSecretToRef:
+    name: chezmoi.sh-cloudflare-token-caddy-dns01-zot

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-terraform-provider.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-terraform-provider.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
+kind: Token
+metadata:
+  name: chezmoi-sh-terraform-provider
+  namespace: crossplane
+spec:
+  forProvider:
+    accountId: 00736631322131f61ce95f2c235143da
+    name: (chezmoi.sh) - terraform-provider
+    policies:
+    - effect: allow
+      permissionGroups:
+      - id: c8fed203ed3043cba015a93ad1616f1f
+      - id: 4755a26eedb94da69e1066d98aa820be
+      - id: 3030687196b94b638145a3953da2b699
+      - id: fb6778dc191143babbfaa57993f1d275
+      resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
+    - effect: allow
+      permissionGroups:
+      - id: c1fde68c7bcc44588cbb6ddbc16d6480
+      - id: 56907406c3d548ed902070ec4df0e328
+      resources: '{"com.cloudflare.api.account.00736631322131f61ce95f2c235143da":"*"}'
+  writeConnectionSecretToRef:
+    name: chezmoi.sh-cloudflare-token-terraform-provider

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/amazonses.chezmoi.sh.v1alpha1.DomainIdentity.chezmoi.sh.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/amazonses.chezmoi.sh.v1alpha1.DomainIdentity.chezmoi.sh.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: amazonses.chezmoi.sh/v1alpha1
+kind: DomainIdentity
+metadata:
+  labels:
+    crossplane.chezmoi.sh/project: nex.rpi
+  name: chezmoi.sh
+spec:
+  compositionRef:
+    name: cloudflare.xdomainidentities.amazonses.chezmoi.sh
+  dnsOptions:
+    dmarcOptions:
+      policy: none
+  domain: chezmoi.sh
+  mailFrom: amazonses
+  providerConfigRefs:
+    aws:
+      region: us-east-1
+    cloudflare:
+      zoneIdSelector:
+        matchLabels:
+          cf.chezmoi.sh/zone: chezmoi.sh

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.CompositeResourceDefinition.xdomainidentities.amazonses.chezmoi.sh.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.CompositeResourceDefinition.xdomainidentities.amazonses.chezmoi.sh.yaml
@@ -1,0 +1,129 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: xdomainidentities.amazonses.chezmoi.sh
+spec:
+  claimNames:
+    categories:
+    - crossplane
+    - chezmoidotsh
+    kind: DomainIdentity
+    listKind: DomainIdentityList
+    plural: domainidentities
+    singular: domainidentity
+  defaultCompositeDeletePolicy: Foreground
+  group: amazonses.chezmoi.sh
+  names:
+    categories:
+    - crossplane
+    - chezmoidotsh
+    kind: XDomainIdentity
+    listKind: XDomainIdentityList
+    plural: xdomainidentities
+    singular: xdomainidentity
+  versions:
+  - name: v1alpha1
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              dnsOptions:
+                description: |
+                  Options for the DNS provider to use for managing resources. Depending on the DNS provider, this may include additional configuration options.
+                properties:
+                  dmarcOptions:
+                    description: |
+                      Options for the DMARC DNS record.
+                    properties:
+                      policy:
+                        default: none
+                        description: |
+                          The DMARC policy to use for the DMARC DNS record.
+                        enum:
+                        - none
+                        - quarantine
+                        - reject
+                        example: none
+                        type: string
+                      rua:
+                        description: |
+                          The email address to send aggregate reports to for the DMARC DNS record.
+                        type: string
+                    type: object
+                type: object
+              domain:
+                description: |
+                  The domain name to use for the SES domain identity. Must be a valid domain name.
+                example: chezmoi.sh
+                pattern: ^[a-zA-Z0-9.-]+$
+                type: string
+              mailFrom:
+                description: |
+                  Subdomain to use for the MAIL FROM domain identity.
+                example: ses
+                type: string
+              providerConfigRefs:
+                description: |
+                  Reference to the configurations that specify the AWS and DNS providers to use for managing resources.
+                oneOf:
+                - properties: null
+                  required:
+                  - aws
+                  - cloudflare
+                properties:
+                  aws:
+                    description: |
+                      Reference to the configuration that specifies the AWS provider to use for managing resources.
+                    properties:
+                      name:
+                        description: Name of the AWS provider configuration to use.
+                        example: default
+                        type: string
+                      region:
+                        description: |
+                          The AWS region to use for the SES domain identity. Must be a valid AWS region.
+                        example: eu-west-3
+                        pattern: ^[a-z]{2}-[a-z]+-\d+$
+                        type: string
+                    required:
+                    - region
+                    type: object
+                  cloudflare:
+                    description: |
+                      Reference to the configuration that specifies the Cloudflare provider to use for managing resources.
+                    properties:
+                      name:
+                        description: Name of the Cloudflare provider configuration
+                          to use.
+                        example: default
+                        type: string
+                      zoneIdSelector:
+                        description: |
+                          Selector for the Cloudflare zone to use for managing resources.
+                        properties:
+                          matchLabels:
+                            additionalProperties:
+                              description: |
+                                Label key and value to match on the Cloudflare zone to use for managing resources.
+                              type: string
+                            description: |
+                              Labels to match on the Cloudflare zone to use for managing resources.
+                            type: object
+                        required:
+                        - matchLabels
+                        type: object
+                    required:
+                    - zoneIdSelector
+                    type: object
+                type: object
+            required:
+            - domain
+            - providerConfigRefs
+            type: object
+        type: object
+    served: true

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.CompositeResourceDefinition.xlocalclustervaults.vault.chezmoi.sh.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.CompositeResourceDefinition.xlocalclustervaults.vault.chezmoi.sh.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    app.kubernetes.io/component: crossplane-xrd
+    app.kubernetes.io/name: clustervault
+    app.kubernetes.io/part-of: vault-integration
+    catalog.chezmoi.sh/category: vault
+    catalog.chezmoi.sh/type: crossplane
+  name: xlocalclustervaults.vault.chezmoi.sh
+spec:
+  claimNames:
+    categories:
+    - crossplane
+    - chezmoidotsh
+    kind: LocalClusterVault
+    listKind: LocalClusterVaultList
+    plural: localclustervaults
+    singular: localclustervault
+  defaultCompositeDeletePolicy: Foreground
+  group: vault.chezmoi.sh
+  names:
+    categories:
+    - crossplane
+    - chezmoidotsh
+    kind: XLocalClusterVault
+    listKind: XLocalClusterVaultList
+    plural: xlocalclustervaults
+    singular: xlocalclustervault
+  versions:
+  - name: v1alpha1
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              additionalPolicies:
+                default: []
+                description: |
+                  List of additional policies to create and add to ESO tokenPolicies.
+                items:
+                  type: string
+                type: array
+              name:
+                description: |
+                  The name of the local Kubernetes cluster to integrate with OpenBao.
+                example: local
+                type: string
+              providerConfigRef:
+                description: |
+                  Reference to the ProviderConfig to use for OpenBao resources.
+                properties:
+                  name:
+                    default: default
+                    description: |
+                      Name of the ProviderConfig.
+                    type: string
+                type: object
+            required:
+            - name
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Standard Kubernetes conditions
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - type
+                  - status
+                  type: object
+                type: array
+              mountPoint:
+                description: The OpenBao mount path for this cluster
+                type: string
+              roles:
+                description: List of roles created for this cluster
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.CompositeResourceDefinition.xremoteclustervaults.vault.chezmoi.sh.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.CompositeResourceDefinition.xremoteclustervaults.vault.chezmoi.sh.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    app.kubernetes.io/component: crossplane-xrd
+    app.kubernetes.io/name: clustervault
+    app.kubernetes.io/part-of: vault-integration
+    catalog.chezmoi.sh/category: vault
+    catalog.chezmoi.sh/type: crossplane
+  name: xremoteclustervaults.vault.chezmoi.sh
+spec:
+  claimNames:
+    categories:
+    - crossplane
+    - chezmoidotsh
+    kind: RemoteClusterVault
+    listKind: RemoteClusterVaultList
+    plural: remoteclustervaults
+    singular: remoteclustervault
+  defaultCompositeDeletePolicy: Foreground
+  group: vault.chezmoi.sh
+  names:
+    categories:
+    - crossplane
+    - chezmoidotsh
+    kind: XRemoteClusterVault
+    listKind: XRemoteClusterVaultList
+    plural: xremoteclustervaults
+    singular: xremoteclustervault
+  versions:
+  - name: v1alpha1
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              additionalPolicies:
+                default: []
+                description: |
+                  List of additional policies to create and add to ESO tokenPolicies.
+                items:
+                  type: string
+                type: array
+              host:
+                description: |
+                  The address of the Kubernetes cluster (API server endpoint).
+                example: https://kubernetes:6443
+                type: string
+              name:
+                description: |
+                  The name of the Kubernetes cluster to integrate with OpenBao.
+                example: amiya.akn
+                type: string
+              providerConfigRef:
+                description: |
+                  Reference to the ProviderConfig to use for OpenBao resources.
+                properties:
+                  name:
+                    default: default
+                    description: |
+                      Name of the ProviderConfig.
+                    type: string
+                type: object
+            required:
+            - name
+            - host
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Standard Kubernetes conditions
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - type
+                  - status
+                  type: object
+                type: array
+              mountPoint:
+                description: The OpenBao mount path for this cluster
+                type: string
+              roles:
+                description: List of roles created for this cluster
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.CompositeResourceDefinition.xtailscaledclustervaults.vault.chezmoi.sh.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.CompositeResourceDefinition.xtailscaledclustervaults.vault.chezmoi.sh.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    app.kubernetes.io/component: crossplane-xrd
+    app.kubernetes.io/name: clustervault
+    app.kubernetes.io/part-of: vault-integration
+    catalog.chezmoi.sh/category: vault
+    catalog.chezmoi.sh/type: crossplane
+  name: xtailscaledclustervaults.vault.chezmoi.sh
+spec:
+  claimNames:
+    categories:
+    - crossplane
+    - chezmoidotsh
+    kind: TailscaledClusterVault
+    listKind: TailscaledClusterVaultList
+    plural: tailscaledclustervaults
+    singular: tailscaledclustervault
+  defaultCompositeDeletePolicy: Foreground
+  group: vault.chezmoi.sh
+  names:
+    categories:
+    - crossplane
+    - chezmoidotsh
+    kind: XTailscaledClusterVault
+    listKind: XTailscaledClusterVaultList
+    plural: xtailscaledclustervaults
+    singular: xtailscaledclustervault
+  versions:
+  - name: v1alpha1
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              additionalPolicies:
+                default: []
+                description: List of additional policies to assign to the ESO role
+                items:
+                  type: string
+                type: array
+              host:
+                description: The Tailscale address of the Kubernetes cluster (API
+                  server endpoint)
+                type: string
+              name:
+                description: The name of the Tailscaled Kubernetes cluster
+                type: string
+              providerConfigRef:
+                description: Reference to the ProviderConfig for OpenBao resources
+                properties:
+                  name:
+                    default: default
+                    description: Name of the ProviderConfig
+                    type: string
+                type: object
+            required:
+            - name
+            - host
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Standard Kubernetes conditions
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - type
+                  - status
+                  type: object
+                type: array
+              mountPoint:
+                description: The OpenBao mount path for this cluster
+                type: string
+              roles:
+                description: List of roles created for this cluster
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.Composition.cloudflare.xdomainidentities.amazonses.chezmoi.sh.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.Composition.cloudflare.xdomainidentities.amazonses.chezmoi.sh.yaml
@@ -1,0 +1,166 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: cloudflare.xdomainidentities.amazonses.chezmoi.sh
+spec:
+  compositeTypeRef:
+    apiVersion: amazonses.chezmoi.sh/v1alpha1
+    kind: XDomainIdentity
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          {{- if not (hasKey $xr.spec.providerConfigRefs "cloudflare") }}
+            {{- fail "Cloudflare provider configuration is required for SES domain mail from" }}
+          {{- end }}
+          ---
+          apiVersion: dns.upjet-cloudflare.m.upbound.io/v1alpha1
+          kind: Record
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: CloudflareTXTDMARC
+            name: {{ $xr.spec.domain | replace "." "-" }}-txt-dmarc
+            namespace: crossplane
+          spec:
+            forProvider:
+              zoneId: 2734d7b22cf00222046320ed3187cb94
+              name: _dmarc.{{ $xr.spec.domain }}
+              type: TXT
+              content: '"v=DMARC1; p={{ $xr.spec.dnsOptions.dmarcOptions.policy | default "none" }}; {{- with $xr.spec.dnsOptions.dmarcOptions.rua }} rua={{ . }};{{ end }}"'
+              comment: (Crossplane) DMARC record for {{ $xr.spec.domain }}
+      kind: GoTemplate
+      source: Inline
+    step: create-ses-mail-records
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          {{- if not (hasKey $xr.spec.providerConfigRefs "cloudflare") }}
+            {{- fail "Cloudflare provider configuration is required for SES domain mail from" }}
+          {{- end }}
+          ---
+          apiVersion: ses.aws.upbound.io/v1beta1
+          kind: DomainIdentity
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: AmazonSESDomainIdentity
+            name: {{ $xr.spec.domain }}
+          spec:
+            forProvider:
+              region: {{ $xr.spec.providerConfigRefs.aws.region }}
+            {{- with $xr.spec.providerConfigRefs.aws.name }}
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRefs.aws.name }}
+            {{- end }}
+          ---
+          apiVersion: ses.aws.upbound.io/v1beta1
+          kind: DomainDKIM
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: AmazonSESDomainDKIM
+            name: {{ $xr.spec.domain }}
+          spec:
+            forProvider:
+              region: {{ $xr.spec.providerConfigRefs.aws.region }}
+            {{- with $xr.spec.providerConfigRefs.aws.name }}
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRefs.aws.name }}
+            {{- end }}
+          ---
+          {{- $dkimTokens := (index ($.observed.resources | default dict) "AmazonSESDomainDKIM").resource.status.atProvider.dkimTokens }}
+          {{- range $i, $dkimToken := (index ($.observed.resources | default dict) "AmazonSESDomainDKIM").resource.status.atProvider.dkimTokens }}
+          ---
+          apiVersion: dns.upjet-cloudflare.m.upbound.io/v1alpha1
+          kind: Record
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: CloudflareDKIMRecord{{ $i }}
+            name: cname-{{ $dkimToken }}-domainkey-{{ $xr.spec.domain | replace "." "-" }}
+            namespace: crossplane
+          spec:
+            forProvider:
+              zoneId: 2734d7b22cf00222046320ed3187cb94
+              name: {{ $dkimToken }}._domainkey.{{ $xr.spec.domain }}
+              type: CNAME
+              content: {{ $dkimToken }}.dkim.amazonses.com
+              comment: (Crossplane) AWS SES DKIM record for {{ $xr.spec.domain }}
+          {{- end }}
+      kind: GoTemplate
+      source: Inline
+    step: create-ses-domain-identity
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          {{- if $xr.spec.mailFrom }}
+          {{- if not (hasKey $xr.spec.providerConfigRefs "cloudflare") }}
+            {{- fail "Cloudflare provider configuration is required for SES domain mail from" }}
+          {{- end }}
+          ---
+          apiVersion: ses.aws.upbound.io/v1beta1
+          kind: DomainMailFrom
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: AmazonSESDomainMailFrom
+            name: {{ $xr.spec.domain }}-domain-mailfrom
+          spec:
+            forProvider:
+              domain: {{ $xr.spec.domain }}
+              mailFromDomain: {{ $xr.spec.mailFrom }}.{{ $xr.spec.domain }}
+              region: {{ $xr.spec.providerConfigRefs.aws.region }}
+            {{- with $xr.spec.providerConfigRefs.aws.name }}
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRefs.aws.name }}
+            {{- end }}
+          ---
+          apiVersion: dns.upjet-cloudflare.m.upbound.io/v1alpha1
+          kind: Record
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: CloudflareMXSES
+            name: {{ $xr.spec.mailFrom | replace "." "-" }}-{{ $xr.spec.domain | replace "." "-" }}-mx-mailfrom
+            namespace: crossplane
+          spec:
+            forProvider:
+              zoneId: 2734d7b22cf00222046320ed3187cb94
+              name: {{ $xr.spec.mailFrom }}.{{ $xr.spec.domain }}
+              type: MX
+              content: feedback-smtp.{{ $xr.spec.providerConfigRefs.aws.region }}.amazonses.com
+              priority: 10
+              comment: (Crossplane) AWS SES MX record for {{ $xr.spec.domain }}
+          {{- end }}
+          ---
+          apiVersion: dns.upjet-cloudflare.m.upbound.io/v1alpha1
+          kind: Record
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: CloudflareTXTMailFromSPF
+            name: {{ $xr.spec.domain | replace "." "-" }}-txt-spf-mailfrom
+            namespace: crossplane
+          spec:
+            forProvider:
+              zoneId: 2734d7b22cf00222046320ed3187cb94
+              name: {{ $xr.spec.mailFrom }}.{{ $xr.spec.domain }}
+              type: TXT
+              content: '"v=spf1 include:amazonses.com ~all"'
+              comment: (Crossplane) AWS SES SPF record for {{ $xr.spec.domain }}
+      kind: GoTemplate
+      source: Inline
+    step: create-ses-domain-mail-from
+  - functionRef:
+      name: function-auto-ready
+    step: wait-for-resources

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.Composition.openbao.xlocalclustervaults.vault.chezmoi.sh.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.Composition.openbao.xlocalclustervaults.vault.chezmoi.sh.yaml
@@ -1,0 +1,176 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    app.kubernetes.io/component: crossplane-xrd
+    app.kubernetes.io/name: clustervault
+    app.kubernetes.io/part-of: vault-integration
+    catalog.chezmoi.sh/category: vault
+    catalog.chezmoi.sh/type: crossplane
+  name: openbao.xlocalclustervaults.vault.chezmoi.sh
+spec:
+  compositeTypeRef:
+    apiVersion: vault.chezmoi.sh/v1alpha1
+    kind: XLocalClusterVault
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          ---
+          apiVersion: vault.vault.upbound.io/v1alpha1
+          kind: Mount
+          metadata:
+            annotations:
+              crossplane.io/external-name: {{ $xr.spec.name }}
+              gotemplating.fn.crossplane.io/composition-resource-name: VaultMount
+            name: {{ $xr.spec.name }}
+          spec:
+            deletionPolicy: Orphan
+            forProvider:
+              description: kv v2 mount for local cluster {{ $xr.spec.name }}
+              options:
+                version: "2"
+              path: {{ $xr.spec.name }}
+              type: kv
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: create-vault-mount
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          ---
+          apiVersion: auth.vault.upbound.io/v1alpha1
+          kind: Backend
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: AuthBackend
+            name: {{ $xr.spec.name }}
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              path: {{ $xr.spec.name }}
+              type: kubernetes
+              description: kubernetes auth backend for cluster {{ $xr.spec.name }}
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: create-auth-backend
+  - functionRef:
+      name: function-auto-ready
+    step: wait-for-backend
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          ---
+          apiVersion: kubernetes.vault.upbound.io/v1alpha1
+          kind: AuthBackendConfig
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: AuthBackendConfig
+            name: {{ $xr.spec.name }}-config
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              backendRef:
+                name: {{ $xr.spec.name }}
+              kubernetesHost: https://kubernetes.default.svc.cluster.local
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: configure-auth-backend
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          {{ $clusterName := $xr.spec.name }}
+          ---
+          # ESO Policy
+          apiVersion: vault.vault.upbound.io/v1alpha1
+          kind: Policy
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: ESOPolicy
+            name: {{ $clusterName }}-eso-policy
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              name: {{ $clusterName }}-eso-policy
+              policy: |
+                # Allow ESO to read all secrets in the project path
+                path "{{ $clusterName }}/*" { capabilities = ["read"] }
+
+                # Allow ESO to read all secrets in the shared/third-parties path
+                path "shared/+/third-parties/+/+/{{ $clusterName }}" { capabilities = ["read"] }
+                path "shared/+/third-parties/+/+/{{ $clusterName }}/*" { capabilities = ["read"] }
+
+                # Allow ESO to read all secrets in the shared/certificates path
+                path "shared/+/certificates/*" { capabilities = ["read"] }
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: create-policies
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          {{ $clusterName := $xr.spec.name }}
+          {{ $additionalPolicies := $xr.spec.additionalPolicies | default (list) }}
+          ---
+          # ESO Role
+          apiVersion: kubernetes.vault.upbound.io/v1alpha1
+          kind: AuthBackendRole
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: ESORole
+            name: {{ $clusterName }}-eso-role
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              backend: {{ $clusterName }}
+              roleName: {{ $clusterName }}-eso-role
+              boundServiceAccountNames:
+                - external-secrets
+              boundServiceAccountNamespaces:
+                - external-secrets-system
+              tokenPolicies:
+                - {{ $clusterName }}-eso-policy
+              {{- range $policy := $additionalPolicies }}
+                - {{ $policy }}
+              {{- end }}
+              tokenTtl: 900
+              tokenMaxTtl: 1800
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: create-auth-roles
+  - functionRef:
+      name: function-auto-ready
+    step: wait-for-resources

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.Composition.openbao.xremoteclustervaults.vault.chezmoi.sh.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.Composition.openbao.xremoteclustervaults.vault.chezmoi.sh.yaml
@@ -1,0 +1,205 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    app.kubernetes.io/component: crossplane-xrd
+    app.kubernetes.io/name: clustervault
+    app.kubernetes.io/part-of: vault-integration
+    catalog.chezmoi.sh/category: vault
+    catalog.chezmoi.sh/type: crossplane
+  name: openbao.xremoteclustervaults.vault.chezmoi.sh
+spec:
+  compositeTypeRef:
+    apiVersion: vault.chezmoi.sh/v1alpha1
+    kind: XRemoteClusterVault
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-extra-resources
+    input:
+      apiVersion: extra-resources.fn.crossplane.io/v1beta1
+      kind: Input
+      spec:
+        extraResources:
+        - apiVersion: v1
+          into: kubernetes-reviewer-secrets
+          kind: Secret
+          selector:
+            matchLabels:
+            - key: vault.crossplane.chezmoi.sh/cluster-name
+              type: FromCompositeFieldPath
+              valueFromFieldPath: spec.name
+            maxMatch: 1
+            minMatch: 1
+          type: Selector
+    step: fetch-ca-cert-secret
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          ---
+          apiVersion: vault.vault.upbound.io/v1alpha1
+          kind: Mount
+          metadata:
+            annotations:
+              crossplane.io/external-name: {{ $xr.spec.name }}
+              gotemplating.fn.crossplane.io/composition-resource-name: VaultMount
+            name: {{ $xr.spec.name }}
+          spec:
+            deletionPolicy: Orphan
+            forProvider:
+              description: kv v2 mount for remote cluster {{ $xr.spec.name }}
+              options:
+                version: "2"
+              path: {{ $xr.spec.name }}
+              type: kv
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: create-vault-mount
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          ---
+          apiVersion: auth.vault.upbound.io/v1alpha1
+          kind: Backend
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: AuthBackend
+            name: {{ $xr.spec.name }}
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              path: {{ $xr.spec.name }}
+              type: kubernetes
+              description: kubernetes auth backend for cluster {{ $xr.spec.name }}
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: create-auth-backend
+  - functionRef:
+      name: function-auto-ready
+    step: wait-for-backend
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          ---
+          apiVersion: kubernetes.vault.upbound.io/v1alpha1
+          kind: AuthBackendConfig
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: AuthBackendConfig
+
+            name: {{ $xr.spec.name }}-config
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              backendRef:
+                name: {{ $xr.spec.name }}
+              kubernetesHost: {{ $xr.spec.host }}
+              disableLocalCaJwt: true
+              {{- $kubernetesReviewerSecrets := index (index .context "apiextensions.crossplane.io/extra-resources") "kubernetes-reviewer-secrets" }}
+              {{- $secret := index $kubernetesReviewerSecrets 0 }}
+              kubernetesCaCert: |- {{ index $secret.data "ca.crt" | b64dec | nindent 6 }}
+              tokenReviewerJwtSecretRef:
+                key: token
+                name: {{ $secret.metadata.name }}
+                namespace: {{ $secret.metadata.namespace }}
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: configure-auth-backend
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          {{ $clusterName := $xr.spec.name }}
+          {{ $enableSharedAccess := $xr.spec.enableSharedAccess | default true }}
+          ---
+          apiVersion: vault.vault.upbound.io/v1alpha1
+          kind: Policy
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: ESOPolicy
+            name: {{ $clusterName }}-eso-policy
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              name: {{ $clusterName }}-eso-policy
+              policy: |
+                # Allow ESO to read all secrets in the project path
+                path "{{ $clusterName }}/*" { capabilities = ["read"] }
+                {{- if $enableSharedAccess }}
+
+                # Allow ESO to read all secrets in the shared/third-parties path scoped to this cluster
+                path "shared/+/third-parties/+/+/{{ $clusterName }}" { capabilities = ["read"] }
+                path "shared/+/third-parties/+/+/{{ $clusterName }}/*" { capabilities = ["read"] }
+
+                # Allow ESO to read all secrets in the shared/certificates path
+                path "shared/+/certificates/*" { capabilities = ["read"] }
+                {{- end }}
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: create-eso-policy
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          {{ $clusterName := $xr.spec.name }}
+          {{ $additionalPolicies := $xr.spec.additionalPolicies | default (list) }}
+          ---
+          apiVersion: kubernetes.vault.upbound.io/v1alpha1
+          kind: AuthBackendRole
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: ESORole
+            name: {{ $clusterName }}-eso-role
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              backend: {{ $clusterName }}
+              roleName: {{ $clusterName }}-eso-role
+              boundServiceAccountNames:
+                - external-secrets
+              boundServiceAccountNamespaces:
+                - external-secrets-system
+              tokenPolicies:
+                - {{ $clusterName }}-eso-policy
+              {{- range $policy := $additionalPolicies }}
+                - {{ $policy }}
+              {{- end }}
+              tokenTtl: 900
+              tokenMaxTtl: 1800
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: create-eso-role
+  - functionRef:
+      name: function-auto-ready
+    step: wait-for-resources

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.Composition.openbao.xtailscaledclustervaults.vault.chezmoi.sh.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/apiextensions.crossplane.io.v1.Composition.openbao.xtailscaledclustervaults.vault.chezmoi.sh.yaml
@@ -1,0 +1,174 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    app.kubernetes.io/component: crossplane-xrd
+    app.kubernetes.io/name: clustervault
+    app.kubernetes.io/part-of: vault-integration
+    catalog.chezmoi.sh/category: vault
+    catalog.chezmoi.sh/type: crossplane
+  name: openbao.xtailscaledclustervaults.vault.chezmoi.sh
+spec:
+  compositeTypeRef:
+    apiVersion: vault.chezmoi.sh/v1alpha1
+    kind: XTailscaledClusterVault
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          ---
+          apiVersion: vault.vault.upbound.io/v1alpha1
+          kind: Mount
+          metadata:
+            annotations:
+              crossplane.io/external-name: {{ $xr.spec.name }}
+              gotemplating.fn.crossplane.io/composition-resource-name: VaultMount
+            name: {{ $xr.spec.name }}
+          spec:
+            deletionPolicy: Orphan
+            forProvider:
+              description: kv v2 mount for Tailscaled cluster {{ $xr.spec.name }}
+              options:
+                version: "2"
+              path: {{ $xr.spec.name }}
+              type: kv
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: create-vault-mount
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          ---
+          apiVersion: auth.vault.upbound.io/v1alpha1
+          kind: Backend
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: AuthBackend
+            name: {{ $xr.spec.name }}
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              path: {{ $xr.spec.name }}
+              type: kubernetes
+              description: kubernetes auth backend for Tailscaled cluster {{ $xr.spec.name }}
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: create-auth-backend
+  - functionRef:
+      name: function-auto-ready
+    step: wait-for-backend
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          ---
+          apiVersion: kubernetes.vault.upbound.io/v1alpha1
+          kind: AuthBackendConfig
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: AuthBackendConfig
+            name: {{ $xr.spec.name }}-config
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              backendRef:
+                name: {{ $xr.spec.name }}
+              kubernetesHost: {{ $xr.spec.host }}
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: configure-auth-backend
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          {{ $clusterName := $xr.spec.name }}
+          ---
+          apiVersion: vault.vault.upbound.io/v1alpha1
+          kind: Policy
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: ESOPolicy
+            name: {{ $clusterName }}-eso-policy
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              name: {{ $clusterName }}-eso-policy
+              policy: |
+                # Allow ESO to read all secrets in the project path
+                path "{{ $clusterName }}/*" { capabilities = ["read"] }
+
+                # Allow ESO to read all secrets in the shared/third-parties path scoped to this cluster
+                path "shared/+/third-parties/+/+/{{ $clusterName }}" { capabilities = ["read"] }
+                path "shared/+/third-parties/+/+/{{ $clusterName }}/*" { capabilities = ["read"] }
+
+                # Allow ESO to read all secrets in the shared/certificates path
+                path "shared/+/certificates/*" { capabilities = ["read"] }
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: create-eso-policy
+  - functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      inline:
+        template: |
+          {{ $xr := getCompositeResource . }}
+          {{ $clusterName := $xr.spec.name }}
+          {{ $additionalPolicies := $xr.spec.additionalPolicies | default (list) }}
+          ---
+          apiVersion: kubernetes.vault.upbound.io/v1alpha1
+          kind: AuthBackendRole
+          metadata:
+            annotations:
+              gotemplating.fn.crossplane.io/composition-resource-name: ESORole
+            name: {{ $clusterName }}-eso-role
+          spec:
+            deletionPolicy: Delete
+            forProvider:
+              backend: {{ $clusterName }}
+              roleName: {{ $clusterName }}-eso-role
+              boundServiceAccountNames:
+                - external-secrets
+              boundServiceAccountNamespaces:
+                - external-secrets-system
+              tokenPolicies:
+                - {{ $clusterName }}-eso-policy
+              {{- range $policy := $additionalPolicies }}
+                - {{ $policy }}
+              {{- end }}
+              tokenTtl: 900
+              tokenMaxTtl: 1800
+            providerConfigRef:
+              name: {{ $xr.spec.providerConfigRef.name | default "default" }}
+      kind: GoTemplate
+      source: Inline
+    step: create-eso-role
+  - functionRef:
+      name: function-auto-ready
+    step: wait-for-resources

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/aws.upbound.io.v1beta1.ProviderConfig.default.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/aws.upbound.io.v1beta1.ProviderConfig.default.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    secretRef:
+      key: aws-credentials.txt
+      name: aws-credentials
+      namespace: crossplane
+    source: Secret

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1.ExternalSecret.aws-credentials.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1.ExternalSecret.aws-credentials.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: aws-credentials
+spec:
+  data:
+  - remoteRef:
+      key: shared/third-parties/aws/iam/chezmoi.sh/crossplane-rw
+      property: access_key_id
+    secretKey: access_key_id
+  - remoteRef:
+      key: shared/third-parties/aws/iam/chezmoi.sh/crossplane-rw
+      property: secret_access_key
+    secretKey: secret_access_key
+  refreshInterval: 720h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  target:
+    name: aws-credentials
+    template:
+      data:
+        aws-credentials.txt: |
+          [default]
+          aws_access_key_id = "{{ .access_key_id }}"
+          aws_secret_access_key = "{{ .secret_access_key }}"
+          region = eu-west-3
+      engineVersion: v2
+      type: Opaque

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1.ExternalSecret.cloudflare-credentials.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1.ExternalSecret.cloudflare-credentials.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-credentials
+spec:
+  data:
+  - remoteRef:
+      key: shared/third-parties/cloudflare/iam/chezmoi.sh/crossplane-rw
+      property: email
+    secretKey: email
+  - remoteRef:
+      key: shared/third-parties/cloudflare/iam/chezmoi.sh/crossplane-rw
+      property: api_key
+    secretKey: api_key
+  refreshInterval: 720h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  target:
+    name: cloudflare-credentials
+    template:
+      data:
+        credentials: '{"email":"{{ .email }}","api_key":"{{ .api_key }}"}'
+      engineVersion: v2
+      type: Opaque

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1.ExternalSecret.cloudflare-terraform-credentials.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1.ExternalSecret.cloudflare-terraform-credentials.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-terraform-credentials
+spec:
+  data:
+  - remoteRef:
+      key: shared/third-parties/cloudflare/iam/chezmoi.sh/terraform-provider
+      property: api_token
+    secretKey: api_token
+  refreshInterval: 720h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  target:
+    name: cloudflare-terraform-credentials
+    template:
+      data:
+        terraform.tfvars.json: |
+          {
+            "api_token": "{{ .api_token }}"
+          }
+      engineVersion: v2
+      type: Opaque

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1.ExternalSecret.kazimierz-terraform-credentials.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1.ExternalSecret.kazimierz-terraform-credentials.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kazimierz-terraform-credentials
+spec:
+  data:
+  - remoteRef:
+      key: shared/third-parties/cloudflare/iam/chezmoi.sh/terraform-provider
+      property: api_token
+    secretKey: cloudflare_api_token
+  - remoteRef:
+      key: shared/third-parties/hetznercloud/iam/arcane/terraform-provider
+      property: api_token
+    secretKey: hcloud_api_token
+  refreshInterval: 720h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  target:
+    name: kazimierz-terraform-credentials
+    template:
+      data:
+        terraform.tfvars.json: |
+          {
+            "cloudflare_api_token": "{{ .cloudflare_api_token }}",
+            "hcloud_api_token": "{{ .hcloud_api_token }}"
+          }
+      engineVersion: v2
+      type: Opaque

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1.ExternalSecret.tailscale-credentials.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1.ExternalSecret.tailscale-credentials.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tailscale-credentials
+spec:
+  dataFrom:
+  - extract:
+      key: amiya.akn/crossplane/providers/tailscale
+  refreshInterval: 720h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  target:
+    template:
+      data:
+        terraform.tfvars.json: |
+          {
+            "oauth_client_id": "{{ .oauth_client_id }}",
+            "oauth_client_secret": "{{ .oauth_client_secret }}"
+          }
+      engineVersion: v2
+      type: Opaque

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.chezmoi.sh-cloudflare-token-terraform-provider.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.chezmoi.sh-cloudflare-token-terraform-provider.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: chezmoi.sh-cloudflare-token-terraform-provider
+  namespace: crossplane
+spec:
+  data:
+  - conversionStrategy: None
+    match:
+      remoteRef:
+        property: api_token
+        remoteKey: shared/data/third-parties/cloudflare/iam/chezmoi.sh/terraform-provider
+      secretKey: attribute.value
+  refreshInterval: 1h
+  secretStoreRefs:
+  - kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  selector:
+    secret:
+      name: chezmoi.sh-cloudflare-token-terraform-provider
+  template:
+    metadata:
+      annotations:
+        description: Cloudflare API Token for Terraform provider
+        origin: crossplane
+        owner: chezmoi.sh
+        renewal-process: |
+          Remove the chezmoi-sh-terraform-provider Token then wait ArgoCD to create a new one.

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.provider-aws-iam.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.provider-aws-iam.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-iam
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-iam:v2.6.0
+  runtimeConfigRef:
+    name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.provider-aws-ses.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.provider-aws-ses.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-ses
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-ses:v2.6.0
+  runtimeConfigRef:
+    name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.provider-terraform.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.provider-terraform.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-terraform
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.1.1
+  runtimeConfigRef:
+    name: hardened-for-terraform

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.upbound-provider-family-aws.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.upbound-provider-family-aws.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: upbound-provider-family-aws
+spec:
+  package: xpkg.upbound.io/upbound/provider-family-aws:v2.6.0
+  runtimeConfigRef:
+    name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.upbound-provider-vault.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.upbound-provider-vault.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: upbound-provider-vault
+spec:
+  package: xpkg.upbound.io/upbound/provider-vault:v3.0.7
+  runtimeConfigRef:
+    name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.wildbitca-provider-cloudflare-account.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.wildbitca-provider-cloudflare-account.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: wildbitca-provider-cloudflare-account
+spec:
+  package: xpkg.upbound.io/wildbitca/provider-cloudflare-account:v0.2.6
+  runtimeConfigRef:
+    name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.wildbitca-provider-cloudflare-dns.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.wildbitca-provider-cloudflare-dns.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: wildbitca-provider-cloudflare-dns
+spec:
+  package: xpkg.upbound.io/wildbitca/provider-cloudflare-dns:v0.2.6
+  runtimeConfigRef:
+    name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.wildbitca-provider-cloudflare-zone.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.wildbitca-provider-cloudflare-zone.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: wildbitca-provider-cloudflare-zone
+spec:
+  package: xpkg.upbound.io/wildbitca/provider-cloudflare-zone:v0.2.6
+  runtimeConfigRef:
+    name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.wildbitca-provider-family-cloudflare.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1.Provider.wildbitca-provider-family-cloudflare.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: wildbitca-provider-family-cloudflare
+spec:
+  package: xpkg.upbound.io/wildbitca/provider-family-cloudflare:v0.2.6
+  runtimeConfigRef:
+    name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.DeploymentRuntimeConfig.hardened-for-terraform.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.DeploymentRuntimeConfig.hardened-for-terraform.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: hardened-for-terraform
+spec:
+  deploymentTemplate:
+    spec:
+      selector: {}
+      template:
+        spec:
+          containers:
+          - env:
+            - name: TF_PLUGIN_CACHE_DIR
+              value: /tmp
+            - name: XP_TF_DIR
+              value: /tmp
+            name: package-runtime
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              privileged: false
+              readOnlyRootFilesystem: true
+            volumeMounts:
+            - mountPath: /tmp
+              name: tmpdir
+          securityContext:
+            fsGroup: 48291
+            runAsGroup: 48291
+            runAsNonRoot: true
+            runAsUser: 48291
+            seccompProfile:
+              type: RuntimeDefault
+          volumes:
+          - emptyDir: {}
+            name: tmpdir

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.DeploymentRuntimeConfig.hardened.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.DeploymentRuntimeConfig.hardened.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: hardened
+spec:
+  deploymentTemplate:
+    spec:
+      selector: {}
+      template:
+        spec:
+          containers:
+          - name: package-runtime
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              privileged: false
+              readOnlyRootFilesystem: true
+            volumeMounts:
+            - mountPath: /tmp
+              name: tmpdir
+          securityContext:
+            fsGroup: 48291
+            runAsGroup: 48291
+            runAsNonRoot: true
+            runAsUser: 48291
+            seccompProfile:
+              type: RuntimeDefault
+          volumes:
+          - emptyDir: {}
+            name: tmpdir

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.Function.function-auto-ready.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.Function.function-auto-ready.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-auto-ready
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.6.5
+  runtimeConfigRef:
+    name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.Function.function-extra-resources.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.Function.function-extra-resources.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-extra-resources
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.3.0
+  runtimeConfigRef:
+    name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.Function.function-go-templating.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.Function.function-go-templating.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-go-templating
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.12.1
+  runtimeConfigRef:
+    name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/tf.upbound.io.v1beta1.ProviderConfig.cloudflare.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/tf.upbound.io.v1beta1.ProviderConfig.cloudflare.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: tf.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: cloudflare
+spec:
+  configuration: |
+    // Modules _must_ use remote state. The provider does not persist state.
+    terraform {
+      backend "kubernetes" {
+        secret_suffix     = "providerconfig-cloudflare"
+        namespace         = "crossplane"
+        in_cluster_config = true
+      }
+    }
+
+    // Install Cloudflare provider
+    variable "api_token" { type = string }
+
+    terraform {
+      required_providers {
+        cloudflare = {
+          source  = "cloudflare/cloudflare"
+          version = "~> 5.0"
+        }
+      }
+    }
+
+    provider "cloudflare" {
+      api_token = var.api_token
+    }
+  credentials:
+  - filename: terraform.tfvars.json
+    secretRef:
+      key: terraform.tfvars.json
+      name: cloudflare-terraform-credentials
+      namespace: crossplane
+    source: Secret

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/tf.upbound.io.v1beta1.ProviderConfig.default.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/tf.upbound.io.v1beta1.ProviderConfig.default.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: tf.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  configuration: |
+    // Modules _must_ use remote state. The provider does not persist state.
+    terraform {
+      backend "kubernetes" {
+        secret_suffix     = "providerconfig-default"
+        namespace         = "crossplane"
+        in_cluster_config = true
+      }
+    }

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/tf.upbound.io.v1beta1.ProviderConfig.kazimierz.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/tf.upbound.io.v1beta1.ProviderConfig.kazimierz.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: tf.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: kazimierz
+spec:
+  configuration: |
+    // Modules _must_ use remote state. The provider does not persist state.
+    terraform {
+      backend "kubernetes" {
+        secret_suffix     = "providerconfig-kazimierz" // checkov:skip=CKV_SECRET_6:This is not a secret
+        namespace         = "crossplane"
+        in_cluster_config = true
+      }
+    }
+
+    // Install required providers for kazimierz
+    variable "cloudflare_api_token" { type = string }
+    variable "hcloud_api_token" { type = string }
+
+    terraform {
+      required_providers {
+        cloudflare = {
+          source  = "cloudflare/cloudflare"
+          version = "~> 5.0"
+        }
+        hcloud = {
+          source  = "hetznercloud/hcloud"
+          version = "~> 1.0"
+        }
+      }
+    }
+
+    provider "cloudflare" {
+      api_token = var.cloudflare_api_token
+    }
+
+    provider "hcloud" {
+      token = var.hcloud_api_token
+    }
+  credentials:
+  - filename: terraform.tfvars.json
+    secretRef:
+      key: terraform.tfvars.json
+      name: kazimierz-terraform-credentials
+      namespace: crossplane
+    source: Secret

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/tf.upbound.io.v1beta1.ProviderConfig.tailscale.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/tf.upbound.io.v1beta1.ProviderConfig.tailscale.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: tf.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: tailscale
+spec:
+  configuration: |
+    // Modules _must_ use remote state. The provider does not persist state.
+    terraform {
+      backend "kubernetes" {
+        secret_suffix     = "providerconfig-tailscale"
+        namespace         = "crossplane"
+        in_cluster_config = true
+      }
+    }
+
+    // Install Tailscale provider
+    variable "oauth_client_id" { type = string }
+    variable "oauth_client_secret" { type = string }
+
+    terraform {
+      required_providers {
+        tailscale = {
+          source  = "tailscale/tailscale"
+          version = "0.21.1"
+        }
+      }
+    }
+
+    provider "tailscale" {
+      oauth_client_id = var.oauth_client_id
+      oauth_client_secret = var.oauth_client_secret
+    }
+  credentials:
+  - filename: terraform.tfvars.json
+    secretRef:
+      key: terraform.tfvars.json
+      name: tailscale-credentials
+      namespace: crossplane
+    source: Secret

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/tf.upbound.io.v1beta1.Workspace.observability-tailscale-oauth-client.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/tf.upbound.io.v1beta1.Workspace.observability-tailscale-oauth-client.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: tf.upbound.io/v1beta1
+kind: Workspace
+metadata:
+  name: observability-tailscale-oauth-client
+spec:
+  forProvider:
+    module: |
+      resource "tailscale_oauth_client" "self" {
+        description = "OAuth client for the o11y LXC"
+        scopes      = ["auth_keys"]
+        tags        = ["tag:o11y"]
+      }
+
+      output "client_id" {
+        description = "OAuth Client ID"
+        value       = tailscale_oauth_client.self.id
+      }
+
+      output "client_secret" {
+        sensitive   = true
+        description = "OAuth Client Secret"
+        value       = tailscale_oauth_client.self.key
+      }
+    source: Inline
+  providerConfigRef:
+    name: tailscale
+  writeConnectionSecretToRef:
+    name: observability-tailscale-oauth-client
+    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/upjet-cloudflare.m.upbound.io.v1beta1.ClusterProviderConfig.default.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/upjet-cloudflare.m.upbound.io.v1beta1.ClusterProviderConfig.default.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: upjet-cloudflare.m.upbound.io/v1beta1
+kind: ClusterProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    secretRef:
+      key: credentials
+      name: cloudflare-credentials
+      namespace: crossplane
+    source: Secret

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/vault.upbound.io.v1beta1.ProviderConfig.default.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/vault.upbound.io.v1beta1.ProviderConfig.default.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: vault.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  address: http://openbao.vault.svc.cluster.local:8200
+  role: crossplane-provisioning

--- a/scripts/dist:render
+++ b/scripts/dist:render
@@ -149,6 +149,14 @@ def find_app_dirs() -> list[Path]:
             dirs.append(kust.parent)
     for kust in REPO_ROOT.glob("projects/*/src/argocd/kustomization.yaml"):
         dirs.append(kust.parent)
+    for kust in REPO_ROOT.glob(
+        "projects/*/src/infrastructure/crossplane/kustomization.yaml"
+    ):
+        dirs.append(kust.parent)
+    for kust in REPO_ROOT.glob(
+        "projects/*/src/infrastructure/crossplane/providers/*/kustomization.yaml"
+    ):
+        dirs.append(kust.parent)
     return sorted(dirs)
 
 
@@ -160,7 +168,8 @@ def find_staged_dirs() -> list[Path]:
         text=True,
     )
     pattern = re.compile(
-        r"^(projects/[^/]+/src/(?:(?:apps|infrastructure/kubernetes)/[^/]+|argocd))/"
+        r"^(projects/[^/]+/src/(?:(?:apps|infrastructure/kubernetes)/[^/]+|argocd"
+        r"|infrastructure/crossplane(?:/providers/[^/]+)?))/"
     )
     seen: set[str] = set()
     dirs: list[Path] = []


### PR DESCRIPTION
## Summary

Applies the dist/ rendered manifests pattern to Crossplane infrastructure in `projects/chezmoi.sh`, matching the pattern already used for apps and in-cluster Kubernetes resources since issue #990. ArgoCD previously deployed Crossplane resources directly from `src/`, which meant provider version bumps produced no readable diff in PRs and all 820+ resources appeared under a single ArgoCD application.

**Related Issue:** #1061

## Rationale

The dist/ pattern was intentionally scoped to apps and in-cluster infra when it was introduced (#990). Crossplane resources were left as-is because they are mostly static YAML — but that gap has two real costs:

1. **No upgrade diffability**: Renovate bumps a version field in `src/`, but the actual CRD/RBAC changes that Crossplane installs at runtime are invisible in the PR diff.
2. **Prerequisite for the provider split**: issue #1060 requires splitting providers into separate ArgoCD apps, which in turn requires the generator to point at a stable dist/ tree rather than the raw `src/`.

## Changes Made

### `dist:render` — crossplane discovery

- **[`scripts/dist:render`](scripts/dist:render)** — Extended `find_app_dirs()` to glob `projects/*/src/infrastructure/crossplane/kustomization.yaml` roots; added a second glob for `providers/*/kustomization.yaml` (pre-emptive, consumed by issue #1060). Extended the staged-files regex in `find_staged_dirs()` to match both the crossplane root and provider subdirectory paths so the pre-commit hook re-renders the right target.

### ApplicationSet — path switch to `dist/`

- **[`projects/amiya.akn/src/apps/crossplane/crossplane.applicationset.yaml`](projects/amiya.akn/src/apps/crossplane/crossplane.applicationset.yaml)** — Generator path changed from `projects/*/src/infrastructure/crossplane` to `projects/*/dist/infrastructure/crossplane`. Added an `exclude: true` entry for `projects/*/dist/infrastructure/crossplane/*/*` to prevent the generator from matching provider sub-directories introduced in issue #1060.
- **[`projects/amiya.akn/dist/apps/crossplane/argoproj.io.v1alpha1.ApplicationSet.crossplane.yaml`](projects/amiya.akn/dist/apps/crossplane/argoproj.io.v1alpha1.ApplicationSet.crossplane.yaml)** — Re-rendered dist output of the ApplicationSet above.

### Initial rendered output

- **`projects/chezmoi.sh/dist/infrastructure/crossplane/`** — 41 pre-rendered YAML files covering all Crossplane providers, ProviderConfigs, ExternalSecrets, DeploymentRuntimeConfigs, Functions, XRDs, Compositions, and claim resources declared in `src/`.

## Technical Impact

### Architecture Simplification

| Before | After |
| ------ | ----- |
| ArgoCD reads `src/` directly; no static manifests committed | ArgoCD reads pre-rendered `dist/`; full manifest tree committed |
| Provider version bumps invisible in PR diff | Bumping a provider version re-renders `dist/` and diffs CRD/RBAC changes |
| `dist:render` ignored crossplane directories | `dist:render --all` and `--staged-only` both handle crossplane |

### Security Boundary Preservation

All existing ProviderConfigs, ExternalSecrets, and network-level resources are faithfully reproduced in `dist/` — no secrets are committed, only ESO `ExternalSecret` references to OpenBao paths.

### Behavioural Changes

None at the Kubernetes level. ArgoCD applies the same resources from `dist/` that kustomize would have produced at sync time from `src/`. `ServerSideApply` remains in use.

### Migration Path

On the first ArgoCD sync after this PR merges, the `crossplane-chezmoi.sh` Application's `path` field updates from `src/` to `dist/`. ArgoCD performs a diff against live cluster state; resources that already exist will show no diff and remain in sync.

### Next Steps

Issue #1060 — split provider families into separate ArgoCD Applications — is the immediate follow-up and can be implemented on top of this `dist/` foundation.

## Testing Validation

- [ ] `dist:render --check --all` reports no stale directories
- [ ] `crossplane-chezmoi.sh` ArgoCD app syncs cleanly after the path switch
- [ ] All ProviderConfigs, ExternalSecrets, and Providers remain `Synced`
- [ ] Renovate-generated provider version bump produces a visible diff in `dist/`

## Related Issues

Closes #1061

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
