### PR TITLE
Revert crossplane AppSet to single per-project generator

### DIFF
--- a/projects/amiya.akn/dist/apps/crossplane/argoproj.io.v1alpha1.ApplicationSet.crossplane.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/argoproj.io.v1alpha1.ApplicationSet.crossplane.yaml
@@ -20,11 +20,6 @@ spec:
         path: projects/*/dist/infrastructure/crossplane/*/*
       repoURL: https://github.com/chezmoidotsh/arcane.git
       revision: main
-  - git:
-      directories:
-      - path: projects/*/dist/infrastructure/crossplane/providers/*
-      repoURL: https://github.com/chezmoidotsh/arcane.git
-      revision: main
   goTemplate: true
   goTemplateOptions:
   - missingkey=error
@@ -42,8 +37,7 @@ spec:
         source-ref.argocd.argoproj.io/0.path: '{{ .path.path }}'
         source-ref.argocd.argoproj.io/0.repository-url: https://github.com/chezmoidotsh/arcane.git
         source-ref.argocd.argoproj.io/0.target-revision: main
-      name: crossplane-{{ index .path.segments 1 }}{{- if gt (len .path.segments)
-        5 }}-{{ index .path.segments 6 }}{{ end -}}
+      name: crossplane-{{ index .path.segments 1 }}
     spec:
       destination:
         namespace: crossplane

--- a/projects/amiya.akn/src/apps/crossplane/crossplane.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/crossplane/crossplane.applicationset.yaml
@@ -24,11 +24,6 @@ spec:
           - path: projects/*/dist/infrastructure/crossplane
           - path: projects/*/dist/infrastructure/crossplane/*/*
             exclude: true
-    - git:
-        repoURL: https://github.com/chezmoidotsh/arcane.git
-        revision: main
-        directories:
-          - path: projects/*/dist/infrastructure/crossplane/providers/*
   syncPolicy:
     # Always preserve Applications on deletion of ApplicationSet
     preserveResourcesOnDeletion: true
@@ -43,7 +38,7 @@ spec:
         source-ref.argocd.argoproj.io/0.repository-url: https://github.com/chezmoidotsh/arcane.git
         source-ref.argocd.argoproj.io/0.target-revision: main
 
-      name: crossplane-{{ index .path.segments 1 }}{{- if gt (len .path.segments) 5 }}-{{ index .path.segments 6 }}{{ end -}}
+      name: crossplane-{{ index .path.segments 1 }}
     spec:
       destination:
         server: https://kubernetes.default.svc


### PR DESCRIPTION
## Summary

Reverts the crossplane `ApplicationSet` to the single-generator pattern that
existed before PR 1065 (Split Crossplane providers into per-family ArgoCD apps).

The providers generator added in that PR introduced conditional name logic
(`if gt (len .path.segments) 5`) that only matched `projects/chezmoi.sh/dist/`
paths, silently dropping app generation for all other clusters (hass,
lungmen.akn, kazimierz.akn, amiya.akn).

## Rationale

The per-provider AppSet architecture needs to be redesigned as a dedicated
second `ApplicationSet` rather than a second generator in the same template.
This revert unblocks cluster app generation while the clean architecture is
implemented.

## Changes Made

### ApplicationSet — crossplane

- **[`projects/amiya.akn/src/apps/crossplane/crossplane.applicationset.yaml`](projects/amiya.akn/src/apps/crossplane/crossplane.applicationset.yaml)** — Remove the providers generator and revert name template to `crossplane-{{ index .path.segments 1 }}`
- **[`projects/amiya.akn/dist/apps/crossplane/argoproj.io.v1alpha1.ApplicationSet.crossplane.yaml`](projects/amiya.akn/dist/apps/crossplane/argoproj.io.v1alpha1.ApplicationSet.crossplane.yaml)** — Regenerated dist

### Removed

- Second `git` generator for `projects/*/dist/infrastructure/crossplane/providers/*`
- Conditional name suffix logic `{{- if gt (len .path.segments) 5 }}-{{ index .path.segments 6 }}{{ end -}}`

## Technical Impact

### Behavioural Changes

The five provider-specific ArgoCD applications (`crossplane-chezmoi.sh-aws`,
`-cloudflare`, `-terraform`, `-vault`) will no longer be generated by the
AppSet after ArgoCD syncs. They currently exist as orphaned apps and will
need manual cleanup or a dedicated providers AppSet to be re-adopted.

### Architecture Simplification

| Before (broken) | After (reverted) |
| --------------- | ---------------- |
| Single AppSet, 2 generators, complex conditional name | Single AppSet, 1 generator, simple name |
| Only `chezmoi.sh` apps generated | All projects with `dist/infrastructure/crossplane` get an app |

## Testing Validation

- [x] `dist:render` reflects the change
- [ ] ArgoCD `crossplane` ApplicationSet generates `crossplane-chezmoi.sh` app
- [ ] Provider-specific apps (`crossplane-chezmoi.sh-cloudflare` etc.) remain until pruned

## Related Issues

Addresses regression introduced in PR 1065

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
