### PR TITLE
Add dedicated crossplane-providers ApplicationSet

### DIFF
--- a/projects/amiya.akn/dist/apps/crossplane/argoproj.io.v1alpha1.ApplicationSet.crossplane-providers.yaml
+++ b/projects/amiya.akn/dist/apps/crossplane/argoproj.io.v1alpha1.ApplicationSet.crossplane-providers.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  annotations:
+    argocd.argoproj.io/description: |
+      This ApplicationSet is responsible for automatically deploying all
+      Crossplane provider resources, one ArgoCD app per provider family.
+  labels:
+    app.kubernetes.io/instance: crossplane
+    app.kubernetes.io/name: crossplane
+  name: crossplane-providers
+  namespace: argocd
+spec:
+  generators:
+  - git:
+      directories:
+      - path: projects/*/dist/infrastructure/crossplane/providers/*
+      repoURL: https://github.com/chezmoidotsh/arcane.git
+      revision: main
+  goTemplate: true
+  goTemplateOptions:
+  - missingkey=error
+  ignoreApplicationDifferences:
+  - jqPathExpressions:
+    - .spec.source.targetRevision
+    - .spec.sources[].targetRevision
+    - .spec.syncPolicy.automated
+  syncPolicy:
+    preserveResourcesOnDeletion: true
+  template:
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-wave: "50"
+        source-ref.argocd.argoproj.io/0.path: '{{ .path.path }}'
+        source-ref.argocd.argoproj.io/0.repository-url: https://github.com/chezmoidotsh/arcane.git
+        source-ref.argocd.argoproj.io/0.target-revision: main
+      name: crossplane-{{ index .path.segments 1 }}-{{ index .path.segments 6 }}
+    spec:
+      destination:
+        namespace: crossplane
+        server: https://kubernetes.default.svc
+      project: crossplane
+      sources:
+      - path: '{{ .path.path }}'
+        repoURL: https://github.com/chezmoidotsh/arcane.git
+        targetRevision: main
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+        - Delete=confirm
+        - Prune=confirm
+        - ServerSideApply=true

--- a/projects/amiya.akn/src/apps/crossplane/crossplane-providers.applicationset.yaml
+++ b/projects/amiya.akn/src/apps/crossplane/crossplane-providers.applicationset.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  annotations:
+    argocd.argoproj.io/description: |
+      This ApplicationSet is responsible for automatically deploying all
+      Crossplane provider resources, one ArgoCD app per provider family.
+  name: crossplane-providers
+  namespace: argocd
+spec:
+  ignoreApplicationDifferences:
+    - jqPathExpressions:
+        - .spec.source.targetRevision
+        - .spec.sources[].targetRevision
+        - .spec.syncPolicy.automated
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - git:
+        repoURL: https://github.com/chezmoidotsh/arcane.git
+        revision: main
+        directories:
+          - path: projects/*/dist/infrastructure/crossplane/providers/*
+  syncPolicy:
+    # Always preserve Applications on deletion of ApplicationSet
+    preserveResourcesOnDeletion: true
+  template:
+    metadata:
+      annotations:
+        # Provider apps should be deployed before crossplane resources
+        argocd.argoproj.io/sync-wave: "50"
+
+        # Source reference for argocd-extension-application-map
+        source-ref.argocd.argoproj.io/0.path: "{{ .path.path }}"
+        source-ref.argocd.argoproj.io/0.repository-url: https://github.com/chezmoidotsh/arcane.git
+        source-ref.argocd.argoproj.io/0.target-revision: main
+
+      name: crossplane-{{ index .path.segments 1 }}-{{ index .path.segments 6 }}
+    spec:
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: crossplane
+      project: crossplane
+      sources:
+        - repoURL: https://github.com/chezmoidotsh/arcane.git
+          path: "{{ .path.path }}"
+          targetRevision: main
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - Delete=confirm
+          - Prune=confirm
+          - ServerSideApply=true

--- a/projects/amiya.akn/src/apps/crossplane/kustomization.yaml
+++ b/projects/amiya.akn/src/apps/crossplane/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 
   # Crossplane x ArgoCD
   - crossplane.applicationset.yaml
+  - crossplane-providers.applicationset.yaml
 
 helmCharts:
   - repo: https://charts.crossplane.io/stable


### PR DESCRIPTION
## Summary

Adds a dedicated `crossplane-providers` ApplicationSet to manage the
per-provider-family ArgoCD apps that were previously generated by the
second generator in the main `crossplane` AppSet (removed in PR 1067).

This completes the two-AppSet architecture: one AppSet per project for
crossplane resources, one dedicated AppSet for providers.

## Rationale

PR 1067 reverted the combined AppSet to restore per-project app generation.
This PR adds back the providers coverage as a standalone ApplicationSet,
keeping the two concerns cleanly separated and each AppSet's template simple.

## Changes Made

### New ApplicationSet — crossplane-providers

- **[`projects/amiya.akn/src/apps/crossplane/crossplane-providers.applicationset.yaml`](projects/amiya.akn/src/apps/crossplane/crossplane-providers.applicationset.yaml)** — Dedicated AppSet matching `projects/*/dist/infrastructure/crossplane/providers/*`, naming apps `crossplane-<project>-<provider>`, sync-wave 50 (before crossplane resources at wave 100)
- **[`projects/amiya.akn/src/apps/crossplane/kustomization.yaml`](projects/amiya.akn/src/apps/crossplane/kustomization.yaml)** — Include the new ApplicationSet
- **[`projects/amiya.akn/dist/apps/crossplane/argoproj.io.v1alpha1.ApplicationSet.crossplane-providers.yaml`](projects/amiya.akn/dist/apps/crossplane/argoproj.io.v1alpha1.ApplicationSet.crossplane-providers.yaml)** — Rendered dist

## Technical Impact

### Architecture Simplification

| AppSet | Pattern | Generated apps |
| ------ | ------- | -------------- |
| `crossplane` | `projects/*/dist/infrastructure/crossplane` | `crossplane-<project>` |
| `crossplane-providers` | `projects/*/dist/infrastructure/crossplane/providers/*` | `crossplane-<project>-<provider>` |

### Behavioural Changes

Provider apps (`crossplane-chezmoi.sh-aws`, `-cloudflare`, `-terraform`,
`-vault`) will be re-adopted by the new AppSet after ArgoCD syncs. No
downtime expected — the apps already exist and match the generated names.

## Testing Validation

- [ ] ArgoCD generates `crossplane-providers` ApplicationSet after sync
- [ ] Four provider apps re-adopted: `crossplane-chezmoi.sh-{aws,cloudflare,terraform,vault}`
- [ ] Main `crossplane-chezmoi.sh` app unaffected

## Related Issues

Completes the work started in PR 1067

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
