### PR TITLE
Consolidate Crossplane Cloudflare token secrets in crossplane-secrets

### DIFF
--- a/projects/amiya.akn/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.amiyaakn-chezmoi-sh-cert-manager.yaml
+++ b/projects/amiya.akn/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.amiyaakn-chezmoi-sh-cert-manager.yaml
@@ -16,3 +16,4 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: amiya.akn-cloudflare-token-certmanager
+    namespace: crossplane-secrets

--- a/projects/amiya.akn/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.amiyaakn-chezmoi-sh-cloudflare-operator.yaml
+++ b/projects/amiya.akn/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.amiyaakn-chezmoi-sh-cloudflare-operator.yaml
@@ -20,3 +20,4 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: amiya.akn-cloudflare-token-cloudflare-operator
+    namespace: crossplane-secrets

--- a/projects/amiya.akn/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.amiya.akn-cloudflare-token-certmanager.yaml
+++ b/projects/amiya.akn/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.amiya.akn-cloudflare-token-certmanager.yaml
@@ -3,7 +3,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: amiya.akn-cloudflare-token-certmanager
-  namespace: amiya-akn
+  namespace: crossplane-secrets
 spec:
   data:
   - conversionStrategy: None

--- a/projects/amiya.akn/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.amiya.akn-cloudflare-token-cloudflare-operator.yaml
+++ b/projects/amiya.akn/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.amiya.akn-cloudflare-token-cloudflare-operator.yaml
@@ -3,7 +3,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: amiya.akn-cloudflare-token-cloudflare-operator
-  namespace: amiya-akn
+  namespace: crossplane-secrets
 spec:
   data:
   - conversionStrategy: None

--- a/projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml
+++ b/projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml
@@ -10,8 +10,8 @@
 #     scoped to zone 2734d7b22cf00222046320ed3187cb94 (chezmoi.sh) only
 #
 # Security:
-#   The connection secret lands in the amiya-akn namespace (same as the Token)
-#   and is synchronized to Vault (vault.chezmoi.sh) via the co-located PushSecret.
+#   The connection secret lands in the crossplane-secrets namespace and is
+#   synchronized to Vault (vault.chezmoi.sh) via the co-located PushSecret.
 #
 # trunk-ignore-all(checkov/CKV2_K8S_5,trivy/KSV113): this is a policy to allow a specific user to use a specific secrets... so it's fine
 ---
@@ -32,12 +32,13 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: amiya.akn-cloudflare-token-certmanager
+    namespace: crossplane-secrets
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: amiya.akn-cloudflare-token-certmanager
-  namespace: amiya-akn
+  namespace: crossplane-secrets
 spec:
   refreshInterval: 1h
   secretStoreRefs:

--- a/projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cloudflare-operator.yaml
+++ b/projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cloudflare-operator.yaml
@@ -13,9 +13,9 @@
 #
 # Security:
 #   Two-policy split prevents account-level permission groups from reaching zone
-#   resources (and vice versa). The connection secret lands in the amiya-akn
-#   namespace (same as the Token) and is synchronized to Vault (vault.chezmoi.sh)
-#   via the co-located PushSecret.
+#   resources (and vice versa). The connection secret lands in the crossplane-secrets
+#   namespace and is synchronized to Vault (vault.chezmoi.sh) via the co-located
+#   PushSecret.
 ---
 apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
 kind: Token
@@ -38,12 +38,13 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: amiya.akn-cloudflare-token-cloudflare-operator
+    namespace: crossplane-secrets
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: amiya.akn-cloudflare-token-cloudflare-operator
-  namespace: amiya-akn
+  namespace: crossplane-secrets
 spec:
   refreshInterval: 1h
   secretStoreRefs:

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-o11y.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-o11y.yaml
@@ -16,3 +16,4 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-o11y
+    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-omni.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-omni.yaml
@@ -16,3 +16,4 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-caddy-dns01-omni
+    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-zot.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-zot.yaml
@@ -16,3 +16,4 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-caddy-dns01-zot
+    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-terraform-provider.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-terraform-provider.yaml
@@ -23,3 +23,4 @@ spec:
       resources: '{"com.cloudflare.api.account.00736631322131f61ce95f2c235143da":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-terraform-provider
+    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.chezmoi.sh-cloudflare-token-terraform-provider.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.chezmoi.sh-cloudflare-token-terraform-provider.yaml
@@ -3,7 +3,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: chezmoi.sh-cloudflare-token-terraform-provider
-  namespace: crossplane
+  namespace: crossplane-secrets
 spec:
   data:
   - conversionStrategy: None

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.observability.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.observability.yaml
@@ -10,9 +10,9 @@
 #     scoped to zone 2734d7b22cf00222046320ed3187cb94 (chezmoi.sh) only
 #
 # Security:
-#   No account-level permissions. The connection secret lands in the crossplane
-#   namespace (same as the Token); retrieve it with:
-#     kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-o11y \
+#   No account-level permissions. The connection secret lands in the
+#   crossplane-secrets namespace; retrieve it with:
+#     kubectl get secret -n crossplane-secrets chezmoi.sh-cloudflare-token-o11y \
 #       -o jsonpath='{.data.attribute\.value}' | base64 -d
 ---
 apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
@@ -32,3 +32,4 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-o11y
+    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.oci-registry.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.oci-registry.yaml
@@ -10,9 +10,9 @@
 #     scoped to zone 2734d7b22cf00222046320ed3187cb94 (chezmoi.sh) only
 #
 # Security:
-#   No account-level permissions. The connection secret lands in the crossplane
-#   namespace (same as the Token); retrieve it with:
-#     kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-caddy-dns01-zot \
+#   No account-level permissions. The connection secret lands in the
+#   crossplane-secrets namespace; retrieve it with:
+#     kubectl get secret -n crossplane-secrets chezmoi.sh-cloudflare-token-caddy-dns01-zot \
 #       -o jsonpath='{.data.attribute\.value}' | base64 -d
 ---
 apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
@@ -32,3 +32,4 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-caddy-dns01-zot
+    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.omni.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.omni.yaml
@@ -10,9 +10,9 @@
 #     scoped to zone 2734d7b22cf00222046320ed3187cb94 (chezmoi.sh) only
 #
 # Security:
-#   No account-level permissions. The connection secret lands in the crossplane
-#   namespace (same as the Token); retrieve it with:
-#     kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-caddy-dns01-omni \
+#   No account-level permissions. The connection secret lands in the
+#   crossplane-secrets namespace; retrieve it with:
+#     kubectl get secret -n crossplane-secrets chezmoi.sh-cloudflare-token-caddy-dns01-omni \
 #       -o jsonpath='{.data.attribute\.value}' | base64 -d
 ---
 apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
@@ -32,3 +32,4 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-caddy-dns01-omni
+    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.terraform-provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.terraform-provider.yaml
@@ -12,9 +12,9 @@
 #
 # Security:
 #   Two-policy split prevents zone-level permission groups from reaching account
-#   resources (and vice versa). The connection secret lands in the crossplane
-#   namespace (same as the Token) and is synchronized to Vault (vault.chezmoi.sh)
-#   via the co-located PushSecret.
+#   resources (and vice versa). The connection secret lands in the crossplane-secrets
+#   namespace and is synchronized to Vault (vault.chezmoi.sh) via the co-located
+#   PushSecret.
 ---
 apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
 kind: Token
@@ -40,12 +40,13 @@ spec:
         resources: '{"com.cloudflare.api.account.00736631322131f61ce95f2c235143da":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-terraform-provider
+    namespace: crossplane-secrets
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: chezmoi.sh-cloudflare-token-terraform-provider
-  namespace: crossplane
+  namespace: crossplane-secrets
 spec:
   refreshInterval: 1h
   secretStoreRefs:

--- a/projects/hass/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.hass-chezmoi-sh-home-assistant.yaml
+++ b/projects/hass/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.hass-chezmoi-sh-home-assistant.yaml
@@ -16,3 +16,4 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: hass-chezmoi-sh-home-assistant
+    namespace: crossplane-secrets

--- a/projects/hass/src/infrastructure/crossplane/cloudflare.iam.home-assistant.yaml
+++ b/projects/hass/src/infrastructure/crossplane/cloudflare.iam.home-assistant.yaml
@@ -16,3 +16,4 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: hass-chezmoi-sh-home-assistant
+    namespace: crossplane-secrets

--- a/projects/lungmen.akn/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.lungmenakn-chezmoi-sh-cert-manager.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.lungmenakn-chezmoi-sh-cert-manager.yaml
@@ -16,3 +16,4 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: lungmen.akn-cloudflare-token-certmanager
+    namespace: crossplane-secrets

--- a/projects/lungmen.akn/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.lungmen.akn-cloudflare-token-certmanager.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.lungmen.akn-cloudflare-token-certmanager.yaml
@@ -3,7 +3,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: lungmen.akn-cloudflare-token-certmanager
-  namespace: lungmen-akn
+  namespace: crossplane-secrets
 spec:
   data:
   - conversionStrategy: None

--- a/projects/lungmen.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml
+++ b/projects/lungmen.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml
@@ -10,8 +10,8 @@
 #     scoped to zone 2734d7b22cf00222046320ed3187cb94 (chezmoi.sh) only
 #
 # Security:
-#   The connection secret lands in the lungmen-akn namespace (same as the Token)
-#   and is synchronized to Vault (vault.chezmoi.sh) via the co-located PushSecret.
+#   The connection secret lands in the crossplane-secrets namespace and is
+#   synchronized to Vault (vault.chezmoi.sh) via the co-located PushSecret.
 #
 # trunk-ignore-all(checkov/CKV2_K8S_5,trivy/KSV113): this is a policy to allow a specific user to use a specific secrets... so it's fine
 ---
@@ -32,12 +32,13 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: lungmen.akn-cloudflare-token-certmanager
+    namespace: crossplane-secrets
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: lungmen.akn-cloudflare-token-certmanager
-  namespace: lungmen-akn
+  namespace: crossplane-secrets
 spec:
   refreshInterval: 1h
   secretStoreRefs:


### PR DESCRIPTION
## Summary

Consolidates all Crossplane-generated Cloudflare API token connection secrets into the `crossplane-secrets` namespace, aligning with the pattern already established by Tailscale OAuth tokens. PushSecrets are co-relocated so ESO can read the connection secrets it forwards to Vault.

## Rationale

Previously, connection secrets landed in the Token resource's own namespace (`amiya-akn`, `crossplane`, `lungmen-akn`), scattering Crossplane-managed secrets across operational namespaces. Centralizing them in `crossplane-secrets` provides a single audit point for all Crossplane-produced credentials and matches the convention already used by `amiya.akn.tailscale-oauth.yaml`, `argotails.tailscale-oauth.yaml`, and `lungmen.akn.tailscale-oauth.yaml`.

## Changes Made

### `projects/amiya.akn`

- **[`cloudflare.iam.cert-manager.yaml`](projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml)** — `writeConnectionSecretToRef.namespace: crossplane-secrets`; PushSecret moved from `amiya-akn` to `crossplane-secrets`
- **[`cloudflare.iam.cloudflare-operator.yaml`](projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cloudflare-operator.yaml)** — same

### `projects/chezmoi.sh`

- **[`cloudflare.iam.observability.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.observability.yaml)** — `writeConnectionSecretToRef.namespace: crossplane-secrets` (no PushSecret)
- **[`cloudflare.iam.oci-registry.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.oci-registry.yaml)** — same
- **[`cloudflare.iam.omni.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.omni.yaml)** — same
- **[`cloudflare.iam.terraform-provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.terraform-provider.yaml)** — `writeConnectionSecretToRef.namespace: crossplane-secrets`; PushSecret moved from `crossplane` to `crossplane-secrets`

### `projects/lungmen.akn`

- **[`cloudflare.iam.cert-manager.yaml`](projects/lungmen.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml)** — `writeConnectionSecretToRef.namespace: crossplane-secrets`; PushSecret moved from `lungmen-akn` to `crossplane-secrets`

### `projects/hass`

- **[`cloudflare.iam.home-assistant.yaml`](projects/hass/src/infrastructure/crossplane/cloudflare.iam.home-assistant.yaml)** — `writeConnectionSecretToRef.namespace: crossplane-secrets` (no PushSecret; not yet deployed by any ArgoCD app)

### `dist/` re-rendered

- `projects/amiya.akn/dist/infrastructure/crossplane/` — 4 files updated
- `projects/chezmoi.sh/dist/infrastructure/crossplane/` — 5 files updated
- `projects/lungmen.akn/dist/infrastructure/crossplane/` — 2 files updated

## Technical Impact

### Architecture Simplification

| Before | After |
| ------ | ----- |
| Token connection secrets scattered across `amiya-akn`, `crossplane`, `lungmen-akn` | All connection secrets land in `crossplane-secrets` |
| PushSecrets spread across 3 operational namespaces | PushSecrets co-located in `crossplane-secrets` |

### Security Boundary Preservation

The `crossplane-secrets` namespace already exists (created by the crossplane app kustomization) and is already used by Tailscale OAuth resources. ESO's `ClusterSecretStore` (`vault.chezmoi.sh`) is cluster-scoped and continues to push the secrets to Vault unchanged. Network policies are unaffected — Crossplane Token resources write their connection secrets via the controller plane, not via network calls into the namespace.

### Behavioural Changes

Live Crossplane Token resources will re-write their connection secrets into `crossplane-secrets` on the next reconcile. The secrets previously created in the old namespaces (`amiya-akn`, `crossplane`, `lungmen-akn`) will remain as orphans until manually cleaned up. If any consumer pulls these secrets directly from those namespaces (rather than via Vault), it will need updating before the old secrets are deleted.

### Migration Path

1. ArgoCD syncs this PR → Crossplane reconciles Tokens → new connection secrets written to `crossplane-secrets`
2. PushSecrets in `crossplane-secrets` push the secrets to Vault
3. Verify: `kubectl get secret -n crossplane-secrets <name>`
4. Manual cleanup: delete orphaned secrets in old namespaces once Vault paths are confirmed populated

## Testing Validation

- [x] `trunk check --filter=-conftest` reports no new issues
- [x] `dist:render` succeeds for all 3 affected projects
- [ ] Crossplane reconciles Tokens and writes secrets to `crossplane-secrets`
- [ ] PushSecrets in `crossplane-secrets` reach `Synced` status and Vault paths are populated
- [ ] Consumers pulling from Vault (cert-manager, cloudflare-operator, Caddy) are unaffected

## Related Issues

Part of the crossplane secret namespace consolidation discussed alongside PR 1067.

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
