### PR TITLE
Fix ArgoCD diff failure on wildbitca Cloudflare Token resources

### DIFF
--- a/projects/amiya.akn/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.amiyaakn-chezmoi-sh-cert-manager.yaml
+++ b/projects/amiya.akn/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.amiyaakn-chezmoi-sh-cert-manager.yaml
@@ -16,4 +16,3 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: amiya.akn-cloudflare-token-certmanager
-    namespace: crossplane-secrets

--- a/projects/amiya.akn/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.amiyaakn-chezmoi-sh-cloudflare-operator.yaml
+++ b/projects/amiya.akn/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.amiyaakn-chezmoi-sh-cloudflare-operator.yaml
@@ -20,4 +20,3 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: amiya.akn-cloudflare-token-cloudflare-operator
-    namespace: crossplane-secrets

--- a/projects/amiya.akn/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.amiya.akn-cloudflare-token-certmanager.yaml
+++ b/projects/amiya.akn/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.amiya.akn-cloudflare-token-certmanager.yaml
@@ -3,7 +3,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: amiya.akn-cloudflare-token-certmanager
-  namespace: crossplane-secrets
+  namespace: amiya-akn
 spec:
   data:
   - conversionStrategy: None

--- a/projects/amiya.akn/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.amiya.akn-cloudflare-token-cloudflare-operator.yaml
+++ b/projects/amiya.akn/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.amiya.akn-cloudflare-token-cloudflare-operator.yaml
@@ -3,7 +3,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: amiya.akn-cloudflare-token-cloudflare-operator
-  namespace: crossplane-secrets
+  namespace: amiya-akn
 spec:
   data:
   - conversionStrategy: None

--- a/projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml
+++ b/projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml
@@ -10,7 +10,7 @@
 #     scoped to zone 2734d7b22cf00222046320ed3187cb94 (chezmoi.sh) only
 #
 # Security:
-#   The connection secret lands in the crossplane-secrets namespace and is
+#   The connection secret lands in the amiya-akn namespace and is
 #   synchronized to Vault (vault.chezmoi.sh) via the co-located PushSecret.
 #
 # trunk-ignore-all(checkov/CKV2_K8S_5,trivy/KSV113): this is a policy to allow a specific user to use a specific secrets... so it's fine
@@ -32,13 +32,12 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: amiya.akn-cloudflare-token-certmanager
-    namespace: crossplane-secrets
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: amiya.akn-cloudflare-token-certmanager
-  namespace: crossplane-secrets
+  namespace: amiya-akn
 spec:
   refreshInterval: 1h
   secretStoreRefs:

--- a/projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cloudflare-operator.yaml
+++ b/projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cloudflare-operator.yaml
@@ -13,7 +13,7 @@
 #
 # Security:
 #   Two-policy split prevents account-level permission groups from reaching zone
-#   resources (and vice versa). The connection secret lands in the crossplane-secrets
+#   resources (and vice versa). The connection secret lands in the amiya-akn
 #   namespace and is synchronized to Vault (vault.chezmoi.sh) via the co-located
 #   PushSecret.
 ---
@@ -38,13 +38,12 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: amiya.akn-cloudflare-token-cloudflare-operator
-    namespace: crossplane-secrets
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: amiya.akn-cloudflare-token-cloudflare-operator
-  namespace: crossplane-secrets
+  namespace: amiya-akn
 spec:
   refreshInterval: 1h
   secretStoreRefs:

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-o11y.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-o11y.yaml
@@ -3,7 +3,7 @@ apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
 kind: Token
 metadata:
   name: chezmoi-sh-caddy-dns01-o11y
-  namespace: crossplane
+  namespace: chezmoi-sh
 spec:
   forProvider:
     accountId: 00736631322131f61ce95f2c235143da

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-o11y.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-o11y.yaml
@@ -16,4 +16,3 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-o11y
-    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-omni.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-omni.yaml
@@ -3,7 +3,7 @@ apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
 kind: Token
 metadata:
   name: chezmoi-sh-caddy-dns01-omni
-  namespace: crossplane
+  namespace: chezmoi-sh
 spec:
   forProvider:
     accountId: 00736631322131f61ce95f2c235143da

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-omni.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-omni.yaml
@@ -16,4 +16,3 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-caddy-dns01-omni
-    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-zot.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-zot.yaml
@@ -16,4 +16,3 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-caddy-dns01-zot
-    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-zot.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-caddy-dns01-zot.yaml
@@ -3,7 +3,7 @@ apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
 kind: Token
 metadata:
   name: chezmoi-sh-caddy-dns01-zot
-  namespace: crossplane
+  namespace: chezmoi-sh
 spec:
   forProvider:
     accountId: 00736631322131f61ce95f2c235143da

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-terraform-provider.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-terraform-provider.yaml
@@ -23,4 +23,3 @@ spec:
       resources: '{"com.cloudflare.api.account.00736631322131f61ce95f2c235143da":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-terraform-provider
-    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-terraform-provider.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.chezmoi-sh-terraform-provider.yaml
@@ -3,7 +3,7 @@ apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
 kind: Token
 metadata:
   name: chezmoi-sh-terraform-provider
-  namespace: crossplane
+  namespace: chezmoi-sh
 spec:
   forProvider:
     accountId: 00736631322131f61ce95f2c235143da

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/core.v1.Namespace.chezmoi-sh.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/core.v1.Namespace.chezmoi-sh.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chezmoi-sh

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.chezmoi.sh-cloudflare-token-terraform-provider.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.chezmoi.sh-cloudflare-token-terraform-provider.yaml
@@ -3,7 +3,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: chezmoi.sh-cloudflare-token-terraform-provider
-  namespace: crossplane-secrets
+  namespace: crossplane
 spec:
   data:
   - conversionStrategy: None

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.chezmoi.sh-cloudflare-token-terraform-provider.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.chezmoi.sh-cloudflare-token-terraform-provider.yaml
@@ -3,7 +3,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: chezmoi.sh-cloudflare-token-terraform-provider
-  namespace: crossplane
+  namespace: chezmoi-sh
 spec:
   data:
   - conversionStrategy: None

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.observability.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.observability.yaml
@@ -11,8 +11,8 @@
 #
 # Security:
 #   No account-level permissions. The connection secret lands in the
-#   crossplane-secrets namespace; retrieve it with:
-#     kubectl get secret -n crossplane-secrets chezmoi.sh-cloudflare-token-o11y \
+#   crossplane namespace; retrieve it with:
+#     kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-o11y \
 #       -o jsonpath='{.data.attribute\.value}' | base64 -d
 ---
 apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
@@ -32,4 +32,3 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-o11y
-    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.observability.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.observability.yaml
@@ -11,15 +11,15 @@
 #
 # Security:
 #   No account-level permissions. The connection secret lands in the
-#   crossplane namespace; retrieve it with:
-#     kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-o11y \
+#   chezmoi-sh namespace; retrieve it with:
+#     kubectl get secret -n chezmoi-sh chezmoi.sh-cloudflare-token-o11y \
 #       -o jsonpath='{.data.attribute\.value}' | base64 -d
 ---
 apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
 kind: Token
 metadata:
   name: chezmoi-sh-caddy-dns01-o11y
-  namespace: crossplane
+  namespace: chezmoi-sh
 spec:
   forProvider:
     name: (chezmoi.sh) - caddy-dns01/observability

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.oci-registry.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.oci-registry.yaml
@@ -11,15 +11,15 @@
 #
 # Security:
 #   No account-level permissions. The connection secret lands in the
-#   crossplane namespace; retrieve it with:
-#     kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-caddy-dns01-zot \
+#   chezmoi-sh namespace; retrieve it with:
+#     kubectl get secret -n chezmoi-sh chezmoi.sh-cloudflare-token-caddy-dns01-zot \
 #       -o jsonpath='{.data.attribute\.value}' | base64 -d
 ---
 apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
 kind: Token
 metadata:
   name: chezmoi-sh-caddy-dns01-zot
-  namespace: crossplane
+  namespace: chezmoi-sh
 spec:
   forProvider:
     name: (chezmoi.sh) - caddy-dns01/zot-registry

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.oci-registry.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.oci-registry.yaml
@@ -11,8 +11,8 @@
 #
 # Security:
 #   No account-level permissions. The connection secret lands in the
-#   crossplane-secrets namespace; retrieve it with:
-#     kubectl get secret -n crossplane-secrets chezmoi.sh-cloudflare-token-caddy-dns01-zot \
+#   crossplane namespace; retrieve it with:
+#     kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-caddy-dns01-zot \
 #       -o jsonpath='{.data.attribute\.value}' | base64 -d
 ---
 apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
@@ -32,4 +32,3 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-caddy-dns01-zot
-    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.omni.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.omni.yaml
@@ -11,8 +11,8 @@
 #
 # Security:
 #   No account-level permissions. The connection secret lands in the
-#   crossplane-secrets namespace; retrieve it with:
-#     kubectl get secret -n crossplane-secrets chezmoi.sh-cloudflare-token-caddy-dns01-omni \
+#   crossplane namespace; retrieve it with:
+#     kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-caddy-dns01-omni \
 #       -o jsonpath='{.data.attribute\.value}' | base64 -d
 ---
 apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
@@ -32,4 +32,3 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-caddy-dns01-omni
-    namespace: crossplane-secrets

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.omni.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.omni.yaml
@@ -11,15 +11,15 @@
 #
 # Security:
 #   No account-level permissions. The connection secret lands in the
-#   crossplane namespace; retrieve it with:
-#     kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-caddy-dns01-omni \
+#   chezmoi-sh namespace; retrieve it with:
+#     kubectl get secret -n chezmoi-sh chezmoi.sh-cloudflare-token-caddy-dns01-omni \
 #       -o jsonpath='{.data.attribute\.value}' | base64 -d
 ---
 apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
 kind: Token
 metadata:
   name: chezmoi-sh-caddy-dns01-omni
-  namespace: crossplane
+  namespace: chezmoi-sh
 spec:
   forProvider:
     name: (chezmoi.sh) - caddy-dns01/omni

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.terraform-provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.terraform-provider.yaml
@@ -12,7 +12,7 @@
 #
 # Security:
 #   Two-policy split prevents zone-level permission groups from reaching account
-#   resources (and vice versa). The connection secret lands in the crossplane
+#   resources (and vice versa). The connection secret lands in the chezmoi-sh
 #   namespace and is synchronized to Vault (vault.chezmoi.sh) via the co-located
 #   PushSecret.
 ---
@@ -20,7 +20,7 @@ apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
 kind: Token
 metadata:
   name: chezmoi-sh-terraform-provider
-  namespace: crossplane
+  namespace: chezmoi-sh
 spec:
   forProvider:
     name: (chezmoi.sh) - terraform-provider
@@ -45,7 +45,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: chezmoi.sh-cloudflare-token-terraform-provider
-  namespace: crossplane
+  namespace: chezmoi-sh
 spec:
   refreshInterval: 1h
   secretStoreRefs:

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.terraform-provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.terraform-provider.yaml
@@ -12,7 +12,7 @@
 #
 # Security:
 #   Two-policy split prevents zone-level permission groups from reaching account
-#   resources (and vice versa). The connection secret lands in the crossplane-secrets
+#   resources (and vice versa). The connection secret lands in the crossplane
 #   namespace and is synchronized to Vault (vault.chezmoi.sh) via the co-located
 #   PushSecret.
 ---
@@ -40,13 +40,12 @@ spec:
         resources: '{"com.cloudflare.api.account.00736631322131f61ce95f2c235143da":"*"}'
   writeConnectionSecretToRef:
     name: chezmoi.sh-cloudflare-token-terraform-provider
-    namespace: crossplane-secrets
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: chezmoi.sh-cloudflare-token-terraform-provider
-  namespace: crossplane-secrets
+  namespace: crossplane
 spec:
   refreshInterval: 1h
   secretStoreRefs:

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/kustomization.yaml
@@ -3,6 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  # Namespaces
+  - namespace.chezmoi-sh.yaml
+
   # Required modules
   - ../../../../../catalog/crossplane/domainidentity.amazonses.chezmoi.sh
   - ../../../../../catalog/crossplane/clustervault.vault.chezmoi.sh

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/namespace.chezmoi-sh.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/namespace.chezmoi-sh.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chezmoi-sh

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/.mise.toml
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/.mise.toml
@@ -55,8 +55,8 @@ run = '''
   set -euo pipefail
 
   # --- Fetch Crossplane-provisioned tokens ---------------------------------
-  echo "[INFO] Fetching Cloudflare token (crossplane/chezmoi.sh-cloudflare-token-o11y)..." >&2
-  CF_TOKEN=$(kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-o11y \
+  echo "[INFO] Fetching Cloudflare token (chezmoi-sh/chezmoi.sh-cloudflare-token-o11y)..." >&2
+  CF_TOKEN=$(kubectl get secret -n chezmoi-sh chezmoi.sh-cloudflare-token-o11y \
     -o jsonpath='{.data.attribute\.value}' | base64 -d)
   [[ -n "${CF_TOKEN}" ]] || { echo "[ERROR] Empty Cloudflare token — is the APIToken Ready?" >&2; exit 1; }
 

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/.mise.toml
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/.mise.toml
@@ -55,8 +55,8 @@ run = '''
   set -euo pipefail
 
   # --- Fetch Crossplane-provisioned tokens ---------------------------------
-  echo "[INFO] Fetching Cloudflare token (crossplane-secrets/chezmoi.sh-cloudflare-token-o11y)..." >&2
-  CF_TOKEN=$(kubectl get secret -n crossplane-secrets chezmoi.sh-cloudflare-token-o11y \
+  echo "[INFO] Fetching Cloudflare token (crossplane/chezmoi.sh-cloudflare-token-o11y)..." >&2
+  CF_TOKEN=$(kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-o11y \
     -o jsonpath='{.data.attribute\.value}' | base64 -d)
   [[ -n "${CF_TOKEN}" ]] || { echo "[ERROR] Empty Cloudflare token — is the APIToken Ready?" >&2; exit 1; }
 

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/.mise.toml
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/.mise.toml
@@ -44,16 +44,16 @@
 # so it can be baked into the LXC image at build time.
 #
 # The Crossplane APIToken resource must be Ready before running this task.
-# Check with: kubectl get apitoken chezmoi-sh-caddy-dns01-zot -n crossplane
+# Check with: kubectl get apitoken chezmoi-sh-caddy-dns01-zot -n chezmoi-sh
 
 [tasks."lxc:secrets:sync"]
 description = "Fetch Cloudflare DNS-01 token from cluster and write secrets/caddy.sops.env"
 run = '''
   set -euo pipefail
 
-  echo "[INFO] Fetching token from crossplane/chezmoi.sh-cloudflare-token-caddy-dns01-zot..." >&2
+  echo "[INFO] Fetching token from chezmoi-sh/chezmoi.sh-cloudflare-token-caddy-dns01-zot..." >&2
   TOKEN=$(
-    kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-caddy-dns01-zot \
+    kubectl get secret -n chezmoi-sh chezmoi.sh-cloudflare-token-caddy-dns01-zot \
     -o jsonpath='{.data.attribute\.value}' | base64 -d \
   )
   [[ -n "${TOKEN}" ]] || { echo "[ERROR] Empty token — is the Crossplane APIToken Ready?" >&2; exit 1; }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/.mise.toml
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/.mise.toml
@@ -51,9 +51,9 @@ description = "Fetch Cloudflare DNS-01 token from cluster and write secrets/cadd
 run = '''
   set -euo pipefail
 
-  echo "[INFO] Fetching token from crossplane-secrets/chezmoi.sh-cloudflare-token-caddy-dns01-zot..." >&2
+  echo "[INFO] Fetching token from crossplane/chezmoi.sh-cloudflare-token-caddy-dns01-zot..." >&2
   TOKEN=$(
-    kubectl get secret -n crossplane-secrets chezmoi.sh-cloudflare-token-caddy-dns01-zot \
+    kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-caddy-dns01-zot \
     -o jsonpath='{.data.attribute\.value}' | base64 -d \
   )
   [[ -n "${TOKEN}" ]] || { echo "[ERROR] Empty token — is the Crossplane APIToken Ready?" >&2; exit 1; }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/.mise.toml
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/.mise.toml
@@ -99,9 +99,9 @@ dir = "{{ config_root }}"
 run = '''
   set -euo pipefail
 
-  echo "[INFO] Fetching token from crossplane-secrets/chezmoi.sh-cloudflare-token-caddy-dns01-omni..." >&2
+  echo "[INFO] Fetching token from crossplane/chezmoi.sh-cloudflare-token-caddy-dns01-omni..." >&2
   TOKEN=$(
-    kubectl get secret -n crossplane-secrets chezmoi.sh-cloudflare-token-caddy-dns01-omni \
+    kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-caddy-dns01-omni \
     -o jsonpath='{.data.attribute\.value}' | base64 -d
   )
   [[ -n "${TOKEN}" ]] || { echo "[ERROR] Empty token — is the Crossplane APIToken Ready?" >&2; exit 1; }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/.mise.toml
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/.mise.toml
@@ -91,7 +91,7 @@ sops = "latest"
 # can be baked into the LXC image at build time.
 #
 # The Crossplane APIToken resource must be Ready before running this task.
-# Check with: kubectl get apitoken chezmoi-sh-caddy-dns01-omni -n crossplane
+# Check with: kubectl get apitoken chezmoi-sh-caddy-dns01-omni -n chezmoi-sh
 
 [tasks."lxc:secrets:sync"]
 description = "Fetch Cloudflare DNS-01 token from cluster and write secrets/caddy.sops.env"
@@ -99,9 +99,9 @@ dir = "{{ config_root }}"
 run = '''
   set -euo pipefail
 
-  echo "[INFO] Fetching token from crossplane/chezmoi.sh-cloudflare-token-caddy-dns01-omni..." >&2
+  echo "[INFO] Fetching token from chezmoi-sh/chezmoi.sh-cloudflare-token-caddy-dns01-omni..." >&2
   TOKEN=$(
-    kubectl get secret -n crossplane chezmoi.sh-cloudflare-token-caddy-dns01-omni \
+    kubectl get secret -n chezmoi-sh chezmoi.sh-cloudflare-token-caddy-dns01-omni \
     -o jsonpath='{.data.attribute\.value}' | base64 -d
   )
   [[ -n "${TOKEN}" ]] || { echo "[ERROR] Empty token — is the Crossplane APIToken Ready?" >&2; exit 1; }

--- a/projects/hass/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.hass-chezmoi-sh-home-assistant.yaml
+++ b/projects/hass/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.hass-chezmoi-sh-home-assistant.yaml
@@ -3,7 +3,7 @@ apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
 kind: Token
 metadata:
   name: hass-chezmoi-sh-home-assistant
-  namespace: crossplane
+  namespace: hass
 spec:
   forProvider:
     accountId: 00736631322131f61ce95f2c235143da

--- a/projects/hass/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.hass-chezmoi-sh-home-assistant.yaml
+++ b/projects/hass/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.hass-chezmoi-sh-home-assistant.yaml
@@ -16,4 +16,3 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: hass-chezmoi-sh-home-assistant
-    namespace: crossplane-secrets

--- a/projects/hass/dist/infrastructure/crossplane/core.v1.Namespace.hass.yaml
+++ b/projects/hass/dist/infrastructure/crossplane/core.v1.Namespace.hass.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hass

--- a/projects/hass/src/infrastructure/crossplane/cloudflare.iam.home-assistant.yaml
+++ b/projects/hass/src/infrastructure/crossplane/cloudflare.iam.home-assistant.yaml
@@ -16,4 +16,3 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: hass-chezmoi-sh-home-assistant
-    namespace: crossplane-secrets

--- a/projects/hass/src/infrastructure/crossplane/cloudflare.iam.home-assistant.yaml
+++ b/projects/hass/src/infrastructure/crossplane/cloudflare.iam.home-assistant.yaml
@@ -3,7 +3,7 @@ apiVersion: account.upjet-cloudflare.m.upbound.io/v1alpha1
 kind: Token
 metadata:
   name: hass-chezmoi-sh-home-assistant
-  namespace: crossplane
+  namespace: hass
 spec:
   forProvider:
     name: (hass.chezmoi.sh) - Home Assistant

--- a/projects/hass/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/hass/src/infrastructure/crossplane/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - namespace.hass.yaml
   - cloudflare.iam.home-assistant.yaml

--- a/projects/hass/src/infrastructure/crossplane/namespace.hass.yaml
+++ b/projects/hass/src/infrastructure/crossplane/namespace.hass.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hass

--- a/projects/lungmen.akn/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.lungmenakn-chezmoi-sh-cert-manager.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/crossplane/account.upjet-cloudflare.m.upbound.io.v1alpha1.Token.lungmenakn-chezmoi-sh-cert-manager.yaml
@@ -16,4 +16,3 @@ spec:
       resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: lungmen.akn-cloudflare-token-certmanager
-    namespace: crossplane-secrets

--- a/projects/lungmen.akn/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.lungmen.akn-cloudflare-token-certmanager.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/crossplane/external-secrets.io.v1alpha1.PushSecret.lungmen.akn-cloudflare-token-certmanager.yaml
@@ -3,7 +3,7 @@ apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: lungmen.akn-cloudflare-token-certmanager
-  namespace: crossplane-secrets
+  namespace: lungmen-akn
 spec:
   data:
   - conversionStrategy: None

--- a/projects/lungmen.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml
+++ b/projects/lungmen.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml
@@ -10,7 +10,7 @@
 #     scoped to zone 2734d7b22cf00222046320ed3187cb94 (chezmoi.sh) only
 #
 # Security:
-#   The connection secret lands in the crossplane-secrets namespace and is
+#   The connection secret lands in the lungmen-akn namespace and is
 #   synchronized to Vault (vault.chezmoi.sh) via the co-located PushSecret.
 #
 # trunk-ignore-all(checkov/CKV2_K8S_5,trivy/KSV113): this is a policy to allow a specific user to use a specific secrets... so it's fine
@@ -32,13 +32,12 @@ spec:
         resources: '{"com.cloudflare.api.account.zone.2734d7b22cf00222046320ed3187cb94":"*"}'
   writeConnectionSecretToRef:
     name: lungmen.akn-cloudflare-token-certmanager
-    namespace: crossplane-secrets
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
   name: lungmen.akn-cloudflare-token-certmanager
-  namespace: crossplane-secrets
+  namespace: lungmen-akn
 spec:
   refreshInterval: 1h
   secretStoreRefs:


### PR DESCRIPTION
## Summary

The `account.upjet-cloudflare.m.upbound.io/v1alpha1 Token` CRD shipped by wildbitca provider v0.2.6 does not declare `namespace` in its `writeConnectionSecretToRef` schema. ArgoCD's structured merge diff fails with `.spec.writeConnectionSecretToRef.namespace: field not declared in schema`, leaving four crossplane ArgoCD applications in Unknown or Degraded state since PR 1070 introduced this field.

This fix removes the unsupported `namespace` field and co-locates each PushSecret with its Token resource, matching the actual runtime behavior (Crossplane writes connection secrets to the Token's own namespace when the field is absent from the schema). Two follow-up commits also migrate chezmoi.sh and hass Cloudflare tokens to dedicated project namespaces (`chezmoi-sh`, `hass`) and fix the lxc:secrets:sync scripts that were pointing at the wrong namespace.

**Related Issue:** #1063 (token rotation context)

## Root Cause

Crossplane upjet-based providers omit `namespace` from the `writeConnectionSecretToRef` OpenAPI schema — only `name` is declared. When the field is present in the desired-state manifest, ArgoCD cannot build a typed value for structured merge diff and reports a `ComparisonError`, blocking all sync operations for the affected application.

Confirmed via:
```
kubectl get crd tokens.account.upjet-cloudflare.m.upbound.io \
  -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.writeConnectionSecretToRef}'
# → only "name" is declared, "namespace" is absent
```

The Terraform Workspace and AWS IAM provider CRDs do declare `namespace` and are unaffected.

## Fix

### Cloudflare Token resources — all projects

Removed `namespace: crossplane-secrets` from `writeConnectionSecretToRef` across all eight affected Token manifests. Crossplane will continue writing connection secrets to the Token's own namespace (where it was already writing them in practice).

- **[`projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml`](projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml)** — Token in `amiya-akn`; PushSecret relocated to `amiya-akn`
- **[`projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cloudflare-operator.yaml`](projects/amiya.akn/src/infrastructure/crossplane/cloudflare.iam.cloudflare-operator.yaml)** — Token in `amiya-akn`; PushSecret relocated to `amiya-akn`
- **[`projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.observability.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.observability.yaml)** — Token moved to `chezmoi-sh`; no PushSecret
- **[`projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.oci-registry.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.oci-registry.yaml)** — Token moved to `chezmoi-sh`; no PushSecret
- **[`projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.omni.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.omni.yaml)** — Token moved to `chezmoi-sh`; no PushSecret
- **[`projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.terraform-provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/cloudflare.iam.terraform-provider.yaml)** — Token moved to `chezmoi-sh`; PushSecret relocated to `chezmoi-sh`
- **[`projects/hass/src/infrastructure/crossplane/cloudflare.iam.home-assistant.yaml`](projects/hass/src/infrastructure/crossplane/cloudflare.iam.home-assistant.yaml)** — Token moved to `hass`; no PushSecret
- **[`projects/lungmen.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml`](projects/lungmen.akn/src/infrastructure/crossplane/cloudflare.iam.cert-manager.yaml)** — Token in `lungmen-akn`; PushSecret relocated to `lungmen-akn`

### Dedicated project namespaces (chezmoi.sh and hass)

Since the wildbitca CRD doesn't support `writeConnectionSecretToRef.namespace`, the only way to control where connection secrets land is to move the Token resource itself to the target namespace. New namespace manifests are created and included in the respective Kustomizations so ArgoCD provisions them ahead of the Token resources.

- **[`projects/chezmoi.sh/src/infrastructure/crossplane/namespace.chezmoi-sh.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/namespace.chezmoi-sh.yaml)** — new `chezmoi-sh` namespace
- **[`projects/hass/src/infrastructure/crossplane/namespace.hass.yaml`](projects/hass/src/infrastructure/crossplane/namespace.hass.yaml)** — new `hass` namespace

### LXC secrets:sync scripts

The `lxc:secrets:sync` mise tasks in observability, oci-registry and omni were fetching Cloudflare tokens from `crossplane-secrets`, then `crossplane` — now correctly updated to `chezmoi-sh` to match the Token's new namespace.

- **[`projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/.mise.toml`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/.mise.toml)**
- **[`projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/.mise.toml`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/.mise.toml)**
- **[`projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/.mise.toml`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/.mise.toml)**

### Rendered dist/ manifests

All affected `dist/` counterparts regenerated via `dist:render`.

## Technical Impact

### Behavioural Changes

No change in runtime behavior for the ArgoCD fix itself — connection secrets were already landing in the Token's own namespace because the `namespace` field was silently ignored by Crossplane. The namespace migration (chezmoi.sh → `chezmoi-sh`, hass → `hass`) is an observable change: connection secrets for those tokens will be recreated in the new namespaces on next sync.

### Regression Risk

Low — the ArgoCD fix restores the pre-PR-1070 namespace layout that was actively in use. The namespace migration follows the same pattern already established by `amiya-akn` and `lungmen-akn` tokens.

### Observability

```sh
# Verify ArgoCD apps recover
kubectl get applications -n argocd | grep crossplane

# Verify connection secrets landed in the new namespaces
kubectl get secrets -n chezmoi-sh
kubectl get secrets -n hass

# Verify PushSecrets remain Synced after resync
kubectl get pushsecret -A
```

## Testing Validation

- [ ] `crossplane-amiya.akn` ArgoCD app transitions from Degraded to Healthy
- [ ] `crossplane-chezmoi.sh-*` ArgoCD apps transition from Unknown to Healthy
- [ ] `crossplane-hass` ArgoCD app transitions from Unknown to Healthy
- [ ] `crossplane-lungmen.akn` ArgoCD app transitions from Unknown to Healthy
- [ ] Connection secrets appear in `chezmoi-sh` namespace (observability, oci-registry, omni, terraform-provider)
- [ ] Connection secret appears in `hass` namespace (home-assistant)
- [ ] All PushSecrets remain in `Synced` state after resync
- [ ] `mise run lxc:secrets:sync` succeeds for observability, oci-registry and omni

## Related Issues

Addresses #1063 (token rotation required rebuilding the LXCs — this PR fixes the ArgoCD sync blocker introduced by the same migration)

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
