### PR TITLE
Extend SEC001 OPA policy to Crossplane Provider and Function packages

### DIFF
--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -115,6 +115,8 @@ the commit touches.
 | `catalog:kustomize`     | `catalog/kustomize/`                     |
 | `catalog:kairos-bundle` | `catalog/kairos-bundles/`                |
 | `catalog:talos`         | `catalog/talos/`                         |
+| `catalog:nix`           | `catalog/nix/` and Nix-related catalogs  |
+| `catalog:opa`           | `catalog/opa/`                           |
 | `gh`                    | `.github/`, root config files            |
 | `deps`                  | Dependency updates (automated or manual) |
 
@@ -223,13 +225,13 @@ updated in sync (see "Keeping this skill in sync" below).
 
 ### Scope rules
 
-| Rule               | Level | Value                                                                                                                                                                                                                                                                   |
-| ------------------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scope-enum`       | warn  | `catalog:ansible`, `catalog:crossplane`, `catalog:flakes`, `catalog:kustomize`, `catalog:kairos-bundle`, `catalog:talos`, `project:amiya.akn`, `project:chezmoi.sh`, `project:hass`, `project:kazimierz.akn`, `project:lungmen.akn`, `project:shodan.akn`, `deps`, `gh` |
-| `scope-empty`      | error | never                                                                                                                                                                                                                                                                   |
-| `scope-case`       | error | lower-case                                                                                                                                                                                                                                                              |
-| `scope-max-length` | error | Infinity                                                                                                                                                                                                                                                                |
-| `scope-min-length` | error | 0                                                                                                                                                                                                                                                                       |
+| Rule               | Level | Value                                                                                                                                                                                                                                                                                                 |
+| ------------------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scope-enum`       | warn  | `catalog:ansible`, `catalog:crossplane`, `catalog:flakes`, `catalog:kustomize`, `catalog:kairos-bundle`, `catalog:talos`, `catalog:nix`, `catalog:opa`, `project:amiya.akn`, `project:chezmoi.sh`, `project:hass`, `project:kazimierz.akn`, `project:lungmen.akn`, `project:shodan.akn`, `deps`, `gh` |
+| `scope-empty`      | error | never                                                                                                                                                                                                                                                                                                 |
+| `scope-case`       | error | lower-case                                                                                                                                                                                                                                                                                            |
+| `scope-max-length` | error | Infinity                                                                                                                                                                                                                                                                                              |
+| `scope-min-length` | error | 0                                                                                                                                                                                                                                                                                                     |
 
 `scope-enum` is set to **warning** because multi-scope commits (`scope1,scope2`) won't
 match single enum entries. Validation is enforced by the cz-git prompt instead.

--- a/catalog/opa/policies/SEC001:crossplane.rego
+++ b/catalog/opa/policies/SEC001:crossplane.rego
@@ -1,0 +1,40 @@
+package main
+
+import rego.v1
+
+# ──────────────────────────────────────────────────────────────────────────────
+# SEC001 — Crossplane Provider & Function packages
+#
+# Extends SEC001 to Crossplane package resources. Provider and Function
+# resources carry a .spec.package field that references an OCI image on an
+# xpkg-compatible registry. Like container images, these must be pulled through
+# the local Zot mirror at oci.chezmoi.sh.
+#
+# Covered resource types (cluster-scoped, no namespace exclusion applies):
+#   pkg.crossplane.io/v1      Provider  → .spec.package
+#   pkg.crossplane.io/v1beta1 Function  → .spec.package
+#
+# Relies on resources and is_local_image from the companion SEC001:kubernetes
+# policy (same package). Supports both single-file and --combine modes via the
+# shared resources rule.
+# ──────────────────────────────────────────────────────────────────────────────
+
+is_crossplane_package(res) if {
+    res.apiVersion == "pkg.crossplane.io/v1"
+    res.kind == "Provider"
+}
+
+is_crossplane_package(res) if {
+    res.apiVersion == "pkg.crossplane.io/v1beta1"
+    res.kind == "Function"
+}
+
+deny contains msg if {
+    some res in resources
+    is_crossplane_package(res)
+    not is_local_image(res.spec.package)
+    msg := sprintf(
+        "SEC001: Crossplane %s %q spec.package must use local registry prefix %q (got %q)",
+        [res.kind, res.metadata.name, local_registry, res.spec.package],
+    )
+}

--- a/catalog/opa/policies/SEC001:crossplane_test.rego
+++ b/catalog/opa/policies/SEC001:crossplane_test.rego
@@ -1,0 +1,114 @@
+package main
+
+import rego.v1
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests for SEC001 — Crossplane Provider & Function packages
+# ──────────────────────────────────────────────────────────────────────────────
+
+test_provider_compliant if {
+    violations := {msg | some msg in deny with input as {
+        "apiVersion": "pkg.crossplane.io/v1",
+        "kind": "Provider",
+        "metadata": {"name": "provider-aws-iam"},
+        "spec": {"package": "oci.chezmoi.sh/xpkg.upbound.io/upbound/provider-aws-iam:v2.6.0"},
+    }}
+    count(violations) == 0
+}
+
+test_provider_non_compliant if {
+    violations := {msg | some msg in deny with input as {
+        "apiVersion": "pkg.crossplane.io/v1",
+        "kind": "Provider",
+        "metadata": {"name": "provider-aws-iam"},
+        "spec": {"package": "xpkg.upbound.io/upbound/provider-aws-iam:v2.6.0"},
+    }}
+    count(violations) == 1
+}
+
+test_function_compliant if {
+    violations := {msg | some msg in deny with input as {
+        "apiVersion": "pkg.crossplane.io/v1beta1",
+        "kind": "Function",
+        "metadata": {"name": "function-go-templating"},
+        "spec": {"package": "oci.chezmoi.sh/xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.12.1"},
+    }}
+    count(violations) == 0
+}
+
+test_function_non_compliant if {
+    violations := {msg | some msg in deny with input as {
+        "apiVersion": "pkg.crossplane.io/v1beta1",
+        "kind": "Function",
+        "metadata": {"name": "function-go-templating"},
+        "spec": {"package": "xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.12.1"},
+    }}
+    count(violations) == 1
+}
+
+test_provider_xpkg_crossplane_io_compliant if {
+    violations := {msg | some msg in deny with input as {
+        "apiVersion": "pkg.crossplane.io/v1",
+        "kind": "Provider",
+        "metadata": {"name": "provider-terraform"},
+        "spec": {"package": "oci.chezmoi.sh/xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.1.1"},
+    }}
+    count(violations) == 0
+}
+
+test_provider_xpkg_crossplane_io_non_compliant if {
+    violations := {msg | some msg in deny with input as {
+        "apiVersion": "pkg.crossplane.io/v1",
+        "kind": "Provider",
+        "metadata": {"name": "provider-terraform"},
+        "spec": {"package": "xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.1.1"},
+    }}
+    count(violations) == 1
+}
+
+test_non_crossplane_resource_ignored if {
+    not is_crossplane_package({
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {"name": "app"},
+        "spec": {},
+    })
+}
+
+test_provider_detected if {
+    is_crossplane_package({
+        "apiVersion": "pkg.crossplane.io/v1",
+        "kind": "Provider",
+        "metadata": {"name": "test"},
+        "spec": {"package": "xpkg.upbound.io/test/provider:v1.0.0"},
+    })
+}
+
+test_function_detected if {
+    is_crossplane_package({
+        "apiVersion": "pkg.crossplane.io/v1beta1",
+        "kind": "Function",
+        "metadata": {"name": "test"},
+        "spec": {"package": "xpkg.upbound.io/test/function:v1.0.0"},
+    })
+}
+
+test_combine_mode_provider_violation if {
+    violations := {msg | some msg in deny with input as [{"path": "provider.yaml", "contents": {
+        "apiVersion": "pkg.crossplane.io/v1",
+        "kind": "Provider",
+        "metadata": {"name": "provider-aws-iam"},
+        "spec": {"package": "xpkg.upbound.io/upbound/provider-aws-iam:v2.6.0"},
+    }}]}
+    count(violations) == 1
+}
+
+test_combine_mode_function_compliant if {
+    violations := {msg | some msg in deny with input as [{"path": "function.yaml", "contents": {
+        "apiVersion": "pkg.crossplane.io/v1beta1",
+        "kind": "Function",
+        "metadata": {"name": "function-auto-ready"},
+        "spec": {"package": "oci.chezmoi.sh/xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.6.5"},
+    }}]}
+    count(violations) == 0
+}

--- a/catalog/opa/rules/SEC001-enforce-local-registry.md
+++ b/catalog/opa/rules/SEC001-enforce-local-registry.md
@@ -48,6 +48,7 @@ prefix, eliminating the need for runtime mutation.
 | ------------------------------------- | -------------------------------------------------------------- |
 | `policies/SEC001:kubernetes.rego`     | Native Kubernetes resources (Pods, Deployments, DaemonSets, …) |
 | `policies/SEC001:cloudnative-pg.rego` | CloudNative-PG `ImageCatalog` and `ClusterImageCatalog`        |
+| `policies/SEC001:crossplane.rego`     | Crossplane `Provider` and `Function` (`.spec.package`)         |
 
 ## What is checked
 
@@ -69,6 +70,18 @@ volume fields must reference `oci.chezmoi.sh`:
 
 * `postgresql.cnpg.io/v1` kind `ImageCatalog` → `.spec.images[].image`
 * `postgresql.cnpg.io/v1` kind `ClusterImageCatalog` → `.spec.images[].image`
+
+### Crossplane resources
+
+Crossplane `Provider` and `Function` resources reference OCI packages through
+`.spec.package` rather than a pod spec container image field. This field is
+functionally equivalent to a container image pull and must equally resolve
+through `oci.chezmoi.sh`.
+
+* `pkg.crossplane.io/v1` kind `Provider` → `.spec.package`
+* `pkg.crossplane.io/v1beta1` kind `Function` → `.spec.package`
+
+These resources are cluster-scoped; namespace exclusions do not apply.
 
 ## Namespace enforcement model
 
@@ -106,5 +119,5 @@ mise exec conftest -- conftest test <manifest.yaml> -p catalog/opa/policies/
 mise exec opa -- opa test catalog/opa/policies/ -v
 ```
 
-CI enforcement is **non-blocking** during the initial rollout (see ADR-012).
-The policy will transition to blocking once all existing manifests are compliant.
+CI enforcement is **blocking** (no `continue-on-error`). All manifests in
+`projects/*/dist/` must be compliant before merging.

--- a/projects/amiya.akn/dist/apps/zot-registry/apps.v1.StatefulSet.zot.yaml
+++ b/projects/amiya.akn/dist/apps/zot-registry/apps.v1.StatefulSet.zot.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 551b7a0a7affebe9afdad1356c91598e9d8849082c37c7a34902e42a58a41479
+        checksum/config: c26301a637abf0320ef0641213f3fc071eb5498875200bf82960bc59d7630529
       labels:
         app.kubernetes.io/instance: zot
         app.kubernetes.io/name: zot

--- a/projects/amiya.akn/dist/apps/zot-registry/core.v1.ConfigMap.zot-config.yaml
+++ b/projects/amiya.akn/dist/apps/zot-registry/core.v1.ConfigMap.zot-config.yaml
@@ -129,6 +129,13 @@ data:
               "onDemand": true,
               "preserveDigest": true,
               "tlsVerify": true
+            },
+            {
+              "urls": ["https://xpkg.upbound.io"],
+              "content": [{"destination": "/xpkg.upbound.io", "prefix": "**"}],
+              "onDemand": true,
+              "preserveDigest": true,
+              "tlsVerify": true
             }
           ]
         }

--- a/projects/amiya.akn/src/apps/zot-registry/zot.helmvalues/default.yaml
+++ b/projects/amiya.akn/src/apps/zot-registry/zot.helmvalues/default.yaml
@@ -223,6 +223,13 @@ configFiles:
               "onDemand": true,
               "preserveDigest": true,
               "tlsVerify": true
+            },
+            {
+              "urls": ["https://xpkg.upbound.io"],
+              "content": [{"destination": "/xpkg.upbound.io", "prefix": "**"}],
+              "onDemand": true,
+              "preserveDigest": true,
+              "tlsVerify": true
             }
           ]
         }

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.Function.function-auto-ready.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.Function.function-auto-ready.yaml
@@ -4,6 +4,6 @@ kind: Function
 metadata:
   name: function-auto-ready
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.6.5
+  package: oci.chezmoi.sh/xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.6.5
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.Function.function-extra-resources.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.Function.function-extra-resources.yaml
@@ -4,6 +4,6 @@ kind: Function
 metadata:
   name: function-extra-resources
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.3.0
+  package: oci.chezmoi.sh/xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.3.0
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.Function.function-go-templating.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/pkg.crossplane.io.v1beta1.Function.function-go-templating.yaml
@@ -4,6 +4,6 @@ kind: Function
 metadata:
   name: function-go-templating
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.12.1
+  package: oci.chezmoi.sh/xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.12.1
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/aws/pkg.crossplane.io.v1.Provider.provider-aws-iam.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/aws/pkg.crossplane.io.v1.Provider.provider-aws-iam.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v2.6.0
+  package: oci.chezmoi.sh/xpkg.upbound.io/upbound/provider-aws-iam:v2.6.0
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/aws/pkg.crossplane.io.v1.Provider.provider-aws-ses.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/aws/pkg.crossplane.io.v1.Provider.provider-aws-ses.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: provider-aws-ses
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-ses:v2.6.0
+  package: oci.chezmoi.sh/xpkg.upbound.io/upbound/provider-aws-ses:v2.6.0
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/aws/pkg.crossplane.io.v1.Provider.upbound-provider-family-aws.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/aws/pkg.crossplane.io.v1.Provider.upbound-provider-family-aws.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: upbound-provider-family-aws
 spec:
-  package: xpkg.upbound.io/upbound/provider-family-aws:v2.6.0
+  package: oci.chezmoi.sh/xpkg.upbound.io/upbound/provider-family-aws:v2.6.0
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/cloudflare/pkg.crossplane.io.v1.Provider.wildbitca-provider-cloudflare-account.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/cloudflare/pkg.crossplane.io.v1.Provider.wildbitca-provider-cloudflare-account.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: wildbitca-provider-cloudflare-account
 spec:
-  package: xpkg.upbound.io/wildbitca/provider-cloudflare-account:v0.2.6
+  package: oci.chezmoi.sh/xpkg.upbound.io/wildbitca/provider-cloudflare-account:v0.2.6
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/cloudflare/pkg.crossplane.io.v1.Provider.wildbitca-provider-cloudflare-dns.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/cloudflare/pkg.crossplane.io.v1.Provider.wildbitca-provider-cloudflare-dns.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: wildbitca-provider-cloudflare-dns
 spec:
-  package: xpkg.upbound.io/wildbitca/provider-cloudflare-dns:v0.2.6
+  package: oci.chezmoi.sh/xpkg.upbound.io/wildbitca/provider-cloudflare-dns:v0.2.6
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/cloudflare/pkg.crossplane.io.v1.Provider.wildbitca-provider-cloudflare-zone.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/cloudflare/pkg.crossplane.io.v1.Provider.wildbitca-provider-cloudflare-zone.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: wildbitca-provider-cloudflare-zone
 spec:
-  package: xpkg.upbound.io/wildbitca/provider-cloudflare-zone:v0.2.6
+  package: oci.chezmoi.sh/xpkg.upbound.io/wildbitca/provider-cloudflare-zone:v0.2.6
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/cloudflare/pkg.crossplane.io.v1.Provider.wildbitca-provider-family-cloudflare.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/cloudflare/pkg.crossplane.io.v1.Provider.wildbitca-provider-family-cloudflare.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: wildbitca-provider-family-cloudflare
 spec:
-  package: xpkg.upbound.io/wildbitca/provider-family-cloudflare:v0.2.6
+  package: oci.chezmoi.sh/xpkg.upbound.io/wildbitca/provider-family-cloudflare:v0.2.6
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/terraform/pkg.crossplane.io.v1.Provider.provider-terraform.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/terraform/pkg.crossplane.io.v1.Provider.provider-terraform.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: provider-terraform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.1.1
+  package: oci.chezmoi.sh/xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.1.1
   runtimeConfigRef:
     name: hardened-for-terraform

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/vault/pkg.crossplane.io.v1.Provider.upbound-provider-vault.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/vault/pkg.crossplane.io.v1.Provider.upbound-provider-vault.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: upbound-provider-vault
 spec:
-  package: xpkg.upbound.io/upbound/provider-vault:v3.0.7
+  package: oci.chezmoi.sh/xpkg.upbound.io/upbound/provider-vault:v3.0.7
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/functions.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/functions.yaml
@@ -4,7 +4,7 @@ kind: Function
 metadata:
   name: function-go-templating
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.12.1
+  package: oci.chezmoi.sh/xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.12.1
   runtimeConfigRef:
     name: hardened
 ---
@@ -13,7 +13,7 @@ kind: Function
 metadata:
   name: function-auto-ready
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.6.5
+  package: oci.chezmoi.sh/xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.6.5
   runtimeConfigRef:
     name: hardened
 ---
@@ -22,6 +22,6 @@ kind: Function
 metadata:
   name: function-extra-resources
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.3.0
+  package: oci.chezmoi.sh/xpkg.upbound.io/crossplane-contrib/function-extra-resources:v0.3.0
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/provider.yaml
@@ -4,7 +4,7 @@ kind: Provider
 metadata:
   name: upbound-provider-family-aws
 spec:
-  package: xpkg.upbound.io/upbound/provider-family-aws:v2.6.0
+  package: oci.chezmoi.sh/xpkg.upbound.io/upbound/provider-family-aws:v2.6.0
   runtimeConfigRef:
     name: hardened
 ---
@@ -13,7 +13,7 @@ kind: Provider
 metadata:
   name: provider-aws-iam
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-iam:v2.6.0
+  package: oci.chezmoi.sh/xpkg.upbound.io/upbound/provider-aws-iam:v2.6.0
   runtimeConfigRef:
     name: hardened
 ---
@@ -22,6 +22,6 @@ kind: Provider
 metadata:
   name: provider-aws-ses
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws-ses:v2.6.0
+  package: oci.chezmoi.sh/xpkg.upbound.io/upbound/provider-aws-ses:v2.6.0
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/cloudflare/wildbitca.providers.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/cloudflare/wildbitca.providers.yaml
@@ -4,7 +4,7 @@ kind: Provider
 metadata:
   name: wildbitca-provider-family-cloudflare
 spec:
-  package: xpkg.upbound.io/wildbitca/provider-family-cloudflare:v0.2.6
+  package: oci.chezmoi.sh/xpkg.upbound.io/wildbitca/provider-family-cloudflare:v0.2.6
   runtimeConfigRef:
     name: hardened
 ---
@@ -13,7 +13,7 @@ kind: Provider
 metadata:
   name: wildbitca-provider-cloudflare-account
 spec:
-  package: xpkg.upbound.io/wildbitca/provider-cloudflare-account:v0.2.6
+  package: oci.chezmoi.sh/xpkg.upbound.io/wildbitca/provider-cloudflare-account:v0.2.6
   runtimeConfigRef:
     name: hardened
 ---
@@ -22,7 +22,7 @@ kind: Provider
 metadata:
   name: wildbitca-provider-cloudflare-zone
 spec:
-  package: xpkg.upbound.io/wildbitca/provider-cloudflare-zone:v0.2.6
+  package: oci.chezmoi.sh/xpkg.upbound.io/wildbitca/provider-cloudflare-zone:v0.2.6
   runtimeConfigRef:
     name: hardened
 ---
@@ -31,6 +31,6 @@ kind: Provider
 metadata:
   name: wildbitca-provider-cloudflare-dns
 spec:
-  package: xpkg.upbound.io/wildbitca/provider-cloudflare-dns:v0.2.6
+  package: oci.chezmoi.sh/xpkg.upbound.io/wildbitca/provider-cloudflare-dns:v0.2.6
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/provider.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: provider-terraform
 spec:
-  package: xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.1.1
+  package: oci.chezmoi.sh/xpkg.crossplane.io/crossplane-contrib/provider-terraform:v1.1.1
   runtimeConfigRef:
     name: hardened-for-terraform

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/provider.yaml
@@ -4,6 +4,6 @@ kind: Provider
 metadata:
   name: upbound-provider-vault
 spec:
-  package: xpkg.upbound.io/upbound/provider-vault:v3.0.7
+  package: oci.chezmoi.sh/xpkg.upbound.io/upbound/provider-vault:v3.0.7
   runtimeConfigRef:
     name: hardened

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/flake.nix
@@ -52,7 +52,7 @@
       # Image version — CalVer (YYYY.MM.DD), used only to name the Proxmox
       # template (oci-registry.<date>-amd64.tar.xz). Bump before every
       # `mise run lxc:build`; append -N for multiple builds on the same day.
-      imageVersion = "2026.06.19";
+      imageVersion = "2026.06.20";
 
       zotPackage = pkgs.stdenvNoCC.mkDerivation {
         pname = "zot";

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/upstreams.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/upstreams.nix
@@ -69,8 +69,11 @@ in
     # Upstream Kubernetes images.
     (mkUpstream "registry.k8s.io")
 
-    # Crossplane provider packages.
+    # Crossplane provider packages (crossplane-contrib).
     (mkUpstream "xpkg.crossplane.io")
+
+    # Upbound marketplace packages (provider-family-aws, provider-vault, …).
+    (mkUpstream "xpkg.upbound.io")
 
     # Microsoft Container Registry.
     (mkUpstream "mcr.microsoft.com")


### PR DESCRIPTION
## Summary

Extends SEC001 supply-chain enforcement to Crossplane `Provider` and `Function`
resources, which reference OCI packages via `spec.package` rather than
`spec.containers[].image`. This field was invisible to the existing
`SEC001:kubernetes` policy, leaving a blind spot where non-local package
references would pass CI undetected.

The PR adds the missing OPA policy, routes all 12 existing Crossplane packages
through `oci.chezmoi.sh`, and registers `xpkg.upbound.io` as a new Zot
upstream so Crossplane can pull those packages on demand via the local mirror.

## Changes Made

### OPA policy — `catalog/opa/`

- **[`catalog/opa/policies/SEC001:crossplane.rego`](catalog/opa/policies/SEC001:crossplane.rego)** — New policy: denies any `pkg.crossplane.io/v1 Provider` or `pkg.crossplane.io/v1beta1 Function` whose `spec.package` does not start with `oci.chezmoi.sh`. Namespace exclusions do not apply (cluster-scoped resources).
- **[`catalog/opa/policies/SEC001:crossplane_test.rego`](catalog/opa/policies/SEC001:crossplane_test.rego)** — 11 unit tests covering compliant/non-compliant paths for both resource types and both xpkg registries.
- **[`catalog/opa/rules/SEC001-enforce-local-registry.md`](catalog/opa/rules/SEC001-enforce-local-registry.md)** — Updated policy file table and "What is checked" section to document Crossplane coverage. Fixed stale note: CI enforcement is now fully blocking (no `continue-on-error`).

### Zot registry — `projects/amiya.akn/`

- **[`projects/amiya.akn/src/apps/zot-registry/zot.helmvalues/default.yaml`](projects/amiya.akn/src/apps/zot-registry/zot.helmvalues/default.yaml)** — Adds `xpkg.upbound.io` as an on-demand pull-through sync upstream. Required for all Upbound marketplace packages (AWS, Vault, Cloudflare providers and crossplane-contrib functions).
- **[`projects/amiya.akn/dist/apps/zot-registry/core.v1.ConfigMap.zot-config.yaml`](projects/amiya.akn/dist/apps/zot-registry/core.v1.ConfigMap.zot-config.yaml)** — Rendered ConfigMap reflecting the new upstream.

### Crossplane providers & functions — `projects/chezmoi.sh/`

All 12 packages prefixed with `oci.chezmoi.sh/` in both `src/` and rendered `dist/`:

| Package | Registry |
| ------- | -------- |
| `provider-family-aws`, `provider-aws-iam`, `provider-aws-ses` | `xpkg.upbound.io` (new upstream) |
| `provider-vault` | `xpkg.upbound.io` (new upstream) |
| `provider-family-cloudflare`, 3 sub-providers | `xpkg.upbound.io` (new upstream) |
| `function-go-templating`, `function-auto-ready`, `function-extra-resources` | `xpkg.upbound.io` (new upstream) |
| `provider-terraform` | `xpkg.crossplane.io` (already in Zot) |

### Commit conventions — `.agents/skills/git-commit/SKILL.md`

- Added `catalog:opa` and `catalog:nix` to the scope table and `scope-enum` row to match `.commitlintrc.js` which already defined them.

## Technical Impact

### Security Implementation

SEC001 now covers every OCI pull surface in `projects/*/dist/`:

| Resource kind | Field checked | Policy file |
| ------------- | ------------- | ----------- |
| Pod / workload containers | `spec.[init|ephemeral]Containers[].image` | `SEC001:kubernetes` |
| OCI image volumes | `spec.volumes[].image` | `SEC001:kubernetes` |
| CNPG ImageCatalog | `spec.images[].image` | `SEC001:cloudnative-pg` |
| Crossplane Provider / Function | `spec.package` | `SEC001:crossplane` ← new |

### Integration Points

The new Zot upstream (`xpkg.upbound.io`) uses the same on-demand pull-through
pattern as every existing upstream: images are fetched from the internet once
and cached locally on first pull. No additional credentials or network rules
are required.

## Testing Validation

- [x] `opa test catalog/opa/policies/ -v` — 79/79 PASS (up from 68 before this PR)
- [x] `conftest test projects/chezmoi.sh/dist/infrastructure/crossplane --policy catalog/opa/policies/ --combine` — 0 violations
- [x] `trunk check --filter=-conftest` — no new issues
- [ ] Zot pod restarts cleanly after ConfigMap update (deploy required)
- [ ] Crossplane providers pull successfully via `oci.chezmoi.sh/xpkg.upbound.io/…`

## Related Issues

No dedicated issue — follow-up to the SEC001 OPA policy introduced in ADR-012.

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
