### PR TITLE
Add provider-oci-objectstorage to the shared OCI provider stack

### DIFF
--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-objectstorage.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-objectstorage.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-oci-objectstorage
+spec:
+  package: oci.chezmoi.sh/ghcr.io/oracle/provider-oci-objectstorage:v1.1.0
+  runtimeConfigRef:
+    name: hardened
+  skipDependencyResolution: true

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml
@@ -17,3 +17,13 @@ spec:
   runtimeConfigRef:
     name: hardened
   skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-oci-objectstorage
+spec:
+  package: oci.chezmoi.sh/ghcr.io/oracle/provider-oci-objectstorage:v1.1.0
+  runtimeConfigRef:
+    name: hardened
+  skipDependencyResolution: true


### PR DESCRIPTION
## Summary

Adds `provider-oci-objectstorage` to the shared OCI Crossplane provider
stack. This provider exposes `Bucket`, `ObjectLifecyclePolicy`, and `Object`
CRDs from the OCI Object Storage service, required to manage the NixOS image
bucket being introduced in the kazimierz.akn infrastructure (issue 1076).

**Related Issue:** #1076

## Changes Made

### OCI provider stack (`projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/`)

- **[`provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml)** — adds `provider-oci-objectstorage:v1.1.0` following the same pattern as `provider-oci-core`: same internal OCI registry image, `hardened` RuntimeConfig, `skipDependencyResolution: true` because `provider-family-oci` manages credentials for all sub-providers
- **[`dist/.../pkg.crossplane.io.v1.Provider.provider-oci-objectstorage.yaml`](projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-objectstorage.yaml)** — rendered dist manifest

## Technical Impact

### Infrastructure Components

One new Crossplane `Provider` package installed alongside `provider-oci-core`.
The family provider (`provider-family-oci`) already handles OCI API key
credentials via the `oci-credentials` ExternalSecret — no new secret or
ProviderConfig is needed.

### Security Implementation

The provider runs under the existing `hardened` RuntimeConfig. No new API
credentials, IAM roles, or network policy changes are required: the
`crossplane-rw` OCI API key already covers the `objectstorage` API scope.

## Testing Validation

- [ ] `kubectl get provider provider-oci-objectstorage` → `INSTALLED=True HEALTHY=True`
- [ ] `kubectl get crds | grep objectstorage.oci.upbound.io` lists Bucket, ObjectLifecyclePolicy, Object CRDs
- [ ] No impact on existing `provider-oci-core` or `provider-family-oci` health

## Related Issues

Addresses #1076 (prerequisite — must be merged before the bucket resources reconcile)

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
