### PR TITLE
Add provider-oci-networking and provider-oci-networkfirewall to the OCI provider stack

### DIFF
--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-networkfirewall.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-networkfirewall.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-oci-networkfirewall
+spec:
+  package: oci.chezmoi.sh/ghcr.io/oracle/provider-oci-networkfirewall:v1.1.0
+  runtimeConfigRef:
+    name: hardened
+  skipDependencyResolution: true

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-networking.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-networking.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-oci-networking
+spec:
+  package: oci.chezmoi.sh/ghcr.io/oracle/provider-oci-networking:v1.1.0
+  runtimeConfigRef:
+    name: hardened
+  skipDependencyResolution: true

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml
@@ -27,3 +27,23 @@ spec:
   runtimeConfigRef:
     name: hardened
   skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-oci-networking
+spec:
+  package: oci.chezmoi.sh/ghcr.io/oracle/provider-oci-networking:v1.1.0
+  runtimeConfigRef:
+    name: hardened
+  skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-oci-networkfirewall
+spec:
+  package: oci.chezmoi.sh/ghcr.io/oracle/provider-oci-networkfirewall:v1.1.0
+  runtimeConfigRef:
+    name: hardened
+  skipDependencyResolution: true


### PR DESCRIPTION
## Summary

Adds `provider-oci-networking` and `provider-oci-networkfirewall` to the
shared OCI Crossplane provider stack. These providers expose advanced VCN
networking resources (beyond the basic core networking in `provider-oci-core`)
and OCI Network Firewall policies as native Crossplane managed resources,
required for the kazimierz.akn firewall and networking evolution.

## Changes Made

### OCI provider stack (`projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/`)

- **[`provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml)** — adds `provider-oci-networking:v1.1.0` and `provider-oci-networkfirewall:v1.1.0`, both following the established pattern: internal OCI registry image, `hardened` RuntimeConfig, `skipDependencyResolution: true`
- **[`dist/.../pkg.crossplane.io.v1.Provider.provider-oci-networking.yaml`](projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-networking.yaml)** — rendered dist manifest
- **[`dist/.../pkg.crossplane.io.v1.Provider.provider-oci-networkfirewall.yaml`](projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-networkfirewall.yaml)** — rendered dist manifest

## Technical Impact

### Infrastructure Components

Two new Crossplane `Provider` packages installed alongside the existing
`provider-oci-core`. No new ProviderConfig or ExternalSecret is needed:
`provider-family-oci` already handles OCI API key credentials for all
sub-providers via the `oci-credentials` ExternalSecret.

`provider-oci-networking` exposes advanced VCN resources (DRG, CPE,
IPSec connections, FastConnect, VTAP, etc.) not covered by `provider-oci-core`.
`provider-oci-networkfirewall` exposes OCI Network Firewall policies,
rules, and applications as managed resources.

### Security Implementation

Both providers run under the existing `hardened` RuntimeConfig. No new
IAM roles or network policy changes are required beyond what
`provider-oci-core` already needs.

## Testing Validation

- [ ] `kubectl get provider provider-oci-networking` → `INSTALLED=True HEALTHY=True`
- [ ] `kubectl get provider provider-oci-networkfirewall` → `INSTALLED=True HEALTHY=True`
- [ ] No impact on existing `provider-oci-core` or `provider-family-oci` health

## Related Issues

Addresses #1076 (prerequisite for future VCN and firewall resources)

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
