### PR TITLE
Add provider-oci-blockstorage to the shared OCI provider stack

### DIFF
--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-blockstorage.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-blockstorage.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-oci-blockstorage
+spec:
+  package: oci.chezmoi.sh/ghcr.io/oracle/provider-oci-blockstorage:v1.1.0
+  runtimeConfigRef:
+    name: hardened
+  skipDependencyResolution: true

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml
@@ -47,3 +47,13 @@ spec:
   runtimeConfigRef:
     name: hardened
   skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-oci-blockstorage
+spec:
+  package: oci.chezmoi.sh/ghcr.io/oracle/provider-oci-blockstorage:v1.1.0
+  runtimeConfigRef:
+    name: hardened
+  skipDependencyResolution: true


### PR DESCRIPTION
## Summary

Adds `provider-oci-blockstorage` v1.1.0 to the shared OCI provider stack in `chezmoi.sh`. This provider registers `Volume` and `VolumeAttachment` CRDs under `blockstorage.oci.m.upbound.io/v1alpha1`, which are required by `kazimierz.akn` to manage the Pangolin persistent data volume via Crossplane (issue 1076).

**Related Issue:** #1076

## Changes Made

### OCI provider stack (`projects/chezmoi.sh/`)

- **[`projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml)** — Adds the `provider-oci-blockstorage` Provider resource, following the same pattern as `provider-oci-objectstorage` and `provider-oci-core` (`skipDependencyResolution: true`, `hardened` RuntimeConfig, internal registry mirror)
- **[`projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-blockstorage.yaml`](projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-blockstorage.yaml)** — Rendered dist manifest (auto-generated by `dist:render`)

## Technical Impact

### Infrastructure Components

Provider `provider-oci-blockstorage:v1.1.0` installs from the internal registry mirror (`oci.chezmoi.sh/ghcr.io/oracle/provider-oci-blockstorage:v1.1.0`). Once healthy, it registers `blockstorage.oci.m.upbound.io/v1alpha1` CRDs on all clusters using the `chezmoi.sh` shared provider stack.

### Security Implementation

No new permissions required. The provider uses the existing `oci-credentials` ExternalSecret (already in scope for `provider-oci-core`) and the `hardened` RuntimeConfig for pod security constraints. `skipDependencyResolution` prevents the provider from pulling additional packages from upstream registries.

### Integration Points

Unblocks `kazimierz.akn` issue 1076 PR (branch `i1076-crossplane-oci-publicinstance`), which declares `blockstorage.oci.m.upbound.io/v1alpha1` Volume and VolumeAttachment resources for the Pangolin data disk.

## Testing Validation

- [ ] `provider-oci-blockstorage` pod reaches `Running` in `crossplane-system`
- [ ] Provider status shows `HEALTHY: True` (`kubectl get provider provider-oci-blockstorage`)
- [ ] CRDs `volumes.blockstorage.oci.m.upbound.io` and `volumeattachments.blockstorage.oci.m.upbound.io` present in cluster

## Related Issues

Addresses #1076 (Phase 1 — provider prerequisite)

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
