### PR TITLE
Add provider-oci-compute to the OCI provider suite

### DIFF
--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-compute.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-compute.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-oci-compute
+spec:
+  package: oci.chezmoi.sh/ghcr.io/oracle/provider-oci-compute:v1.1.0
+  runtimeConfigRef:
+    name: hardened
+  skipDependencyResolution: true

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml
@@ -57,3 +57,13 @@ spec:
   runtimeConfigRef:
     name: hardened
   skipDependencyResolution: true
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-oci-compute
+spec:
+  package: oci.chezmoi.sh/ghcr.io/oracle/provider-oci-compute:v1.1.0
+  runtimeConfigRef:
+    name: hardened
+  skipDependencyResolution: true


### PR DESCRIPTION
## Summary

Adds `provider-oci-compute` to the shared OCI Crossplane provider suite in `chezmoi.sh`.
The `VolumeAttachment` CRD (shipped by `provider-oci-blockstorage`) resolves `instanceIdRef`
against an `Instance` resource in `compute.oci.m.upbound.io/v1alpha1`. Without this provider
that API group does not exist on the cluster and every `VolumeAttachment` reconcile fails with
`no matches for kind "Instance" in version "compute.oci.m.upbound.io/v1alpha1"`.

**Related Issue:** #1076

## Root Cause

`crossplane-kazimierz.akn` was in `Degraded` health. Investigation via `kubectl get managed -n kazimierz-akn` revealed two failing resources:

- `VolumeAttachment/kazimierz-akn-pangolin-data-attachment` — `SYNCED: False`
- `Volume/kazimierz-akn-pangolin-data` — `SYNCED: False, READY: False`

The `VolumeAttachment` error:

```
cannot resolve references: mg.Spec.ForProvider.InstanceID:
cannot get referenced resource:
no matches for kind "Instance" in version "compute.oci.m.upbound.io/v1alpha1"
```

The blockstorage provider's `VolumeAttachment` CRD expects to cross-reference an `Instance`
managed resource from `provider-oci-compute`. That provider was never added to the OCI suite
alongside the other sub-providers (blockstorage, networking, objectstorage, etc.).

## Fix

### `projects/chezmoi.sh` — OCI provider suite

- **[`src/infrastructure/crossplane/providers/oci/provider.yaml`](projects/chezmoi.sh/src/infrastructure/crossplane/providers/oci/provider.yaml)** — adds `provider-oci-compute` at the same version (`v1.1.0`) and with the same runtime config as the existing sub-providers
- **[`dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-compute.yaml`](projects/chezmoi.sh/dist/infrastructure/crossplane/providers/oci/pkg.crossplane.io.v1.Provider.provider-oci-compute.yaml)** — rendered manifest (generated by `dist:render`)

## Technical Impact

### Behavioural Changes

Once the provider is installed, the `compute.oci.m.upbound.io/v1alpha1` API group becomes available.
The `VolumeAttachment` reconciler will be able to resolve `instanceIdRef` and move past the
reference-resolution error. The `Volume` reconcile failure (OCI IAM 404) is a separate issue
tracked in the debug document at the repo root.

### Regression Risk

Low. This is an additive change — a new read-only CRD group is registered. No existing resources
are modified. The pattern is identical to the five sub-providers already in production
(blockstorage, networking, networkfirewall, objectstorage, core).

### Observability

```bash
# Provider becomes Healthy
kubectl get providers.pkg.crossplane.io provider-oci-compute

# VolumeAttachment stops reporting the reference error
kubectl get volumeattachments.blockstorage.oci.m.upbound.io \
  kazimierz-akn-pangolin-data-attachment -n kazimierz-akn \
  -o jsonpath='{.status.conditions[?(@.type=="Synced")].message}'
```

## Testing Validation

- [ ] `provider-oci-compute` reaches `Installed: True / Healthy: True`
- [ ] `compute.oci.m.upbound.io` API group appears in `kubectl api-resources`
- [ ] `VolumeAttachment/kazimierz-akn-pangolin-data-attachment` no longer reports the Instance reference error

## Related Issues

Addresses #1076

---
<sub>AI-assisted with anthropic:claude-sonnet-4.6 under human supervision</sub>
