### PR TITLE
Replace new-VMID LXC upgrade with in-place rootfs swap

### DIFF
--- a/.agents/skills/lxc-maintenance/SKILL.md
+++ b/.agents/skills/lxc-maintenance/SKILL.md
@@ -13,7 +13,9 @@ compatibility: Requires mise, nix, sops, scp, and SSH access to a Proxmox host
 
 The `projects/chezmoi.sh/src/infrastructure/proxmox/lxc/` directory contains
 five NixOS-based LXC appliances, each built as an immutable tarball and
-deployed to Proxmox via rootfs swap (not in-place updates).
+upgraded in place: the running container keeps its VMID (and therefore its
+static IP and PBS backup identity) while its rootfs volume is swapped for a
+freshly built one, with a Proxmox snapshot as the rollback path.
 
 ```text
 lxc/
@@ -73,31 +75,33 @@ Where `<pve-host>` is the hostname or IP of the target Proxmox node (e.g. `pve.l
 
 ```sh
 mise run lxc:upgrade -- <pve-host>
-# or with explicit VMIDs:
-mise run lxc:upgrade -- --pve-host <pve-host> --source-id <vmid> --target-id <vmid>
+# or with an explicit VMID:
+mise run lxc:upgrade -- --pve-host <pve-host> --vmid <vmid>
 # or non-interactive:
 mise run lxc:upgrade -- --pve-host <pve-host> --yes
 ```
 
 The upgrade executes 7 numbered steps with an ANSI progress display:
 
-| Step | Action                                                                                      |
-| ---- | ------------------------------------------------------------------------------------------- |
-| 1    | Pre-flight: verify template exists on PVE, source CT exists, target VMID is free            |
-| 2    | Create target CT from the new template (rootfs only)                                        |
-| 3    | Smoke-test: start target, verify NixOS activation, stop                                     |
-| 4    | Merge config: copy source config to target, swap rootfs volume, strip mount point lines     |
-| 5    | Cutover: stop source, re-attach mount points to target, start target (downtime starts here) |
-| 6    | Health check: verify services are active after 15s warm-up, show e2e hint                   |
-| 7    | Decommission source (or rollback on failure)                                                |
+| Step | Action                                                                                                     |
+| ---- | ---------------------------------------------------------------------------------------------------------- |
+| 1    | Pre-flight: verify template exists on PVE, CT exists, registered mount points present                      |
+| 2    | Temporary CT smoke-test: create a disposable CT from the new template, verify NixOS activation, destroy it |
+| 3    | Snapshot the CT (`pct snapshot <vmid> pre-upgrade-<timestamp>`)                                            |
+| 4    | Stop the CT (downtime starts here)                                                                         |
+| 5    | Replace the rootfs volume in place (same VMID), then start the CT                                          |
+| 6    | Health check: verify services are active after 30s warm-up, show e2e hint                                  |
+| 7    | Commit — delete the snapshot and free the old volume (or roll back on failure)                             |
 
-**Auto-detection**: if `--source-id` is omitted, the running container is found
-by matching PVE tags or hostname against `LXC_TAGS`. If `--target-id` is omitted,
-the next free VMID at or above 100 is used.
+The VMID never changes across an upgrade, so static IP, PBS backup identity,
+and mount point attachments are untouched by the whole process.
+
+**Auto-detection**: if `--vmid` is omitted, the running container is found
+by matching PVE tags or hostname against `LXC_TAGS`.
 
 **Rollback**: if the health check fails or the user answers "N" at step 7, the
-mount points are re-attached to the source and the source is restarted. The failed
-target CT is left for manual cleanup.
+CT is stopped, `pct rollback`ed to the pre-upgrade snapshot, and restarted. The
+orphaned rootfs volume created during step 5 is freed automatically.
 
 ## Shared library reference
 
@@ -109,7 +113,7 @@ CONFIG_ROOT="$(pwd)"
 source "${CONFIG_ROOT}/../.mise/lib/lxc.sh"
 ```
 
-The library is at `lxc/.mise/lib/lxc.sh` (704 lines). Functions:
+The library is at `lxc/.mise/lib/lxc.sh`. Functions:
 
 ### `lxc_init <name> <config_root> [tag ...]`
 
@@ -156,8 +160,9 @@ lxc_services "caddy" "vector" "victoriametrics" "lxc-agent"
 
 ### `lxc_mp <mp-id> <subdir> <uid>`
 
-Register a persistent mount point subdirectory that needs ownership fixing at cutover.
-Call once per sub-directory that has its own UID namespace.
+Register a persistent mount point subdirectory, checked for presence during
+pre-flight. Since the upgrade never detaches mount points (same VMID
+throughout), this is a sanity check only — not a re-attachment mechanism.
 
 ```bash
 lxc_mp "mp0" "o11y" 100980    # /persistent/o11y owned by UID 100980
@@ -178,13 +183,12 @@ lxc_e2e_hint "curl -sSf https://o11y.chezmoi.sh/metrics/api/v1/query?query=up"
 
 Run the full upgrade flow. Flags:
 
-| Flag                 | Default        | Description                         |
-| -------------------- | -------------- | ----------------------------------- |
-| `--pve-host <host>`  | required       | Proxmox node hostname or IP         |
-| `--source-id <vmid>` | auto-detect    | VMID of the running container       |
-| `--target-id <vmid>` | auto-pick      | VMID for the new container          |
-| `--version <ver>`    | from flake.nix | Image version string                |
-| `--yes` / `-y`       | off            | Skip confirmation prompts (CI-safe) |
+| Flag                | Default        | Description                         |
+| ------------------- | -------------- | ----------------------------------- |
+| `--pve-host <host>` | required       | Proxmox node hostname or IP         |
+| `--vmid <vmid>`     | auto-detect    | VMID of the running container       |
+| `--version <ver>`   | from flake.nix | Image version string                |
+| `--yes` / `-y`      | off            | Skip confirmation prompts (CI-safe) |
 
 ## Adding a new LXC appliance
 
@@ -240,11 +244,10 @@ Run the full upgrade flow. Flags:
 
    ```bash
    #!/usr/bin/env bash
-   # [MISE] description="Upgrade the <name> LXC to a new image version via rootfs swap"
+   # [MISE] description="Upgrade the <name> LXC to a new image version in place"
    # [MISE] dir="{{config_root}}"
    # [USAGE] arg "<pve_host>" help="Hostname or IP of the Proxmox node (e.g. pve.lan)"
-   # [USAGE] flag "-s --source-id <id>" help="VMID of the running container (auto-detected via PVE tags if omitted)"
-   # [USAGE] flag "-t --target-id <id>" help="VMID for the new container (auto-picked if omitted)"
+   # [USAGE] flag "-i --vmid <id>" help="VMID of the running container (auto-detected via PVE tags if omitted)"
    # [USAGE] flag "-V --version <version>" help="Image version — auto-detected from flake if omitted"
    # [USAGE] flag "-y --yes" help="Skip confirmation prompts"
 
@@ -261,8 +264,7 @@ Run the full upgrade flow. Flags:
 
    lxc_upgrade \
      --pve-host "${usage_pve_host}" \
-     --source-id "${usage_source_id-}" \
-     --target-id "${usage_target_id-}" \
+     --vmid "${usage_vmid-}" \
      --version "${usage_version-}" \
      ${usage_yes:+--yes}
    ```
@@ -275,14 +277,14 @@ Run the full upgrade flow. Flags:
 
 ## Common issues
 
-| Symptom                                   | Cause                                                      | Fix                                                     |
-| ----------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------- |
-| `Could not detect version from flake.nix` | `imageVersion` or `version` field not found                | Check the flake.nix field name matches the grep pattern |
-| `<KEY> is empty in <file>`                | SOPS key exists but is blank                               | Populate the key in the SOPS file                       |
-| `Template not found on <host>`            | `lxc:push` was not run yet                                 | Run `mise run lxc:push -- <host>`                       |
-| Source CT not auto-detected               | PVE tags don't include any of `LXC_TAGS`                   | Pass `--source-id` explicitly or add the tag in PVE     |
-| Smoke test fails                          | NixOS activation error, often missing `features.nesting=1` | Add `features: nesting=1` to the Proxmox CT config      |
-| Mount point missing after cutover         | `lxc_mp` not called for a mount                            | Register all mounts with `lxc_mp` in the upgrade script |
+| Symptom                                   | Cause                                                      | Fix                                                                 |
+| ----------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------- |
+| `Could not detect version from flake.nix` | `imageVersion` or `version` field not found                | Check the flake.nix field name matches the grep pattern             |
+| `<KEY> is empty in <file>`                | SOPS key exists but is blank                               | Populate the key in the SOPS file                                   |
+| `Template not found on <host>`            | `lxc:push` was not run yet                                 | Run `mise run lxc:push -- <host>`                                   |
+| CT not auto-detected                      | PVE tags don't include any of `LXC_TAGS`                   | Pass `--vmid` explicitly or add the tag in PVE                      |
+| Smoke test fails                          | NixOS activation error, often missing `features.nesting=1` | Add `features: nesting=1` to the Proxmox CT config                  |
+| Orphaned rootfs volume after a failed run | Script interrupted between step 5 and step 7               | Check `pvesm list <storage>` and free unreferenced volumes manually |
 
 ## References
 

--- a/.agents/skills/lxc-maintenance/SKILL.md
+++ b/.agents/skills/lxc-maintenance/SKILL.md
@@ -99,9 +99,15 @@ and mount point attachments are untouched by the whole process.
 **Auto-detection**: if `--vmid` is omitted, the running container is found
 by matching PVE tags or hostname against `LXC_TAGS`.
 
-**Rollback**: if the health check fails or the user answers "N" at step 7, the
-CT is stopped, `pct rollback`ed to the pre-upgrade snapshot, and restarted. The
-orphaned rootfs volume created during step 5 is freed automatically.
+**Rollback**: the step 6 health check is informational only — it does not
+gate automatically. Answer "N" at step 7 (after reviewing its output) to
+roll back: the CT is stopped, `pct rollback`ed to the pre-upgrade snapshot,
+and restarted, with the orphaned rootfs volume from step 5 freed
+automatically. With `--yes`, step 7 always answers "y" regardless of the
+health check's output — review it yourself before running non-interactively.
+If the script aborts unexpectedly anywhere after the snapshot is taken (a
+remote command failing under `set -e`), an automatic-recovery trap runs the
+same rollback before exiting.
 
 ## Shared library reference
 

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh
@@ -344,12 +344,45 @@ _lxc_pick_free_vmid() {
   echo "${candidate}"
 }
 
+# Attempt automatic rollback if lxc_upgrade aborts unexpectedly (e.g. a
+# remote command fails under `set -e`) after the pre-upgrade snapshot was
+# taken but before the function reached its own commit/rollback decision.
+# Relies on bash's dynamic scoping: pve_host/vmid/snapshot/new_vol are
+# lxc_upgrade's local variables, still visible here because the trap fires
+# while lxc_upgrade's stack frame is active. A no-op on a clean exit or
+# before the snapshot exists; every intentional return path in lxc_upgrade
+# clears the trap first with `trap - EXIT` so this never double-fires.
+_lxc_recover_on_abort() {
+  local ec=$?
+  [[ ${ec} -eq 0 ]] && return
+  [[ -z ${snapshot:-} ]] && return
+
+  echo "" >&2
+  _fail "Upgrade aborted unexpectedly (exit ${ec}) — attempting automatic rollback."
+  if _lxc_ssh "${pve_host}" "
+    set -e
+    pct status ${vmid} | grep -q running && pct stop ${vmid}
+    pct rollback ${vmid} ${snapshot}
+    pct start ${vmid}
+  " 2>/dev/null; then
+    _ok "Rolled back CT ${vmid} to snapshot ${snapshot}."
+    if [[ -n ${new_vol:-} ]] && ! _lxc_ssh "${pve_host}" "pvesm free ${new_vol}" 2>/dev/null; then
+      _warn "Could not free ${new_vol} — free it manually:"
+      echo -e "  ${DIM}  ssh root@${pve_host} \"pvesm free ${new_vol}\"${NC}" >&2
+    fi
+  else
+    echo -e "  ${DIM}Automatic rollback failed — recover manually:${NC}" >&2
+    echo -e "  ${DIM}  ssh root@${pve_host} \"pct stop ${vmid}; pct rollback ${vmid} ${snapshot}; pct start ${vmid}\"${NC}" >&2
+  fi
+}
+
 # ============================================================================
 # lxc_upgrade — in-place rootfs replacement (same CT, snapshot rollback)
 # ============================================================================
 
 lxc_upgrade() {
   local pve_host="" vmid="" version="" auto_yes=""
+  local snapshot="" old_vol="" new_vol=""
 
   while [[ $# -gt 0 ]]; do
     case $1 in
@@ -363,6 +396,8 @@ lxc_upgrade() {
 
   [[ -n ${pve_host} ]] || { echo -e "${RED}[ERROR]${NC} --pve-host is required." >&2; return 1; }
   readonly LXC_YES="${auto_yes}"
+
+  trap _lxc_recover_on_abort EXIT
 
   # Resolve version
   if [[ -n ${version} ]]; then
@@ -411,6 +446,11 @@ lxc_upgrade() {
     fi
   fi
 
+  [[ ${vmid} =~ ^[0-9]+$ ]] || {
+    echo -e "${RED}[ERROR]${NC} Invalid VMID: '${vmid}' (must be numeric)." >&2
+    return 1
+  }
+
   # ------------------------------------------------------------------
   # Header / summary
   # ------------------------------------------------------------------
@@ -444,6 +484,19 @@ lxc_upgrade() {
   fi
   [[ -n ${hostname} ]] || hostname=$(echo "${conf}" | awk '/^hostname:/{print $2}')
   _ok "CT ${vmid} exists (${hostname})"
+
+  # A pre-upgrade-* snapshot already present means a previous run created
+  # one and never reached step 7 (interrupted, or aborted before the
+  # automatic-recovery trap could clean up). Refuse to stack a second
+  # snapshot on top — the operator must resolve the existing one first.
+  local stray_snap
+  stray_snap=$(_lxc_ssh "${pve_host}" "pct listsnapshot ${vmid} 2>/dev/null | grep -oE 'pre-upgrade-[0-9-]+' | head -1" || true)
+  if [[ -n ${stray_snap} ]]; then
+    _fail "CT ${vmid} already has a snapshot '${stray_snap}' from a previous, unfinished upgrade."
+    echo -e "${DIM}        Resolve it first: roll back (ssh root@${pve_host} \"pct stop ${vmid}; pct rollback ${vmid} ${stray_snap}; pct start ${vmid}\")${NC}" >&2
+    echo -e "${DIM}        or, if CT ${vmid} already reflects the desired state, delete it (pct delsnapshot ${vmid} ${stray_snap}).${NC}" >&2
+    return 1
+  fi
 
   # Confirm registered mount points are still present (they are never
   # detached during an in-place upgrade — this is a sanity check only).
@@ -517,13 +570,16 @@ lxc_upgrade() {
   # ==================================================================
   _lxc_step "Snapshot"
 
-  local snapshot
   snapshot="pre-upgrade-$(date +%Y%m%d-%H%M%S)"
   _lxc_ssh "${pve_host}" "pct snapshot ${vmid} ${snapshot} --description 'Before upgrade to ${LXC_UPG_VERSION}'"
   _ok "Snapshot ${snapshot} created"
 
   if ! _lxc_confirm "Ready to start the upgrade? (CT ${vmid} will stop)"; then
     echo -e "  ${DIM}Aborted — snapshot ${snapshot} left in place.${NC}" >&2
+    # Nothing has touched the CT yet (still running, unmodified) — declining
+    # here is not a failure to recover from, so don't let the abort trap
+    # below try to "roll back" a CT that was never actually changed.
+    trap - EXIT
     return 1
   fi
 
@@ -556,15 +612,20 @@ lxc_upgrade() {
     pct create ${scratch_id} ${template_path} --rootfs \${ROOTFS_STORAGE}:\${ROOTFS_SIZE} >&2
     NEW_VOL=\$(grep '^rootfs:' /etc/pve/lxc/${scratch_id}.conf | awk '{print \$2}' | cut -d, -f1)
 
-    sed -i \"0,/^rootfs:/s|^rootfs:.*|rootfs: \${NEW_VOL},size=\${ROOTFS_SIZE}G|\" /etc/pve/lxc/${vmid}.conf
+    # Strip + destroy the scratch config *before* repointing vmid's rootfs:
+    # at no point should two configs simultaneously reference NEW_VOL — if
+    # this were done in the other order, a recovery attempt that destroys
+    # the leftover scratch config (still owning NEW_VOL) after vmid has
+    # already been repointed to it would delete the volume vmid now boots
+    # from.
     sed -i '/^rootfs:/d' /etc/pve/lxc/${scratch_id}.conf
     pct destroy ${scratch_id}
+    sed -i \"0,/^rootfs:/s|^rootfs:.*|rootfs: \${NEW_VOL},size=\${ROOTFS_SIZE}G|\" /etc/pve/lxc/${vmid}.conf
 
     echo \"OLD_VOL=\${OLD_VOL}\"
     echo \"NEW_VOL=\${NEW_VOL}\"
   ")
 
-  local old_vol new_vol
   old_vol=$(echo "${swap_result}" | grep '^OLD_VOL=' | cut -d= -f2)
   new_vol=$(echo "${swap_result}" | grep '^NEW_VOL=' | cut -d= -f2)
   [[ -n ${old_vol} && -n ${new_vol} ]] || {
@@ -621,23 +682,32 @@ lxc_upgrade() {
     _lxc_step "Commit"
 
     _lxc_ssh "${pve_host}" "pct delsnapshot ${vmid} ${snapshot}"
-    _lxc_ssh "${pve_host}" "pvesm free ${old_vol}" 2>/dev/null || true
+    if ! _lxc_ssh "${pve_host}" "pvesm free ${old_vol}" 2>/dev/null; then
+      _warn "Could not free old volume ${old_vol} — free it manually:"
+      echo -e "  ${DIM}  ssh root@${pve_host} \"pvesm free ${old_vol}\"${NC}" >&2
+    fi
     local total
     total=$(($(date +%s) - _LXC_UPGRADE_T0))
     echo "" >&2
     echo -e "${GREEN}${BOLD}  ✓ Upgrade complete${NC} — CT ${vmid} (${hostname}) is on ${LXC_UPG_VERSION} (${total}s)." >&2
     echo "" >&2
+    trap - EXIT
   else
     _lxc_step "Rollback"
     _warn "Rolling back CT ${vmid} to snapshot ${snapshot}..."
 
     _lxc_ssh "${pve_host}" "
+      set -e
       pct stop ${vmid}
       pct rollback ${vmid} ${snapshot}
       pct start ${vmid}
     "
-    _lxc_ssh "${pve_host}" "pvesm free ${new_vol}" 2>/dev/null || true
+    if ! _lxc_ssh "${pve_host}" "pvesm free ${new_vol}" 2>/dev/null; then
+      _warn "Could not free new volume ${new_vol} — free it manually:"
+      echo -e "  ${DIM}  ssh root@${pve_host} \"pvesm free ${new_vol}\"${NC}" >&2
+    fi
     _ok "Rolled back CT ${vmid} to pre-upgrade state."
+    trap - EXIT
     return 1
   fi
 }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh
@@ -11,7 +11,7 @@
 #   lxc_build
 #
 # The upgrade flow auto-detects the running container via PVE tags and
-# auto-picks the next available VMID.
+# upgrades it in place (same VMID), using a Proxmox snapshot for rollback.
 
 # Guard against double-sourcing.
 [[ -n ${_LXC_LIB_LOADED:-} ]] && return 0
@@ -326,8 +326,9 @@ _lxc_detect_source() {
   " 2>/dev/null || true
 }
 
-# Find the first free VMID at or above the configured base.
-_lxc_pick_target() {
+# Find a free VMID at or above the configured base, for disposable/scratch
+# CTs used during the upgrade (never the persistent app VMID).
+_lxc_pick_free_vmid() {
   local pve_host="$1"
   local base="${LXC_VMID_BASE:-100}"
   local used
@@ -344,19 +345,18 @@ _lxc_pick_target() {
 }
 
 # ============================================================================
-# lxc_upgrade — full rootfs-swap upgrade with interactive UI
+# lxc_upgrade — in-place rootfs replacement (same CT, snapshot rollback)
 # ============================================================================
 
 lxc_upgrade() {
-  local pve_host="" source_id="" target_id="" version="" auto_yes=""
+  local pve_host="" vmid="" version="" auto_yes=""
 
   while [[ $# -gt 0 ]]; do
     case $1 in
-      --pve-host)   pve_host="$2";   shift 2 ;;
-      --source-id)  source_id="$2";  shift 2 ;;
-      --target-id)  target_id="$2";  shift 2 ;;
-      --version)    version="$2";    shift 2 ;;
-      --yes|-y)     auto_yes="1";    shift ;;
+      --pve-host) pve_host="$2"; shift 2 ;;
+      --vmid)     vmid="$2";     shift 2 ;;
+      --version)  version="$2";  shift 2 ;;
+      --yes|-y)   auto_yes="1";  shift ;;
       *) echo -e "${RED}[ERROR]${NC} Unknown argument: $1" >&2; return 1 ;;
     esac
   done
@@ -381,46 +381,33 @@ lxc_upgrade() {
   _hdr "Initiating ${LXC_NAME} upgrade"
 
   # ------------------------------------------------------------------
-  # Resolve source VMID (auto-detect via tags/hostname)
+  # Resolve VMID (auto-detect via tags/hostname)
   # ------------------------------------------------------------------
-  local source_hostname=""
+  local hostname=""
 
-  if [[ -z ${source_id} ]]; then
+  if [[ -z ${vmid} ]]; then
     local detected
     detected=$(_lxc_detect_source "${pve_host}")
 
     if [[ -n ${detected} ]]; then
-      source_id=$(echo "${detected}" | awk '{print $1}')
-      source_hostname=$(echo "${detected}" | awk '{print $2}')
-      _info "Detected CT ${source_id} (${source_hostname}) via tags/hostname"
+      vmid=$(echo "${detected}" | awk '{print $1}')
+      hostname=$(echo "${detected}" | awk '{print $2}')
+      _info "Detected CT ${vmid} (${hostname}) via tags/hostname"
     fi
 
-    if [[ -z ${source_id} ]]; then
+    if [[ -z ${vmid} ]]; then
       if [[ -n ${LXC_YES} ]]; then
-        echo -e "${RED}[ERROR]${NC} Cannot auto-detect source CT — use --source-id." >&2
+        echo -e "${RED}[ERROR]${NC} Cannot auto-detect CT — use --vmid." >&2
         return 1
       fi
-      _lxc_prompt "  ${BOLD}?${NC} Source CT VMID (no auto-match found): " source_id || true
-      [[ -n ${source_id} ]] || { echo -e "${RED}[ERROR]${NC} Source VMID is required." >&2; return 1; }
+      _lxc_prompt "  ${BOLD}?${NC} CT VMID (no auto-match found): " vmid || true
+      [[ -n ${vmid} ]] || { echo -e "${RED}[ERROR]${NC} VMID is required." >&2; return 1; }
     else
       if [[ -z ${LXC_YES} && -t 0 ]]; then
         local override
-        _lxc_prompt "  ${BOLD}?${NC} Source CT ${DIM}[${source_id}]${NC}: " override || true
-        [[ -n ${override} ]] && source_id="${override}"
+        _lxc_prompt "  ${BOLD}?${NC} CT ${DIM}[${vmid}]${NC}: " override || true
+        [[ -n ${override} ]] && vmid="${override}"
       fi
-    fi
-  fi
-
-  # ------------------------------------------------------------------
-  # Resolve target VMID (auto-pick next free)
-  # ------------------------------------------------------------------
-  if [[ -z ${target_id} ]]; then
-    target_id=$(_lxc_pick_target "${pve_host}")
-    _info "Auto-picked target VMID: ${target_id}"
-    if [[ -z ${LXC_YES} && -t 0 ]]; then
-      local override
-      _lxc_prompt "  ${BOLD}?${NC} Target CT ${DIM}[${target_id}]${NC}: " override || true
-      [[ -n ${override} ]] && target_id="${override}"
     fi
   fi
 
@@ -431,8 +418,7 @@ lxc_upgrade() {
   _hdr "${LXC_NAME} · upgrade"
   echo -e "${CYAN}${DIM}──────────────────────────────────────────────────────${NC}" >&2
   printf "${CYAN}%-12s %s${NC}\n" "Template" "${template}" >&2
-  printf "${CYAN}%-12s CT %s%s${NC}\n" "Source" "${source_id}" "${source_hostname:+ (${source_hostname})}" >&2
-  printf "${CYAN}%-12s CT %s${NC}\n" "Target" "${target_id}" >&2
+  printf "${CYAN}%-12s CT %s%s${NC}\n" "Container" "${vmid}" "${hostname:+ (${hostname})}" >&2
 
   # ==================================================================
   # Step 1 — Pre-flight checks
@@ -446,183 +432,158 @@ lxc_upgrade() {
   fi
   _ok "Template present on PVE"
 
-  local source_conf
-  source_conf=$(_lxc_ssh "${pve_host}" "cat /etc/pve/lxc/${source_id}.conf 2>/dev/null" || true)
-  if [[ -z ${source_conf} ]]; then
-    _fail "CT ${source_id} does not exist on ${pve_host}."
+  # Use `pct config` (not the raw conf file) everywhere below: once a
+  # pre-upgrade snapshot exists, the conf file also contains an embedded
+  # [snapname] section with its own copy of every key (rootfs, mpN, ...),
+  # and a plain grep on the file would match both and double the value.
+  local conf
+  conf=$(_lxc_ssh "${pve_host}" "pct config ${vmid} 2>/dev/null" || true)
+  if [[ -z ${conf} ]]; then
+    _fail "CT ${vmid} does not exist on ${pve_host}."
     return 1
   fi
-  [[ -n ${source_hostname} ]] || source_hostname=$(echo "${source_conf}" | awk '/^hostname:/{print $2}')
-  _ok "Source CT ${source_id} exists (${source_hostname})"
+  [[ -n ${hostname} ]] || hostname=$(echo "${conf}" | awk '/^hostname:/{print $2}')
+  _ok "CT ${vmid} exists (${hostname})"
 
-  local target_conf
-  target_conf=$(_lxc_ssh "${pve_host}" "cat /etc/pve/lxc/${target_id}.conf 2>/dev/null" || true)
-  if [[ -n ${target_conf} ]]; then
-    _fail "CT ${target_id} already exists. Destroy it first or choose another VMID."
-    return 1
-  fi
-  _ok "Target VMID ${target_id} is free"
-
-  # Extract all mpX specs (if any mount points are registered)
+  # Confirm registered mount points are still present (they are never
+  # detached during an in-place upgrade — this is a sanity check only).
   if _lxc_has_mp; then
     local _uid
     while IFS= read -r _uid; do
       [[ -n ${_uid} ]] || continue
       local spec
-      spec=$(_lxc_ssh "${pve_host}" "grep '^${_uid}:' /etc/pve/lxc/${source_id}.conf 2>/dev/null | sed 's/^${_uid}: //'" || true)
+      spec=$(_lxc_ssh "${pve_host}" "pct config ${vmid} 2>/dev/null | grep '^${_uid}:' | sed 's/^${_uid}: //'" || true)
       if [[ -z ${spec} ]]; then
-        _fail "No ${_uid} found in CT ${source_id} config."
+        _fail "No ${_uid} found in CT ${vmid} config."
         return 1
       fi
-      local mnt
-      mnt=$(echo "${spec}" | grep -oE 'mp=[^,]+' | cut -d= -f2-)
       _ok "${_uid}: ${spec}"
-      # Store spec and mount path for later steps (mp IDs are alphanumeric, safe for eval)
-      eval "_MP_SPEC_${_uid}=\"\${spec}\""
-      eval "_MP_MOUNT_${_uid}=\"\${mnt}\""
     done <<< "$(_lxc_unique_mp_ids)"
   fi
 
-  if ! _lxc_confirm "Upgrade CT ${source_id} → CT ${target_id}?"; then
+  if ! _lxc_confirm "Upgrade CT ${vmid} in place to ${LXC_UPG_VERSION}?"; then
     echo -e "  ${DIM}Aborted.${NC}" >&2
     return 1
   fi
 
   # ==================================================================
-  # Step 2 — Create target CT (rootfs only)
+  # Step 2 — Temporary CT smoke-test
   # ==================================================================
-  _lxc_step "Create target CT"
+  _lxc_step "Temporary CT smoke-test"
+
+  local smoke_id
+  smoke_id=$(_lxc_pick_free_vmid "${pve_host}")
 
   _lxc_ssh "${pve_host}" "
-    ROOTFS_LINE=\$(grep '^rootfs:' /etc/pve/lxc/${source_id}.conf | sed 's/^rootfs: //')
+    CONF=\$(pct config ${vmid})
+    ROOTFS_LINE=\$(echo \"\$CONF\" | grep '^rootfs:' | sed 's/^rootfs: //')
     ROOTFS_STORAGE=\$(echo \"\$ROOTFS_LINE\" | cut -d: -f1)
     ROOTFS_SIZE=\$(echo \"\$ROOTFS_LINE\" | grep -oE 'size=[0-9]+' | cut -d= -f2)
-    FEATURES=\$(grep '^features:' /etc/pve/lxc/${source_id}.conf | sed 's/^features: //')
-    MEMORY=\$(grep '^memory:' /etc/pve/lxc/${source_id}.conf | awk '{print \$2}')
-    CORES=\$(grep '^cores:' /etc/pve/lxc/${source_id}.conf | awk '{print \$2}')
+    FEATURES=\$(echo \"\$CONF\" | grep '^features:' | sed 's/^features: //')
+    MEMORY=\$(echo \"\$CONF\" | grep '^memory:' | awk '{print \$2}')
+    CORES=\$(echo \"\$CONF\" | grep '^cores:' | awk '{print \$2}')
 
-    pct create ${target_id} ${template_path} \
+    pct create ${smoke_id} ${template_path} \
       --rootfs \$ROOTFS_STORAGE:\$ROOTFS_SIZE \
       --features \"\$FEATURES\" \
       --memory \$MEMORY \
       --cores \$CORES \
       --swap 0
   "
-  _ok "Created CT ${target_id} from template"
 
-  # ==================================================================
-  # Step 3 — Smoke-test
-  # ==================================================================
-  _lxc_step "Smoke-test"
-
-  _lxc_ssh "${pve_host}" "pct start ${target_id}" || true
+  _lxc_ssh "${pve_host}" "pct start ${smoke_id}" || true
   sleep 10
 
   local activation
-  activation=$(_lxc_ssh "${pve_host}" "pct exec ${target_id} -- /bin/sh -c 'test -e /run/current-system && echo OK || echo FAIL'" || true)
+  activation=$(_lxc_ssh "${pve_host}" "pct exec ${smoke_id} -- /bin/sh -c 'test -e /run/current-system && echo OK || echo FAIL'" || true)
   if [[ ${activation} != *"OK"* ]]; then
     _fail "NixOS activation failed — is features:nesting=1 set?"
-    _lxc_ssh "${pve_host}" "pct stop ${target_id}" 2>/dev/null || true
+    _lxc_ssh "${pve_host}" "pct stop ${smoke_id}" 2>/dev/null || true
+    _lxc_ssh "${pve_host}" "pct destroy ${smoke_id}" 2>/dev/null || true
     return 1
   fi
   _ok "NixOS activation passed"
 
-  _lxc_ssh "${pve_host}" "pct exec ${target_id} -- /run/current-system/sw/bin/bash -lc '
+  _lxc_ssh "${pve_host}" "pct exec ${smoke_id} -- /run/current-system/sw/bin/bash -lc '
     systemctl is-system-running
     systemctl --failed --no-legend
   '" >&2 || true
 
-  _lxc_ssh "${pve_host}" "pct stop ${target_id}"
-  _ok "Smoke test passed"
+  _lxc_ssh "${pve_host}" "pct stop ${smoke_id}; pct destroy ${smoke_id}"
+  _ok "Smoke test passed — temporary CT ${smoke_id} destroyed"
 
   # ==================================================================
-  # Step 4 — Merge config (rootfs swap)
+  # Step 3 — Snapshot
   # ==================================================================
-  if _lxc_has_mp; then
-    _lxc_step "Merge config" "(rootfs swap, strip mounts)"
-  else
-    _lxc_step "Merge config" "(rootfs swap)"
+  _lxc_step "Snapshot"
+
+  local snapshot
+  snapshot="pre-upgrade-$(date +%Y%m%d-%H%M%S)"
+  _lxc_ssh "${pve_host}" "pct snapshot ${vmid} ${snapshot} --description 'Before upgrade to ${LXC_UPG_VERSION}'"
+  _ok "Snapshot ${snapshot} created"
+
+  if ! _lxc_confirm "Ready to start the upgrade? (CT ${vmid} will stop)"; then
+    echo -e "  ${DIM}Aborted — snapshot ${snapshot} left in place.${NC}" >&2
+    return 1
   fi
 
-  _lxc_ssh "${pve_host}" "
-    NEW_ROOTFS_VOL=\$(grep '^rootfs:' /etc/pve/lxc/${target_id}.conf | awk '{print \$2}' | cut -d, -f1)
-    OLD_ROOTFS_VOL=\$(grep '^rootfs:' /etc/pve/lxc/${source_id}.conf | sed 's/^rootfs: //' | cut -d, -f1)
-    sed \"s|\$OLD_ROOTFS_VOL|\$NEW_ROOTFS_VOL|g\" /etc/pve/lxc/${source_id}.conf > /etc/pve/lxc/${target_id}.conf
-  "
-
-  # Strip all mpX lines from target config (stateful LXCs)
-  if _lxc_has_mp; then
-    _lxc_ssh "${pve_host}" "sed -i '/^mp[0-9]:/d' /etc/pve/lxc/${target_id}.conf"
-  fi
-
-  # Copy firewall rules
-  _lxc_ssh "${pve_host}" "
-    if [[ -f /etc/pve/firewall/${source_id}.fw ]]; then
-      cp /etc/pve/firewall/${source_id}.fw /etc/pve/firewall/${target_id}.fw
-    fi
-  " 2>/dev/null || true
-  _ok "Config merged"
-
   # ==================================================================
-  # Step 5 — Cutover (downtime starts)
+  # Step 4 — Stop
   # ==================================================================
-  if ! _lxc_confirm "Ready to cut over? (CT ${source_id} will stop)"; then
-    echo -e "  ${DIM}Aborted — target ready but not started.${NC}" >&2
-    return 0
-  fi
-
-  _lxc_step "Cutover" "(downtime)"
+  _lxc_step "Stop CT ${vmid}" "(downtime starts)"
   local t0
   t0=$(date +%s)
 
-  if _lxc_has_mp; then
-    # Build detach + attach commands for all mount points
-    local mp_detach=""
-    local mp_attach=""
-    local _uid
-    while IFS= read -r _uid; do
-      [[ -n ${_uid} ]] || continue
-      eval "local spec=\"\${_MP_SPEC_${_uid}}\""
-      mp_detach+="pct set ${source_id} --delete ${_uid}; "
-      mp_attach+="pct set ${target_id} -${_uid} '${spec}'; "
-    done <<< "$(_lxc_unique_mp_ids)"
+  _lxc_ssh "${pve_host}" "pct stop ${vmid}"
+  _ok "CT ${vmid} stopped"
 
-    _lxc_ssh "${pve_host}" "pct stop ${source_id}; ${mp_detach} ${mp_attach}"
+  # ==================================================================
+  # Step 5 — Replace rootfs in-place, start
+  # ==================================================================
+  _lxc_step "Replace rootfs in-place"
 
-    # Fix ownership on mount subdirectories
-    local chown_cmds=""
-    local j
-    for ((j = 0; j < ${#_LXC_MP_DIRS[@]}; j++)); do
-      local mp_id="${_LXC_MP_IDS[$j]}"
-      local dir="${_LXC_MP_DIRS[$j]}"
-      local uid="${_LXC_MP_UIDS[$j]}"
-      eval "local mount_path=\"\${_MP_MOUNT_${mp_id}}\""
-      chown_cmds+="mkdir -p /var/lib/lxc/${target_id}/rootfs${mount_path}/${dir}; "
-      chown_cmds+="chown --recursive ${uid}:${uid} /var/lib/lxc/${target_id}/rootfs${mount_path}/${dir}; "
-    done
+  local scratch_id
+  scratch_id=$(_lxc_pick_free_vmid "${pve_host}")
 
-    _lxc_ssh "${pve_host}" "
-      pct mount ${target_id} >/dev/null
-      ${chown_cmds}
-      pct unmount ${target_id}
-      pct start ${target_id}
-    "
-  else
-    _lxc_ssh "${pve_host}" "
-      pct stop ${source_id}
-      pct start ${target_id}
-    "
-  fi
+  local swap_result
+  swap_result=$(_lxc_ssh "${pve_host}" "
+    set -e
+    ROOTFS_LINE=\$(pct config ${vmid} | grep '^rootfs:' | sed 's/^rootfs: //')
+    ROOTFS_STORAGE=\$(echo \"\$ROOTFS_LINE\" | cut -d: -f1)
+    ROOTFS_SIZE=\$(echo \"\$ROOTFS_LINE\" | grep -oE 'size=[0-9]+' | cut -d= -f2)
+    OLD_VOL=\$(echo \"\$ROOTFS_LINE\" | cut -d, -f1)
+
+    pct create ${scratch_id} ${template_path} --rootfs \${ROOTFS_STORAGE}:\${ROOTFS_SIZE} >&2
+    NEW_VOL=\$(grep '^rootfs:' /etc/pve/lxc/${scratch_id}.conf | awk '{print \$2}' | cut -d, -f1)
+
+    sed -i \"0,/^rootfs:/s|^rootfs:.*|rootfs: \${NEW_VOL},size=\${ROOTFS_SIZE}G|\" /etc/pve/lxc/${vmid}.conf
+    sed -i '/^rootfs:/d' /etc/pve/lxc/${scratch_id}.conf
+    pct destroy ${scratch_id}
+
+    echo \"OLD_VOL=\${OLD_VOL}\"
+    echo \"NEW_VOL=\${NEW_VOL}\"
+  ")
+
+  local old_vol new_vol
+  old_vol=$(echo "${swap_result}" | grep '^OLD_VOL=' | cut -d= -f2)
+  new_vol=$(echo "${swap_result}" | grep '^NEW_VOL=' | cut -d= -f2)
+  [[ -n ${old_vol} && -n ${new_vol} ]] || {
+    _fail "Could not determine rootfs volumes during swap."
+    return 1
+  }
+  _ok "rootfs swapped: ${old_vol} → ${new_vol}"
+
+  _lxc_ssh "${pve_host}" "pct start ${vmid}"
 
   local elapsed
   elapsed=$(($(date +%s) - t0))
-  _ok "Cutover done in ${elapsed}s — services warming up"
+  _ok "CT ${vmid} started in ${elapsed}s — services warming up"
 
   # ==================================================================
   # Step 6 — Health check
   # ==================================================================
-  _lxc_step "Health check" "(15s warm-up)"
-  sleep 15
+  _lxc_step "Health check" "(30s warm-up)"
+  sleep 30
 
   local svc_list=""
   local s
@@ -630,7 +591,7 @@ lxc_upgrade() {
     svc_list+="printf \"%-24s %s\\\\n\" \"${s}\" \"\$(systemctl is-active ${s})\"; "
   done
 
-  _lxc_ssh "${pve_host}" "pct exec ${target_id} -- /run/current-system/sw/bin/bash -lc '
+  _lxc_ssh "${pve_host}" "pct exec ${vmid} -- /run/current-system/sw/bin/bash -lc '
     echo === system ===
     systemctl is-system-running
     systemctl --failed --no-legend
@@ -645,59 +606,38 @@ lxc_upgrade() {
   fi
 
   # ==================================================================
-  # Step 7 — Decommission or rollback
+  # Step 7 — Commit or rollback
   # ==================================================================
   local confirm
   if [[ -n ${LXC_YES} ]]; then
     confirm="y"
   else
     local inp
-    _lxc_prompt "  ${BOLD}?${NC} CT ${target_id} is working correctly? ${DIM}[y/N]${NC} " inp || inp=""
+    _lxc_prompt "  ${BOLD}?${NC} CT ${vmid} is working correctly? ${DIM}[y/N]${NC} " inp || inp=""
     confirm="${inp}"
   fi
 
   if [[ ${confirm} =~ ^[Yy]$ ]]; then
-    _lxc_step "Decommission CT ${source_id}"
+    _lxc_step "Commit"
 
-    _lxc_ssh "${pve_host}" "
-      sed -i '/^rootfs:/d; /^unused0:/d' /etc/pve/lxc/${source_id}.conf
-      pct destroy ${source_id}
-    "
+    _lxc_ssh "${pve_host}" "pct delsnapshot ${vmid} ${snapshot}"
+    _lxc_ssh "${pve_host}" "pvesm free ${old_vol}" 2>/dev/null || true
     local total
     total=$(($(date +%s) - _LXC_UPGRADE_T0))
     echo "" >&2
-    echo -e "${GREEN}${BOLD}  ✓ Upgrade complete${NC} — CT ${target_id} (${source_hostname}) is live (${total}s)." >&2
+    echo -e "${GREEN}${BOLD}  ✓ Upgrade complete${NC} — CT ${vmid} (${hostname}) is on ${LXC_UPG_VERSION} (${total}s)." >&2
     echo "" >&2
   else
     _lxc_step "Rollback"
-    _warn "Rolling back — restarting CT ${source_id}..."
+    _warn "Rolling back CT ${vmid} to snapshot ${snapshot}..."
 
-    if _lxc_has_mp; then
-      # Reverse all mount point attachments
-      local rb_detach=""
-      local rb_attach=""
-      local _uid
-      while IFS= read -r _uid; do
-        [[ -n ${_uid} ]] || continue
-        eval "local spec=\"\${_MP_SPEC_${_uid}}\""
-        rb_detach+="pct set ${target_id} --delete ${_uid}; "
-        rb_attach+="pct set ${source_id} -${_uid} '${spec}'; "
-      done <<< "$(_lxc_unique_mp_ids)"
-
-      _lxc_ssh "${pve_host}" "
-        pct stop ${target_id}
-        ${rb_detach} ${rb_attach}
-        pct start ${source_id}
-      "
-    else
-      _lxc_ssh "${pve_host}" "
-        pct stop ${target_id}
-        pct start ${source_id}
-      "
-    fi
-    _ok "Rolled back to CT ${source_id}."
-    echo -e "  ${DIM}Destroy the failed target:${NC}" >&2
-    echo -e "  ${DIM}  ssh root@${pve_host} \"sed -i '/^unused0:/d' /etc/pve/lxc/${target_id}.conf && pct destroy ${target_id}\"${NC}" >&2
+    _lxc_ssh "${pve_host}" "
+      pct stop ${vmid}
+      pct rollback ${vmid} ${snapshot}
+      pct start ${vmid}
+    "
+    _lxc_ssh "${pve_host}" "pvesm free ${new_vol}" 2>/dev/null || true
+    _ok "Rolled back CT ${vmid} to pre-upgrade state."
     return 1
   fi
 }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/.mise.toml
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/.mise.toml
@@ -9,7 +9,7 @@
 #   mise run lxc:secrets:sync                       # Sync Crossplane tokens (Cloudflare + Tailscale); preserves Alertmanager URLs
 #   mise run lxc:build                              # Build the LXC tarball with all secrets baked in
 #   mise run lxc:push -- <pve-host>                 # Upload template to Proxmox (local storage)
-#   mise run lxc:upgrade -- <pve-host> <src> <dst>  # Upgrade a running LXC to a new image
+#   mise run lxc:upgrade -- <pve-host> --vmid <vmid>  # Upgrade a running LXC in place
 #
 # Secret files (both SOPS/age-encrypted, baked into the image at build time):
 #   secrets/caddy.sops.env          CLOUDFLARE_API_TOKEN          (Crossplane — DNS-01 ACME)
@@ -131,4 +131,4 @@ run = '''
 # -----------------------------------------------------------------------------
 # lxc:build   → .mise/tasks/lxc/build   (build LXC tarball with all secrets baked in)
 # lxc:push    → .mise/tasks/lxc/push    (upload template to Proxmox)
-# lxc:upgrade → .mise/tasks/lxc/upgrade (upgrade running LXC to new image)
+# lxc:upgrade → .mise/tasks/lxc/upgrade (in-place rootfs-swap upgrade, same VMID)

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/.mise/tasks/lxc/upgrade
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/.mise/tasks/lxc/upgrade
@@ -2,8 +2,7 @@
 # [MISE] description="Upgrade the observability LXC to a new image version via rootfs swap"
 # [MISE] dir="{{config_root}}"
 # [USAGE] arg "<pve_host>" help="Hostname or IP of the Proxmox node (e.g. pve.lan)"
-# [USAGE] flag "-s --source-id <id>" help="VMID of the running container (auto-detected via PVE tags if omitted)"
-# [USAGE] flag "-t --target-id <id>" help="VMID for the new container (auto-picked if omitted)"
+# [USAGE] flag "-i --vmid <id>" help="VMID of the running container (auto-detected via PVE tags if omitted)"
 # [USAGE] flag "-V --version <version>" help="Image version (e.g. 2026.06.14-2) — auto-detected from flake if omitted"
 # [USAGE] flag "-y --yes" help="Skip confirmation prompts"
 
@@ -21,7 +20,6 @@ lxc_e2e_hint "curl -sSf https://o11y.chezmoi.sh/metrics/api/v1/query?query=up"
 
 lxc_upgrade \
   --pve-host "${usage_pve_host}" \
-  --source-id "${usage_source_id-}" \
-  --target-id "${usage_target_id-}" \
+  --vmid "${usage_vmid-}" \
   --version "${usage_version-}" \
   ${usage_yes:+--yes}

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/.mise.toml
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/.mise.toml
@@ -8,7 +8,7 @@
 #   mise run lxc:secrets:sync                              # Fetch Cloudflare token from cluster → secrets/caddy.sops.env
 #   mise run lxc:build                                     # Build the LXC tarball with Cloudflare token baked in
 #   mise run lxc:push -- <pve-host>                        # Upload template to Proxmox (local storage)
-#   mise run lxc:upgrade -- <pve-host> <src> <dest>        # Upgrade a running LXC to a new image
+#   mise run lxc:upgrade -- <pve-host> --vmid <vmid>        # Upgrade a running LXC in place
 #
 # Typical workflow (first time):
 #   mise run lxc:secrets:sync              # Requires kubectl access to amiya.akn
@@ -18,7 +18,7 @@
 # Typical workflow (upgrade):
 #   mise run lxc:build
 #   mise run lxc:push -- pve.lan
-#   mise run lxc:upgrade -- pve.lan <source_id> <target_id>
+#   mise run lxc:upgrade -- pve.lan --vmid <vmid>
 #
 # File-based tasks (bash scripts, easier to maintain):
 #   .mise/tasks/lxc/build    — build task
@@ -76,4 +76,4 @@ dir = "{{ config_root }}"
 # -----------------------------------------------------------------------------
 # lxc:build   → .mise/tasks/lxc/build   (build LXC tarball with token baked in)
 # lxc:push    → .mise/tasks/lxc/push    (upload template to Proxmox)
-# lxc:upgrade → .mise/tasks/lxc/upgrade (upgrade running LXC to new image)
+# lxc:upgrade → .mise/tasks/lxc/upgrade (in-place rootfs-swap upgrade, same VMID)

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/.mise/tasks/lxc/upgrade
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/.mise/tasks/lxc/upgrade
@@ -2,8 +2,7 @@
 # [MISE] description="Upgrade the oci-registry LXC to a new image version via rootfs swap"
 # [MISE] dir="{{config_root}}"
 # [USAGE] arg "<pve_host>" help="Hostname or IP of the Proxmox node (e.g. pve.lan)"
-# [USAGE] flag "-s --source-id <id>" help="VMID of the running container (auto-detected via PVE tags if omitted)"
-# [USAGE] flag "-t --target-id <id>" help="VMID for the new container (auto-picked if omitted)"
+# [USAGE] flag "-i --vmid <id>" help="VMID of the running container (auto-detected via PVE tags if omitted)"
 # [USAGE] flag "-V --version <version>" help="Image version (e.g. 2026.06.14-2) — auto-detected from flake if omitted"
 # [USAGE] flag "-y --yes" help="Skip confirmation prompts"
 
@@ -21,7 +20,6 @@ lxc_e2e_hint "curl -sSf https://oci.chezmoi.sh/v2/"
 
 lxc_upgrade \
   --pve-host "${usage_pve_host}" \
-  --source-id "${usage_source_id-}" \
-  --target-id "${usage_target_id-}" \
+  --vmid "${usage_vmid-}" \
   --version "${usage_version-}" \
   ${usage_yes:+--yes}

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/.mise.toml
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/.mise.toml
@@ -20,12 +20,12 @@
 #     mise run lxc:secrets:omni           # Paste key → omni.sops.env
 #     mise run lxc:build
 #     mise run lxc:push -- <pve-host>
-#     mise run lxc:upgrade -- <pve-host> <source_id>
+#     mise run lxc:upgrade -- <pve-host> --vmid <vmid>
 #
 # Typical upgrade workflow (after initial setup):
 #     mise run lxc:build
 #     mise run lxc:push -- <pve-host>
-#     mise run lxc:upgrade -- <pve-host> <source_id>
+#     mise run lxc:upgrade -- <pve-host> --vmid <vmid>
 #
 # Secret files (SOPS/age-encrypted):
 #   secrets/proxmox.sops.env   PROXMOX_PASSWORD         (Proxmox API password)
@@ -34,7 +34,7 @@
 # File-based tasks:
 #   .mise/tasks/lxc/build    — build LXC tarball with secrets baked in
 #   .mise/tasks/lxc/push     — upload template to Proxmox
-#   .mise/tasks/lxc/upgrade  — rootfs-swap upgrade of a running LXC
+#   .mise/tasks/lxc/upgrade  — in-place rootfs-swap upgrade (same VMID)
 # =============================================================================
 
 [tools]
@@ -93,4 +93,4 @@ run = '''
 # -----------------------------------------------------------------------------
 # lxc:build   → .mise/tasks/lxc/build   (build LXC tarball)
 # lxc:push    → .mise/tasks/lxc/push    (upload to Proxmox)
-# lxc:upgrade → .mise/tasks/lxc/upgrade (rootfs-swap upgrade)
+# lxc:upgrade → .mise/tasks/lxc/upgrade (in-place rootfs-swap upgrade, same VMID)

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/.mise/tasks/lxc/upgrade
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/.mise/tasks/lxc/upgrade
@@ -2,8 +2,7 @@
 # [MISE] description="Upgrade the omni-infra-provider-proxmox LXC to a new image version"
 # [MISE] dir="{{config_root}}"
 # [USAGE] arg "<pve_host>" help="Hostname or IP of the Proxmox node (e.g. pve.lan)"
-# [USAGE] flag "-s --source-id <id>" help="VMID of the running container (auto-detected via PVE tags if omitted)"
-# [USAGE] flag "-t --target-id <id>" help="VMID for the new container (auto-picked if omitted)"
+# [USAGE] flag "-i --vmid <id>" help="VMID of the running container (auto-detected via PVE tags if omitted)"
 # [USAGE] flag "-V --version <version>" help="Image version (e.g. 2026.06.14-2) — auto-detected from flake if omitted"
 # [USAGE] flag "-y --yes" help="Skip confirmation prompts"
 
@@ -18,7 +17,6 @@ lxc_services "omni-infra-provider-proxmox" "prometheus-node-exporter" "lxc-agent
 
 lxc_upgrade \
   --pve-host "${usage_pve_host}" \
-  --source-id "${usage_source_id-}" \
-  --target-id "${usage_target_id-}" \
+  --vmid "${usage_vmid-}" \
   --version "${usage_version-}" \
   ${usage_yes:+--yes}

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/flake.nix
@@ -18,7 +18,7 @@
   #       mise run lxc:secrets:proxmox && mise run lxc:build && mise run lxc:push -- <pve>
   #   Phase 2 — after registering the provider in Omni UI
   #       mise run lxc:secrets:omni && mise run lxc:build && mise run lxc:push -- <pve>
-  #       mise run lxc:upgrade -- <pve> <source_id>
+  #       mise run lxc:upgrade -- <pve> --vmid <vmid>
   # ---------------------------------------------------------------------------
 
   inputs.nixpkgs.url = "nixpkgs/nixos-26.05";

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/.mise.toml
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/.mise.toml
@@ -10,7 +10,7 @@
 #   mise run lxc:secrets:sync                              # Fetch Cloudflare token from cluster → secrets/caddy.sops.env
 #   mise run lxc:build                                     # Build the LXC tarball with secrets baked in
 #   mise run lxc:push -- <pve-host>                        # Upload template to Proxmox (local storage)
-#   mise run lxc:upgrade -- <pve-host> <src> [-t <dst>]    # Upgrade a running LXC (target VMID auto-picked ≥ 100 if omitted)
+#   mise run lxc:upgrade -- <pve-host> --vmid <vmid>       # Upgrade a running LXC in place
 #
 # Typical workflow (first time):
 #   mise run lxc:secrets:rotate            # Sets the Dex admin password
@@ -21,7 +21,7 @@
 # Typical workflow (upgrade):
 #   mise run lxc:build
 #   mise run lxc:push -- pve.lan
-#   mise run lxc:upgrade -- pve.lan <source_id> <target_id>
+#   mise run lxc:upgrade -- pve.lan --vmid <vmid>
 #
 # Secret files (SOPS/age-encrypted, baked into the image at build time):
 #   secrets/omni.sops.env    DEX_ADMIN_PASSWORD_HASH    (operator-provided — bcrypt hash for the Dex admin user)
@@ -123,4 +123,4 @@ run = '''
 # -----------------------------------------------------------------------------
 # lxc:build   → .mise/tasks/lxc/build   (build LXC tarball with secrets baked in)
 # lxc:push    → .mise/tasks/lxc/push    (upload template to Proxmox)
-# lxc:upgrade → .mise/tasks/lxc/upgrade (rootfs-swap upgrade of a running LXC)
+# lxc:upgrade → .mise/tasks/lxc/upgrade (in-place rootfs-swap upgrade, same VMID)

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/.mise/tasks/lxc/upgrade
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/.mise/tasks/lxc/upgrade
@@ -2,8 +2,7 @@
 # [MISE] description="Upgrade the Omni LXC to a new image version via rootfs swap"
 # [MISE] dir="{{config_root}}"
 # [USAGE] arg "<pve_host>" help="Hostname or IP of the Proxmox node (e.g. pve.lan)"
-# [USAGE] flag "-s --source-id <id>" help="VMID of the running container (auto-detected via PVE tags if omitted)"
-# [USAGE] flag "-t --target-id <id>" help="VMID for the new container (auto-picked if omitted)"
+# [USAGE] flag "-i --vmid <id>" help="VMID of the running container (auto-detected via PVE tags if omitted)"
 # [USAGE] flag "-V --version <version>" help="Image version (e.g. 2026.06.14-2) — auto-detected from flake if omitted"
 # [USAGE] flag "-y --yes" help="Skip confirmation prompts"
 
@@ -21,7 +20,6 @@ lxc_e2e_hint "curl -sSfk https://omni.chezmoi.sh/"
 
 lxc_upgrade \
   --pve-host "${usage_pve_host}" \
-  --source-id "${usage_source_id-}" \
-  --target-id "${usage_target_id-}" \
+  --vmid "${usage_vmid-}" \
   --version "${usage_version-}" \
   ${usage_yes:+--yes}

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/.mise.toml
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/.mise.toml
@@ -10,7 +10,7 @@
 #   mise run lxc:secrets:rotate                     # Interactively set/rotate the PVE token (and host)
 #   mise run lxc:build                              # Build the LXC tarball with secrets baked in
 #   mise run lxc:push -- <pve-host>                 # Upload template to Proxmox (local storage)
-#   mise run lxc:upgrade -- <pve-host> <src> <dst>  # Upgrade a running LXC to a new image
+#   mise run lxc:upgrade -- <pve-host> --vmid <vmid>  # Upgrade a running LXC in place
 #
 # Secret files (SOPS/age-encrypted, baked into the image at build time):
 #   secrets/pve-exporter.sops.env  PVE_HOST        (operator-provided — PVE API host address)
@@ -119,4 +119,4 @@ run = '''
 # -----------------------------------------------------------------------------
 # lxc:build   → .mise/tasks/lxc/build   (build LXC tarball with secrets baked in)
 # lxc:push    → .mise/tasks/lxc/push    (upload template to Proxmox)
-# lxc:upgrade → .mise/tasks/lxc/upgrade (upgrade running LXC to new image)
+# lxc:upgrade → .mise/tasks/lxc/upgrade (in-place rootfs-swap upgrade, same VMID)

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/.mise/tasks/lxc/upgrade
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/.mise/tasks/lxc/upgrade
@@ -2,8 +2,7 @@
 # [MISE] description="Upgrade the pve-exporter LXC to a new image version via rootfs swap"
 # [MISE] dir="{{config_root}}"
 # [USAGE] arg "<pve_host>" help="Hostname or IP of the Proxmox node (e.g. pve.lan)"
-# [USAGE] flag "-s --source-id <id>" help="VMID of the running container (auto-detected via PVE tags if omitted)"
-# [USAGE] flag "-t --target-id <id>" help="VMID for the new container (auto-picked if omitted)"
+# [USAGE] flag "-i --vmid <id>" help="VMID of the running container (auto-detected via PVE tags if omitted)"
 # [USAGE] flag "-V --version <version>" help="Image version (e.g. 2026.06.14-2) — auto-detected from flake if omitted"
 # [USAGE] flag "-y --yes" help="Skip confirmation prompts"
 
@@ -18,7 +17,6 @@ lxc_services "pve-exporter" "prometheus-node-exporter" "lxc-agent"
 
 lxc_upgrade \
   --pve-host "${usage_pve_host}" \
-  --source-id "${usage_source_id-}" \
-  --target-id "${usage_target_id-}" \
+  --vmid "${usage_vmid-}" \
   --version "${usage_version-}" \
   ${usage_yes:+--yes}


### PR DESCRIPTION
## Summary

Replaces the `lxc_upgrade` new-VMID flow with an in-place rootfs swap on the
same CT, using a Proxmox snapshot as the rollback path. The previous flow
created a fresh VMID on every upgrade, which orphaned rootfs volumes on
decommission, broke PBS backup continuity for the persistent `mp0` volume,
and made a stable per-CT static IP policy impossible to enforce.

**Related Issue:** #1087

## Rationale

Every upgrade allocating a new VMID meant: (1) the source CT's rootfs was
stripped from its config before `pct destroy`, silently leaking the
underlying volume every run (issue #1058 patched the symptom, not the
cause); (2) the persistent `mp0` volume moved to a new VMID each upgrade,
so PBS backups taken before an upgrade no longer matched the CT that
"owns" them from PBS's point of view; (3) the VMID — and therefore the
CT's identity in PVE — changed every run, so a static IP could never be
pinned to the appliance across upgrades.

Keeping the same VMID for the whole appliance lifetime removes all three
problems at the design level rather than patching around them.

## Changes Made

### Shared upgrade library

* **[`projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh)** — `lxc_upgrade` rewritten as a 7-step in-place flow: preflight, disposable smoke-test CT, `pct snapshot`, stop, rootfs swap (scratch CT allocates the new volume, config-only destroy), health check, commit (`pct delsnapshot` + free the old volume) or rollback (`pct rollback` + free the new volume). `--source-id`/`--target-id` collapse into a single `--vmid`; `_lxc_pick_target` is renamed `_lxc_pick_free_vmid` since it now only ever allocates disposable scratch CTs.

### Appliance task scripts

* **`observability`**, **`oci-registry`**, **`omni`**, **`omni-infra-provider-proxmox`**, **`pve-exporter`** — `.mise/tasks/lxc/upgrade` updated to the new `--vmid`/`-i` flag.

### Documentation

* **[`.agents/skills/lxc-maintenance/SKILL.md`](.agents/skills/lxc-maintenance/SKILL.md)** — step table, flag reference, and appliance template updated to match the new flow.

## Technical Impact

### Architecture Simplification

| Before                                                          | After                                                     |
| ----------------------------------------------------------------| ---------------------------------------------------------|
| New VMID every upgrade; mount points detached/reattached + chown | Same VMID for life; mount points never move               |
| Source rootfs stripped then `pct destroy` (leaked volume)        | Old volume explicitly freed on commit, no leak            |
| No rollback beyond "restart the old CT"                          | `pct snapshot`/`pct rollback` restores config + rootfs    |
| VMID (and therefore static IP) drifts every upgrade               | VMID, IP, and PBS backup identity are stable forever      |

### Security Boundary Preservation

No change to firewall rules, secrets handling, or network policy — the CT's
`/etc/pve/firewall/<vmid>.fw` file is never touched since the VMID never
changes.

### Behavioural Changes

Operators now pass `--vmid` instead of `--source-id`/`--target-id`; there is
no more "target CT" to review before cutover — the upgrade happens on the
same CT the operator already knows. Snapshot names follow
`pre-upgrade-<timestamp>` and are visible via `pct listsnapshot` until the
upgrade commits or rolls back.

### Migration Path

No stored state to migrate — the next upgrade of any appliance simply uses
the new flow. The very first invocation of the new script is exercised
end-to-end in this PR (see Testing Validation).

## Testing Validation

* [x] Full upgrade of a live production container (observability, VMID 103,
      pve-01.pve.chezmoi.sh) from `2026.06.20` to `2026.07.05`: preflight,
      smoke-test, snapshot, stop, rootfs swap, health check, commit all
      completed successfully.
* [x] VMID (103), static IP, and PBS backup identity (`mp0`) unchanged
      before/after.
* [x] No rootfs volume left orphaned after the successful commit.
* [x] Rollback path exercised for real: an earlier run's health check
      failure triggered `pct rollback`, which correctly restored the CT to
      its pre-upgrade state (config + rootfs) with no manual intervention
      beyond fixing a bug found in that first attempt (see the stacked
      fix/lxc-static-ip-guest PR for the follow-up networking issue found
      during this same testing session).
* [ ] Upgrade the remaining four appliances (oci-registry, omni,
      omni-infra-provider-proxmox, pve-exporter) with the new flow.

## Related Issues

Closes #1087

***

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
