### PR TITLE
Fix LXC static IP never applied inside the NixOS guest

### DIFF
--- a/catalog/nix/flake.nix
+++ b/catalog/nix/flake.nix
@@ -9,5 +9,6 @@
     in
     {
       nixosModules.lxcAgent = ./modules/lxc-o11y-agent;
+      nixosModules.staticNetwork = ./modules/lxc-static-network;
     };
 }

--- a/catalog/nix/modules/lxc-static-network/default.nix
+++ b/catalog/nix/modules/lxc-static-network/default.nix
@@ -1,0 +1,64 @@
+{ config, lib, ... }:
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Static IPv4 networking for Proxmox LXC guests
+# ─────────────────────────────────────────────────────────────────────────────
+# Proxmox only auto-injects the `net0` `ip=`/`gw=` config into guest OSes it
+# recognizes out of the box (Debian/Ubuntu/CentOS, ...) — NixOS isn't one of
+# them, so a `pct` `net0` line with a static `ip=` is otherwise inert inside
+# the guest. Without this module the interface only comes up via whatever DHCP
+# client NixOS ships with by default, and VLAN 5 has DHCP disabled (see
+# docs/network/vlans.md) — the guest then falls back to a self-assigned
+# link-local address (169.254.0.0/16) with no real connectivity.
+#
+# A container that has never restarted since VLAN 5's DHCP was disabled can
+# still be reachable on a stale lease obtained before the change; the address
+# and default route silently disappear the moment it reboots or is stopped —
+# which `lxc:upgrade`'s rootfs swap does on every run. This module makes the
+# address permanent by mirroring the PVE-side net0 static config inside the
+# guest itself.
+# ─────────────────────────────────────────────────────────────────────────────
+
+let
+  cfg = config.catalog.staticNetwork;
+in
+{
+  options.catalog.staticNetwork = {
+    enable = lib.mkEnableOption "static IPv4 addressing on the primary LXC interface";
+
+    interface = lib.mkOption {
+      type = lib.types.str;
+      default = "eth0";
+      description = "Interface name to configure — must match the PVE net0 `name=` field.";
+    };
+
+    address = lib.mkOption {
+      type = lib.types.str;
+      description = "Static IPv4 address, matching the PVE net0 `ip=` field (e.g. \"10.0.0.22\").";
+    };
+
+    prefixLength = lib.mkOption {
+      type = lib.types.int;
+      description = "Subnet prefix length, matching the PVE net0 `ip=` field (e.g. 22 for a /22).";
+    };
+
+    gateway = lib.mkOption {
+      type = lib.types.str;
+      description = "Default gateway, matching the PVE net0 `gw=` field.";
+    };
+
+    nameservers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "1.1.1.1" "9.9.9.9" ];
+      description = "DNS resolvers. Public resolvers by default — VLAN 5 has no documented internal DNS relay.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.interfaces.${cfg.interface}.ipv4.addresses = [
+      { inherit (cfg) address prefixLength; }
+    ];
+    networking.defaultGateway = cfg.gateway;
+    networking.nameservers = cfg.nameservers;
+  };
+}

--- a/catalog/nix/modules/lxc-static-network/default.nix
+++ b/catalog/nix/modules/lxc-static-network/default.nix
@@ -38,7 +38,7 @@ in
     };
 
     prefixLength = lib.mkOption {
-      type = lib.types.int;
+      type = lib.types.ints.between 0 32;
       description = "Subnet prefix length, matching the PVE net0 `ip=` field (e.g. 22 for a /22).";
     };
 
@@ -55,9 +55,17 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    networking.interfaces.${cfg.interface}.ipv4.addresses = [
-      { inherit (cfg) address prefixLength; }
-    ];
+    # Disabling DHCP on this interface is required, not cosmetic: NixOS's
+    # default DHCP client still runs otherwise, spends ~30s retrying against
+    # a VLAN with DHCP disabled, delays network-online.target (and anything
+    # ordered after it, e.g. lxc-agent), and risks landing on the same
+    # link-local fallback address this module exists to eliminate.
+    networking.interfaces.${cfg.interface} = {
+      useDHCP = false;
+      ipv4.addresses = [
+        { inherit (cfg) address prefixLength; }
+      ];
+    };
     networking.defaultGateway = cfg.gateway;
     networking.nameservers = cfg.nameservers;
   };

--- a/docs/network/vlans.md
+++ b/docs/network/vlans.md
@@ -130,6 +130,11 @@ Allocation convention within `10.0.0.0/26`: `.1` gateway, `.10–.19` hypervisor
 > (`195.201.114.83`, kazimierz.akn) — it resolves outside VLAN 5 entirely and isn't tied to any
 > IP in this table.
 
+> **DNS resolvers.** VLAN 5 has no internal DNS relay documented here — the UDM Pro gateway
+> (`10.0.0.1`) does not answer DNS queries from this VLAN. The static-IP LXCs above use public
+> resolvers (`1.1.1.1`, `9.9.9.9`) via `catalog.staticNetwork.nameservers`
+> (`catalog/nix/modules/lxc-static-network/`). Revisit if an internal resolver is ever stood up.
+
 ### Cilium LoadBalancer Pools
 
 Each cluster gets a `/29` block (6 usable IPs). The `/26` holds exactly 8 × `/29`. Order follows cluster creation sequence; sandbox takes the last slot.

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/README.md
@@ -335,7 +335,7 @@ ssh root@${NODE} pct create ${VMID} local:vztmpl/${TEMPLATE} \
     --swap         0 \
     --rootfs       local-zfs:4 \
     --mp0          local-zfs:64,mp=/persistent \
-    --net0         name=eth0,bridge=vmbr0,ip=dhcp,firewall=1 \
+    --net0         name=eth0,bridge=vmbr1,ip=10.0.0.22/22,gw=10.0.0.1,firewall=1,tag=5 \
     --onboot       1
 
 # 2. Wire up the console device for `pct console <vmid>`.

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/configuration.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/configuration.nix
@@ -38,6 +38,16 @@
   system.stateVersion = "26.05";
   networking.hostName = "o11y";
 
+  # ── Static IPv4 (mirrors PVE net0: ip=10.0.0.22/22,gw=10.0.0.1) ──────────
+  # See catalog.nix's lxc-static-network module — without this, eth0 falls
+  # back to a link-local address on every reboot (VLAN 5 has DHCP disabled).
+  catalog.staticNetwork = {
+    enable = true;
+    address = "10.0.0.22";
+    prefixLength = 22;
+    gateway = "10.0.0.1";
+  };
+
   time.timeZone = "Etc/UTC";
   i18n.defaultLocale = "C.UTF-8";
 

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/flake.nix
@@ -48,7 +48,7 @@
       # Proxmox template (observability.<date>-amd64.tar.xz). Component
       # versions track the nixpkgs pin. Bump this date before every
       # `mise run lxc:build`; append -N for multiple builds on the same day.
-      version = "2026.06.20";
+      version = "2026.07.05";
 
       # -----------------------------------------------------------------------
       # Build-time secrets, forwarded to the modules via _module.args.
@@ -75,6 +75,7 @@
         format = "lxc";
         modules = [
           arcane-catalog.nixosModules.lxcAgent
+          arcane-catalog.nixosModules.staticNetwork
           ./modules
           ./configuration.nix
           { _module.args = { inherit secrets; }; }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/README.md
@@ -188,7 +188,7 @@ ssh root@${NODE} pct create ${VMID} local:vztmpl/${TEMPLATE} \
     --swap         0 \
     --rootfs       local-zfs:2 \
     --mp0          local-zfs:100,mp=/var/lib/zot \
-    --net0         name=eth0,bridge=vmbr0,ip=dhcp,firewall=1 \
+    --net0         name=eth0,bridge=vmbr1,ip=10.0.0.23/22,gw=10.0.0.1,firewall=1,tag=5 \
     --onboot       1
 
 # 2. Wire up the console device so `pct console <vmid>` connects to the

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/configuration.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/configuration.nix
@@ -27,6 +27,16 @@
   system.stateVersion = "26.05";
   networking.hostName = "oci-registry";
 
+  # ── Static IPv4 (mirrors PVE net0: ip=10.0.0.23/22,gw=10.0.0.1) ──────────
+  # See catalog.nix's lxc-static-network module — without this, eth0 falls
+  # back to a link-local address on every reboot (VLAN 5 has DHCP disabled).
+  catalog.staticNetwork = {
+    enable = true;
+    address = "10.0.0.23";
+    prefixLength = 22;
+    gateway = "10.0.0.1";
+  };
+
   time.timeZone = "Etc/UTC";
   i18n.defaultLocale = "C.UTF-8";
 

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/flake.nix
@@ -95,6 +95,7 @@
         format = "lxc";
         modules = [
           arcane-catalog.nixosModules.lxcAgent
+          arcane-catalog.nixosModules.staticNetwork
           ./modules
           ./configuration.nix
           { _module.args = { inherit zotPackage cloudflareToken; }; }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/README.md
@@ -267,7 +267,7 @@ EOF
     --memory       512 \
     --swap         0 \
     --rootfs       nvme-lvm:4 \
-    --net0         name=eth0,bridge=vmbr1,ip=dhcp,firewall=1,tag=5 \
+    --net0         name=eth0,bridge=vmbr1,ip=10.0.0.25/22,gw=10.0.0.1,firewall=1,tag=5 \
     --pool         core \
     --cmode        console \
     --onboot       1

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/configuration.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/configuration.nix
@@ -21,6 +21,16 @@
   system.stateVersion = "26.05";
   networking.hostName = "omni-infra-provider-proxmox";
 
+  # ── Static IPv4 (mirrors PVE net0: ip=10.0.0.25/22,gw=10.0.0.1) ──────────
+  # See catalog.nix's lxc-static-network module — without this, eth0 falls
+  # back to a link-local address on every reboot (VLAN 5 has DHCP disabled).
+  catalog.staticNetwork = {
+    enable = true;
+    address = "10.0.0.25";
+    prefixLength = 22;
+    gateway = "10.0.0.1";
+  };
+
   time.timeZone = "Etc/UTC";
   i18n.defaultLocale = "C.UTF-8";
 

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/flake.nix
@@ -56,6 +56,7 @@
         format = "lxc";
         modules = [
           arcane-catalog.nixosModules.lxcAgent
+          arcane-catalog.nixosModules.staticNetwork
           ./modules
           ./configuration.nix
           { _module.args = { inherit proxmoxPassword omniServiceAccountKey; }; }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/README.md
@@ -278,7 +278,7 @@ EOF
     --swap         0 \
     --rootfs       nvme-lvm:4 \
     --mp0          nvme-lvm:20,mp=/persistent,backup=1 \
-    --net0         name=eth0,bridge=vmbr1,ip=dhcp,firewall=1,tag=5 \
+    --net0         name=eth0,bridge=vmbr1,ip=10.0.0.21/22,gw=10.0.0.1,firewall=1,tag=5 \
     --cmode        console \
     --onboot       1
 

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/configuration.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/configuration.nix
@@ -36,6 +36,17 @@
   system.stateVersion = "26.05";
   networking.hostName = "omni";
 
+  # ── Static IPv4 (mirrors PVE net0: ip=10.0.0.21/22,gw=10.0.0.1) ──────────
+  # See catalog.nix's lxc-static-network module — without this, eth0 falls
+  # back to a link-local address on every reboot (VLAN 5 has DHCP disabled).
+  # eth1 (pvenet, below) is unaffected — different interface, own static addr.
+  catalog.staticNetwork = {
+    enable = true;
+    address = "10.0.0.21";
+    prefixLength = 22;
+    gateway = "10.0.0.1";
+  };
+
   time.timeZone = "Etc/UTC";
   i18n.defaultLocale = "C.UTF-8";
 

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/flake.nix
@@ -68,6 +68,7 @@
         format = "lxc";
         modules = [
           arcane-catalog.nixosModules.lxcAgent
+          arcane-catalog.nixosModules.staticNetwork
           ./modules
           ./configuration.nix
           { _module.args = { inherit cloudflareToken dexAdminPasswordHash; }; }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/README.md
@@ -236,7 +236,7 @@ EOF
     --memory       256 \
     --swap         0 \
     --rootfs       nvme-lvm:2 \
-    --net0         name=eth0,bridge=vmbr1,ip=dhcp,firewall=1,tag=5 \
+    --net0         name=eth0,bridge=vmbr1,ip=10.0.0.24/22,gw=10.0.0.1,firewall=1,tag=5 \
     --onboot       1
 
 # Wire the console device so `pct console <vmid>` works.

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/configuration.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/configuration.nix
@@ -23,6 +23,16 @@
   system.stateVersion = "26.05";
   networking.hostName = "pve-exporter";
 
+  # ── Static IPv4 (mirrors PVE net0: ip=10.0.0.24/22,gw=10.0.0.1) ──────────
+  # See catalog.nix's lxc-static-network module — without this, eth0 falls
+  # back to a link-local address on every reboot (VLAN 5 has DHCP disabled).
+  catalog.staticNetwork = {
+    enable = true;
+    address = "10.0.0.24";
+    prefixLength = 22;
+    gateway = "10.0.0.1";
+  };
+
   time.timeZone = "Etc/UTC";
   i18n.defaultLocale = "C.UTF-8";
 

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/flake.nix
@@ -60,6 +60,7 @@
         format = "lxc";
         modules = [
           arcane-catalog.nixosModules.lxcAgent
+          arcane-catalog.nixosModules.staticNetwork
           ./modules
           ./configuration.nix
           { _module.args = { inherit pveHost pveTokenValue; }; }


### PR DESCRIPTION
## Summary

None of the five Proxmox LXC appliances actually apply their static IP
inside the NixOS guest — Proxmox only auto-injects `net0`'s `ip=`/`gw=`
into guest OSes it recognizes (Debian/Ubuntu/CentOS), and NixOS isn't one
of them. Every guest was reachable only through a DHCP lease predating
VLAN 5's DHCP being disabled; a restart drops that lease and leaves the
guest on a self-assigned link-local address with no real connectivity.

**Related Issue:** Found while testing #1087's in-place upgrade flow (see the base `issue-1087/in-place-rootfs-upgrade` PR)

## Root Cause

Live-testing the in-place upgrade against `observability` (VMID 103,
pve-01.pve.chezmoi.sh) restarted the CT for the first time in a while. The
container came back with `eth0` holding only `169.254.229.179/16` — a
kernel self-assigned link-local address — instead of the `10.0.0.22/22`
configured in `net0`:

```
2: eth0@if1006: ... state UP
    inet 169.254.229.179/16 brd 169.254.255.255 scope global noprefixroute eth0
```

`caddy` then failed to start:

```
Error: loading initial config: loading new config: http app module: start:
listening on tailscale/o11y-ep:80: tsnet: resolving auth key: Post
"https://api.tailscale.com/api/v2/tailnet/-/keys": Post
".../oauth/token": dial tcp: lookup api.tailscale.com: no such host
```

Checking the other four appliances confirmed the same latent state: `omni`
and `omni-infra-provider-proxmox` had real connectivity, but only via a
`proto dhcp`-style default route obtained before VLAN 5's DHCP was
disabled (container uptimes of 6-14 days, predating the migration) — the
lease and route simply hadn't expired yet. Any restart, including this new
`lxc:upgrade`, would drop all five back to link-local.

## Fix

### New shared module

* **[`catalog/nix/modules/lxc-static-network/default.nix`](catalog/nix/modules/lxc-static-network/default.nix)** — `catalog.staticNetwork` option (address, prefixLength, gateway, nameservers) that sets `networking.interfaces.<if>.ipv4.addresses`, `networking.defaultGateway`, and `networking.nameservers` inside the guest, mirroring the PVE-side `net0` config so it survives every reboot.
* **[`catalog/nix/flake.nix`](catalog/nix/flake.nix)** — exposes the module as `nixosModules.staticNetwork`.

### Appliance wiring

* **`observability`**, **`oci-registry`**, **`omni`**, **`omni-infra-provider-proxmox`**, **`pve-exporter`** — `flake.nix` imports the module; `configuration.nix` enables it with the address already reserved in `docs/network/vlans.md` (10.0.0.21-25/22, gateway 10.0.0.1, DNS 1.1.1.1 + 9.9.9.9 — no internal resolver is documented for VLAN 5).

### Documentation

* Five `README.md` bootstrap `net0` examples corrected: they documented `ip=.../24` and `bridge=vmbr0` for two appliances, but the live PVE config for all five actually uses `/22` and `bridge=vmbr1,tag=5`.

## Technical Impact

### Behavioural Changes

All five appliances now configure their static IP from inside the guest on
every boot, independent of DHCP. No operator-facing change — the IP
addresses are the same ones already reserved and already in `net0`; they
simply now actually work after a restart.

### Regression Risk

**Low.** The only appliance rebuilt and redeployed in this PR is
`observability`, and it was verified end-to-end (see Testing Validation).
The other four appliances have the Nix config change but were not
rebuilt/redeployed here — they keep running on their current (working,
stale-lease) image until their next `lxc:build`/`lxc:upgrade`, at which
point this fix takes effect for them too.

### Observability

After a rebuild, `ip addr show eth0` inside the guest should show the
static address with no `169.254.0.0/16` fallback, and `ip route show`
should show `default via 10.0.0.1 dev eth0 proto static` (not `proto dhcp`
or a link-scope-only route).

## Testing Validation

* [x] Rebuilt `observability` (version bumped to `2026.07.05`) with the fix
      and pushed to pve-01.
* [x] Full `lxc:upgrade` run: guest came up with `10.0.0.22/22` assigned
      directly (no link-local address at all), `nameserver 1.1.1.1` /
      `9.9.9.9` in `/etc/resolv.conf`, and `caddy` authenticated to
      Tailscale successfully.
* [x] All nine registered systemd services (`caddy`, `vector`,
      `victoriametrics`, `victorialogs`, `victoriatraces`, `vmalert`,
      `alertmanager`, `prometheus-node-exporter`, `lxc-agent`) reported
      `active`.
* [ ] Rebuild and redeploy the remaining four appliances to pick up the fix.

## Related Issues

Related to #1087 (found while validating that PR's in-place upgrade flow)

***

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
