### PR TITLE
Record ADR-015 for the Crossplane-to-Pulumi migration

### DIFF
--- a/.agents/skills/adr-authoring/SKILL.md
+++ b/.agents/skills/adr-authoring/SKILL.md
@@ -57,11 +57,11 @@ When in doubt, write a short draft and let the user decide whether it deserves a
    RFCs, NIST guidelines, project-specific best practices — to anchor the reasoning in
    something a reader can follow up on independently. The existing ADRs set a high bar here.
 
-4. **Draft:** Use the template at the bottom of this skill. Two things get removed when
-   authoring: the `<!-- ADR TEMPLATE … -->` HTML comment (right after the frontmatter), and
-   every `>` blockquote block (those are *authoring instructions*, not content). Keep the
-   `template-version` frontmatter field — it records which template revision produced the
-   ADR. Then read the
+4. **Draft:** Use the template at the bottom of this skill. Strip its authoring scaffolding
+   (the `<!-- ADR TEMPLATE … -->` comment, every `>` blockquote block, and the `[Optional]`
+   labels on any optional sections you keep — see "ADR Template" below for the full list),
+   but keep the `template-version` frontmatter field — it records which template revision
+   produced the ADR. Then read the
    draft with fresh eyes against "Anti-patterns to avoid" below: is every claim either
    validated or explicitly marked as expected? Is the core argument stated once, not four
    times? Does the title name the *same single* decision as the strategic question?
@@ -98,6 +98,7 @@ implementation-completed: YYYY-MM-DD   # optional, add only once implemented
 decision-makers: ["Alexandre"]         # the human(s) who own this decision
 assisted-by: ["claude-sonnet-4.6"]    # AI models that contributed; format: <model-name>
 informed: []
+template-version: "1.1.0"              # ADR template revision this file was created from
 ---
 ```
 
@@ -366,5 +367,6 @@ it was born from (via the `template-version` frontmatter field).
 The authoritative template is at `references/adr-template.md` (relative to this skill).
 Read that file and copy its content verbatim as the starting point for a new ADR, then,
 before saving: delete the `<!-- ADR TEMPLATE … -->` HTML comment (it sits just after the
-frontmatter), remove all `>` blockquote authoring instructions, and keep the
-`template-version` frontmatter field.
+frontmatter), remove all `>` blockquote authoring instructions, strip the `[Optional]`
+labels from the headings (and TOC entries) of the optional sections you keep — dropping any
+optional section you don't use — and keep the `template-version` frontmatter field.

--- a/.agents/skills/adr-authoring/SKILL.md
+++ b/.agents/skills/adr-authoring/SKILL.md
@@ -1,15 +1,10 @@
 ---
 name: adr-authoring
 description: >
-  Writes and updates Architecture Decision Records (ADR) following the standard project
-  template in docs/decisions/. Use this skill whenever the user wants to document an
-  architectural choice, record why a technology was selected, capture a design decision,
-  update the status of an existing ADR, or whenever phrases like "write an ADR",
-  "document this decision", "record why we chose X", "create an architectural decision
-  record", "update ADR-00N", "this should be an ADR", "let's write up this choice",
-  or "how did we decide X" appear. Also trigger this skill when the user has just made
-  a significant design decision during a task and it would be worth preserving for future
-  reference — even if they didn't ask for an ADR explicitly.
+  Writes and updates Architecture Decision Records (ADR) in docs/decisions/. Use it to
+  document an architectural choice or record why a technology was selected ("write an ADR",
+  "document this decision", "update ADR-00N", "this should be an ADR"), or right after a
+  significant design decision worth preserving — even if an ADR wasn't explicitly requested.
 ---
 
 # Architecture Decision Record (ADR) Authoring Skill
@@ -62,10 +57,14 @@ When in doubt, write a short draft and let the user decide whether it deserves a
    RFCs, NIST guidelines, project-specific best practices — to anchor the reasoning in
    something a reader can follow up on independently. The existing ADRs set a high bar here.
 
-4. **Draft:** Use the template at the bottom of this skill. The `>` blockquote blocks are
-   *authoring instructions*, not content — remove them entirely when filling in the sections.
-   Then read the draft with fresh eyes: does the context explain *why now*? Does each option
-   have enough substance? Is the rationale argued, not just stated?
+4. **Draft:** Use the template at the bottom of this skill. Two things get removed when
+   authoring: the `<!-- ADR TEMPLATE … -->` HTML comment (right after the frontmatter), and
+   every `>` blockquote block (those are *authoring instructions*, not content). Keep the
+   `template-version` frontmatter field — it records which template revision produced the
+   ADR. Then read the
+   draft with fresh eyes against "Anti-patterns to avoid" below: is every claim either
+   validated or explicitly marked as expected? Is the core argument stated once, not four
+   times? Does the title name the *same single* decision as the strategic question?
 
 5. **Cross-reference:** Link related ADRs in "References and Related Decisions". Scan
    existing files to find candidates — the chain of decisions (001 → 002 → 003) in this
@@ -155,10 +154,59 @@ to *why* each rejected option was ruled out — not just that it was.
 option addresses each decision driver, what trade-offs were accepted and why they are
 acceptable given the context, and what would need to change for a different option to win.
 
+### Non-Goals — say what you are NOT deciding
+
+State explicitly what the ADR does *not* decide. This is not padding — it is the cheapest
+way to prevent three failure modes:
+
+1. **A settled premise misread as an open option.** If a prior decision (a POC result, an
+   earlier ADR) fixes part of the design, name it as a non-goal so a reader does not think
+   the options reopen it. If one of your "options" is really the already-settled question,
+   you have the wrong options — the real decision is narrower than you framed it.
+2. **A tempting adjacent area silently excluded.** If the decision deliberately leaves
+   something out (a system that stays manual, a capability not migrated), say so *and why*.
+   Otherwise a future reader re-proposes exactly what you already rejected.
+3. **A capability of the old approach knowingly dropped.** Naming it as a non-goal turns a
+   silent regression into a documented, deliberate trade-off.
+
+Put non-goals in their own section right after Context (the template has it). Do not bury
+them in a "Neutral" consequence — a deliberate scope boundary deserves to be visible.
+
+### Anti-patterns to avoid
+
+These are the recurring ways ADRs go wrong. Named anti-patterns follow Olaf Zimmermann's
+[ADR creation guide](https://ozimmer.ch/practices/2023/04/03/ADRCreation.html); the rest
+come from reviews in this repo.
+
+* **Unsupported claim / pseudo-accuracy** — the most damaging, because it looks rigorous.
+  Do not present a benefit as established when it was only asserted. If a POC *expected* a
+  smaller footprint but never measured it, write exactly that and keep it out of the
+  load-bearing rationale. A driver the reader cannot verify is worse than no driver: it
+  invites a rebuttal that collapses the whole argument. Distinguish *validated* from
+  *expected* explicitly, and cite where each came from.
+* **Fairy tale** — only pros, no cons; truisms as justification. Every option (including the
+  chosen one) must list what it costs. An option with no `-` bullets is under-analyzed.
+* **Dummy alternative** — a straw-man option that exists only to be knocked down. If your
+  decisive drivers eliminate an option *the moment they are stated*, that option is not
+  really discriminating the decision. Prefer options that all pass the hard constraints, so
+  the rationale has to argue the *real* trade-off (e.g. two viable designs separated by blast
+  radius, not by a constraint one of them fails outright).
+* **Restating instead of arguing (repetition)** — the same argument appearing in Context,
+  every option's cons, the Decision Outcome, and Consequences reads as length without
+  information. State the core argument *once*, sharply, in the Decision Outcome; elsewhere
+  refer to it, don't re-derive it. Density of reasoning per line matters more than word count.
+* **Mega-ADR / more than one decision** — one ADR decides one thing. If the title says one
+  decision but the options quietly bundle several (tool choice *and* execution model *and*
+  operational policy), split them or narrow the framing. The title and the strategic
+  question must name the *same* decision.
+* **Free lunch coupon** — ignoring hard or long-term consequences. Negative consequences,
+  especially operational ones a future operator will hit, must be spelled out, not softened.
+
 ### Optional sections — include when they add value
 
 | Section                                  | Include when                                                                                                                                               |
 | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Non-Goals**                            | A settled premise, a deliberately excluded adjacent area, or a knowingly dropped capability could be misread as an oversight (see "Non-Goals" above)       |
 | **Consequences**                         | The decision has non-obvious downstream effects worth calling out explicitly                                                                               |
 | **Implementation Details / Status**      | A high-level architecture diagram or current rollout status is useful; avoid runbooks and low-level configs (those belong in Git or `docs/procedures/`)    |
 | **Decision Evolution**                   | The decision pivoted during implementation — document *why* with the specific technical discovery that caused the pivot (ADR-001 is the canonical example) |
@@ -276,11 +324,47 @@ third-party credentials) live in a dedicated `shared/` mount with their own gove
     strong motivation and trade-off analysis
   * [KEP-1287: In-Place Update of Pod Resources](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources) —
     exemplary alternatives and risks sections
+* ADR quality and anti-patterns:
+  * [Olaf Zimmermann — ADR creation, and how not to](https://ozimmer.ch/practices/2023/04/03/ADRCreation.html) —
+    the named anti-pattern catalogue (fairy tale, dummy alternative, mega-ADR, …).
+  * [adr.github.io — AD practices](https://adr.github.io/ad-practices/)
+  * [AWS — ADR best practices](https://aws.amazon.com/blogs/architecture/master-architecture-decision-records-adrs-best-practices-for-effective-decision-making/) —
+    one decision per ADR; keep it short.
+
+***
+
+## Template Versioning
+
+The ADR template (`references/adr-template.md`) is versioned so that changes to the
+*structure* of ADRs are themselves tracked, and so each ADR records the template revision
+it was born from (via the `template-version` frontmatter field).
+
+* **Scheme:** semantic-ish `MAJOR.MINOR.PATCH`.
+  * `MAJOR` — a change that would make old ADRs look structurally wrong (a required
+    section added/removed/renamed).
+  * `MINOR` — a new optional section, or non-breaking authoring-guidance changes carried
+    into the template.
+  * `PATCH` — wording/typo fixes in the template's instructions.
+* **When you change the template**, bump the version in *three* places in sync: the
+  `<!-- ADR TEMPLATE vX.Y.Z -->` comment, the `template-version` frontmatter default, and
+  the changelog below. Existing ADRs are **not** back-migrated — their `template-version`
+  records the revision they were written under, which is the point.
+
+### Template changelog
+
+* **1.1.0** (2026-07-05): Added the **Non-Goals** optional section; introduced
+  `template-version` provenance in frontmatter; expanded authoring guidance with the
+  "Anti-patterns to avoid" and "Non-Goals" standards (unsupported/unmeasured claims,
+  repetition, one-decision scope, dummy alternatives). Prompted by the ADR-015 review.
+* **1.0.0**: Initial template extracted from `docs/decisions/000-adr-template.md` into
+  this skill as the single source of truth.
 
 ***
 
 ## ADR Template
 
 The authoritative template is at `references/adr-template.md` (relative to this skill).
-Read that file and copy its content verbatim as the starting point for a new ADR, then
-remove all `>` blockquote authoring instructions before saving.
+Read that file and copy its content verbatim as the starting point for a new ADR, then,
+before saving: delete the `<!-- ADR TEMPLATE … -->` HTML comment (it sits just after the
+frontmatter), remove all `>` blockquote authoring instructions, and keep the
+`template-version` frontmatter field.

--- a/.agents/skills/adr-authoring/references/adr-template.md
+++ b/.agents/skills/adr-authoring/references/adr-template.md
@@ -5,13 +5,22 @@ implementation-completed: {YYYY-MM-DD when the implementation was finalized (opt
 decision-makers: ["Alexandre"]
 assisted-by: ["<model-name>"]
 informed: []
+template-version: "1.1.0"
 ---
+
+<!--
+  ADR TEMPLATE v1.1.0 — see the "Template Versioning" section of
+  .agents/skills/adr-authoring/SKILL.md for the changelog and the rules that govern
+  this file. Keep the `template-version` frontmatter field above so each ADR records
+  which template revision produced it. Delete this HTML comment when authoring.
+-->
 
 # {Short title, representative of solved problem and found solution}
 
 ## Table of Contents
 
 * [Context and Problem Statement](#context-and-problem-statement)
+* [Non-Goals \[Optional\]](#non-goals-optional)
 * [Decision Drivers](#decision-drivers)
 * [Considered Options](#considered-options)
   * [Option 1: {title of option 1}](#option-1-title-of-option-1)
@@ -39,6 +48,24 @@ informed: []
 > * **Strategic Question**: The core question this ADR aims to answer.
 
 {Write comprehensive context here...}
+
+## Non-Goals \[Optional]
+
+> List what this ADR deliberately does NOT decide or cover. Non-goals prevent scope
+> creep and stop a reader from mistaking an omission for an oversight. Include this
+> section when any of the following apply:
+>
+> * A related decision is already settled elsewhere and is a *premise* here, not an
+>   option (state it, so the options aren't misread as reopening it).
+> * The decision deliberately excludes a tempting adjacent area (say why — a future
+>   reader will otherwise re-propose it).
+> * A capability of the superseded approach is intentionally given up.
+>
+> Keep each non-goal to a sentence or two with its reason. Omit the section entirely
+> if the decision's scope is self-evident — do not pad with truisms.
+
+* {non-goal 1 — and why it is out of scope}
+* {non-goal 2 — and why it is out of scope}
 
 ## Decision Drivers
 

--- a/docs/decisions/015-migrate-crossplane-to-pulumi.md
+++ b/docs/decisions/015-migrate-crossplane-to-pulumi.md
@@ -1,8 +1,8 @@
 ---
-status: "proposed"
+status: "accepted"
 date: 2026-07-05
 decision-makers: ["Alexandre"]
-assisted-by: ["claude-opus-4-8"]
+assisted-by: ["claude-opus-4.8"]
 informed: []
 template-version: "1.1.0"
 ---
@@ -84,8 +84,8 @@ cluster is guaranteed?**
 ## Decision Drivers
 
 * **Escape the per-provider model**: replace Crossplane's one-CRD-set-per-API-family
-  overhead, whose structural explosion (7 providers / \~500 resources for OCI alone) is the
-  primary motivation. Footprint reduction is expected but unquantified.
+  overhead, whose structural explosion (quantified in Context) is the primary motivation.
+  Footprint reduction is expected but unquantified.
 * **Composition as code**: express fan-out logic (the `ClusterVault`/`DomainIdentity`
   patterns) in a real programming language rather than a templating/HCL-module layer, for
   maintainability and easier reasoning.
@@ -112,8 +112,8 @@ genuine strength — a live control loop that self-heals drift and surfaces stat
 `kubectl get composite,claim` and ArgoCD.
 
 It is rejected on the two structural problems it cannot shed. The per-provider model is the
-overhead this decision exists to remove (the OCI migration's 7-provider / \~500-resource
-explosion is intrinsic, not a misconfiguration). And being an in-cluster controller, it
+overhead this decision exists to remove (the OCI migration's provider explosion is intrinsic,
+not a misconfiguration). And being an in-cluster controller, it
 cannot manage cloud state when no cluster exists — a hard blocker for the `rhodes`
 reconstruction (#370).
 
@@ -210,28 +210,28 @@ not the argument.
 
 ### Positive
 
-* Sheds Crossplane's per-provider CRD/controller model and its structural resource explosion.
-* Cloud state becomes manageable with no cluster running — unblocking the `rhodes`
+* ✅ Sheds Crossplane's per-provider CRD/controller model and its structural resource explosion.
+* ✅ Cloud state becomes manageable with no cluster running — unblocking the `rhodes`
   reconstruction (#370).
-* One toolchain runs locally now and in-cluster later, so the execution model can evolve
+* ✅ One toolchain runs locally now and in-cluster later, so the execution model can evolve
   without re-choosing tools.
-* Terraform Workspaces consolidate into native Pulumi providers, removing a second IaC system.
+* ✅ Terraform Workspaces consolidate into native Pulumi providers, removing a second IaC system.
 
 ### Negative
 
-* **While executed locally (current phase)**: no continuous drift reconciliation (drift
+* ⚠️ **While executed locally (current phase)**: no continuous drift reconciliation (drift
   surfaces only when a human runs `pulumi preview`) and no ArgoCD-UI visibility into cloud
   state. These are precisely the properties the deferred **in-cluster phase** restores — so
   they are phase limitations, not permanent regressions.
-* Migration must `pulumi import` every Crossplane-managed resource with zero recreation.
-* Pulumi's supply-chain surface (npm dependencies executing with cloud credentials) must be
+* ⚠️ Migration must `pulumi import` every Crossplane-managed resource with zero recreation.
+* ⚠️ Pulumi's supply-chain surface (npm dependencies executing with cloud credentials) must be
   managed — lightly now (`npm ci` strict-lockfile installs locally), and with the POC's
   pod-hardening controls when the in-cluster phase lands (see Implementation).
 
 ### Neutral
 
-* Proxmox/Unifi remain manual (#1094) — unchanged by this decision.
-* Garage as the state backend (#1097) is a premise, not an effect, of this ADR.
+* ⚖️ Proxmox/Unifi remain manual (#1094) — unchanged by this decision.
+* ⚖️ Garage as the state backend (#1097) is a premise, not an effect, of this ADR.
 
 ***
 

--- a/docs/decisions/015-migrate-crossplane-to-pulumi.md
+++ b/docs/decisions/015-migrate-crossplane-to-pulumi.md
@@ -1,0 +1,337 @@
+---
+status: "proposed"
+date: 2026-07-05
+decision-makers: ["Alexandre"]
+assisted-by: ["claude-opus-4-8"]
+informed: []
+template-version: "1.1.0"
+---
+
+# Migrate cloud infrastructure management from Crossplane to Pulumi
+
+## Table of Contents
+
+* [Context and Problem Statement](#context-and-problem-statement)
+* [Non-Goals](#non-goals)
+* [Decision Drivers](#decision-drivers)
+* [Considered Options](#considered-options)
+  * [Option 1: Keep Crossplane](#option-1-keep-crossplane)
+  * [Option 2: Terraform / OpenTofu](#option-2-terraform--opentofu)
+  * [Option 3: Pulumi](#option-3-pulumi)
+* [Decision Outcome](#decision-outcome)
+* [Consequences](#consequences)
+  * [Positive](#positive)
+  * [Negative](#negative)
+  * [Neutral](#neutral)
+* [Implementation Details / Status](#implementation-details--status)
+* [Decision Evolution](#decision-evolution)
+* [References and Related Decisions](#references-and-related-decisions)
+* [Changelog](#changelog)
+
+## Context and Problem Statement
+
+`amiya.akn` runs Crossplane as the sole controller for cloud and cloud-adjacent
+infrastructure. Crossplane's model installs **one provider package per cloud API family** —
+each a Deployment plus its own CRD set — and expresses fan-out logic (a claim producing many
+managed resources) through custom XRDs and Compositions. Today that means 12 provider
+packages, two custom XRDs (`ClusterVault`, `DomainIdentity`), \~8 Cloudflare tokens, \~19
+Vault/OpenBao resources, \~9 AWS SES/Cloudflare resources, and 6 Terraform Workspaces run
+via `provider-terraform`.
+
+This per-provider model does not scale on homelab hardware. The OCI registry migration
+(#1010, #1076) was the tipping point: onboarding a handful of OCI resources required **7
+additional provider packages and \~500 additional Kubernetes resources**. That structural
+overhead — provider Deployments, CRDs, and managed-resource objects multiplying per API
+family — is the concrete problem, counted directly in the POC (#1089, §1). The CPU/RAM cost
+that rides on top of it is expected to be substantial but was not quantified (the POC's
+footprint criteria V-005/V-006 are `Pending`); the decision rests on the observed structural
+explosion, not on an unmeasured resource delta.
+
+The Pulumi-vs-Crossplane POC (#1089,
+`docs/experiments/20260702-pulumi-crossplane-evaluation/`) validated that a Pulumi
+`ComponentResource` reaches functional parity with the `ClusterVault` and `DomainIdentity`
+Compositions, and that Garage (S3-compatible, #1097) works as a Pulumi state backend.
+Pulumi's model is fundamentally lighter: one npm package per provider (no permanently
+installed CRDs), stacks written as TypeScript programs, and state in S3 rather than in
+etcd as custom resources.
+
+A second constraint compounds the first. The `rhodes` reconstruction (#370) requires that
+cloud/infrastructure state be reconstructable and manageable **with no Kubernetes cluster
+guaranteed to exist** — something Crossplane, being an in-cluster controller, cannot do by
+construction.
+
+The strategic question this ADR answers is: **what tool should manage the homelab's cloud
+and cloud-adjacent infrastructure as code, replacing Crossplane's per-provider
+CRD/controller model, while remaining operable during the `rhodes` reconstruction when no
+cluster is guaranteed?**
+
+## Non-Goals
+
+* **Fixing the permanent execution model.** This ADR decides the *tool* (Pulumi replaces
+  Crossplane). Execution is rolled out in phases: **local / out-of-cluster first**, during
+  the migration; running Pulumi **in-cluster** via the Pulumi Kubernetes Operator remains
+  the eventual target and is **deferred, not rejected** (see
+  [Implementation](#implementation-details--status) for the sequencing and its reasons).
+* **Proxmox and Unifi IaC management.** Both stay outside Pulumi/GitOps and remain manual.
+  They are foundational to the homelab (Proxmox hosts every cluster; Unifi is the network
+  substrate), so credentials to manage them must never sit inside — or downstream of —
+  anything a cluster runs, to avoid a `Proxmox → hosts K8s → K8s manages Proxmox` trust
+  cycle. Tracked as a deliberate case by the manual-infrastructure inventory (#1094);
+  reasoning carried forward from the POC (§9).
+* **Re-opening the state backend choice.** Garage as the S3 state backend is settled by
+  \#1097 and is a premise here.
+
+## Decision Drivers
+
+* **Escape the per-provider model**: replace Crossplane's one-CRD-set-per-API-family
+  overhead, whose structural explosion (7 providers / \~500 resources for OCI alone) is the
+  primary motivation. Footprint reduction is expected but unquantified.
+* **Composition as code**: express fan-out logic (the `ClusterVault`/`DomainIdentity`
+  patterns) in a real programming language rather than a templating/HCL-module layer, for
+  maintainability and easier reasoning.
+* **Cluster-independent execution**: the tool must run without a Kubernetes cluster, to
+  satisfy the `rhodes` reconstruction (#370).
+* **Strong in-cluster story for later**: because in-cluster execution is the eventual
+  target, the tool's Kubernetes operator must be first-class — this phase is deferred, not
+  abandoned.
+* **Native provider authoring**: upcoming native providers for Garage, Talos Omni, and
+  Pocket-Id (#1092/#1093/#1095) must be cheap to build against each product's own API.
+* **Migration-time safety**: adoption must import existing resources with zero recreation
+  (`pulumi import`, clean `pulumi preview`) and introduce no window where two controllers
+  reconcile the same resource.
+
+## Considered Options
+
+### Option 1: Keep Crossplane
+
+> **Status: REJECTED**
+
+Stay on Crossplane: one provider package per cloud API family, Compositions fanning claims
+into managed resources, all reconciled continuously in-cluster. No migration cost, and a
+genuine strength — a live control loop that self-heals drift and surfaces state through
+`kubectl get composite,claim` and ArgoCD.
+
+It is rejected on the two structural problems it cannot shed. The per-provider model is the
+overhead this decision exists to remove (the OCI migration's 7-provider / \~500-resource
+explosion is intrinsic, not a misconfiguration). And being an in-cluster controller, it
+cannot manage cloud state when no cluster exists — a hard blocker for the `rhodes`
+reconstruction (#370).
+
+* `+` Zero migration effort; continuous drift reconciliation; ArgoCD-native visibility.
+* `-` Per-provider CRD/controller model is exactly the overhead to escape.
+* `-` Requires a live cluster to manage cloud state — incompatible with `rhodes`.
+* `-` Custom XRDs/Compositions are a bespoke abstraction to hand-maintain indefinitely.
+
+### Option 2: Terraform / OpenTofu
+
+> **Status: REJECTED**
+
+The mainstream IaC alternative, and already partly present in the repo — the 6 Terraform
+Workspaces run today via Crossplane's `provider-terraform`. Standardizing on Terraform/
+OpenTofu would consolidate onto a widely-supported tool with a large provider ecosystem, and
+would also run out-of-cluster, satisfying the `rhodes` constraint.
+
+It is rejected in favor of Pulumi on four grounds (the last three are the maintainer's
+assessment):
+
+* **Composition as code, not HCL modules.** The `ClusterVault`/`DomainIdentity` fan-out maps
+  naturally onto a Pulumi `ComponentResource` (real TypeScript) — more maintainable than the
+  equivalent expressed as Terraform modules.
+
+* **Better Kubernetes operator.** The Pulumi Kubernetes Operator is considered markedly
+  better designed than Terraform's operator options — decisive because in-cluster execution
+  is the *eventual* target (see Non-Goals / Implementation), so the deferred phase must land
+  on a solid operator.
+
+* **AI-assisted ergonomics.** A mainstream TypeScript codebase is easier for AI assistants
+  to work in than HCL, which matters for a single-operator homelab that leans on AI.
+
+* **Cheaper native providers.** Building a native provider from a product's own API (Garage,
+  Omni, Pocket-Id — #1092/#1093/#1095) is judged simpler with Pulumi's provider model than
+  with Terraform's.
+
+* `+` Large ecosystem; out-of-cluster capable; already partly in use.
+
+* `-` HCL modules are a weaker fit than code for the existing composition/fan-out logic.
+
+* `-` Operator story weaker than Pulumi's, which matters for the deferred in-cluster phase.
+
+* `-` Higher friction for AI-assisted work and for authoring native providers.
+
+### Option 3: Pulumi
+
+> **Status: ACCEPTED**
+
+Replace Crossplane with Pulumi: TypeScript stacks (`catalog/pulumi/` for shared components
+such as a `ClusterVault`-equivalent `ComponentResource`, `projects/<scope>/src/
+infrastructure/pulumi/` for per-project stacks), one npm package per provider, state in
+Garage (#1097). Pulumi runs the same program locally or in-cluster, which is what lets the
+execution model be staged: local-first now, in-cluster later, on one toolchain. The POC
+validated parity and the S3 backend; existing Terraform Workspaces fold into native Pulumi
+providers (`@pulumi/hcloud`, `@pulumi/tailscale`), collapsing two IaC systems into one.
+
+* `+` No permanently installed CRDs/controllers — sheds the per-provider overhead.
+* `+` Fan-out logic as TypeScript `ComponentResource`; strong Kubernetes operator for the
+  deferred in-cluster phase; AI-friendly; cheap native-provider authoring.
+* `+` Same program runs locally or in-cluster, enabling a staged rollout on one toolchain.
+* `+` Consolidates the `provider-terraform` Workspaces into native Pulumi providers.
+* `-` Loses Crossplane's always-on reconciliation and ArgoCD visibility *while executed
+  locally* (recovered when the in-cluster phase lands — see Consequences).
+* `-` Migration requires importing every resource with zero recreation.
+
+## Decision Outcome
+
+**Chosen option: "Pulumi" (Option 3).**
+
+Pulumi is the only option that removes the per-provider CRD/controller overhead *and* runs
+without a cluster. Keeping Crossplane (Option 1) fails on both counts by construction — the
+overhead is intrinsic to its model and it cannot manage cloud state when no cluster exists,
+which the `rhodes` reconstruction (#370) requires. Terraform/OpenTofu (Option 2) clears both
+bars but loses to Pulumi on the qualities that matter most for this specific homelab:
+expressing the existing composition/fan-out logic as code rather than HCL modules, a
+stronger Kubernetes operator for the eventual in-cluster phase, easier AI-assisted work, and
+cheaper native-provider authoring for the Garage/Omni/Pocket-Id providers already planned
+(#1092/#1093/#1095).
+
+That Pulumi runs the *same* program locally or in-cluster is what makes the staged execution
+model possible without re-choosing tools later: the migration proceeds **local-first**
+(details and rationale in [Implementation](#implementation-details--status)), and the
+in-cluster Operator — Pulumi's, rated the best of the candidates — is adopted afterward as a
+deliberate second phase, not forced now while Crossplane is still live.
+
+The footprint magnitude is deliberately not load-bearing: the POC counted the structural
+explosion (providers, CRDs, resources) but never measured CPU/RAM. The observed structural
+overhead is enough to justify leaving Crossplane; the unmeasured resource delta is a bonus,
+not the argument.
+
+***
+
+## Consequences
+
+### Positive
+
+* Sheds Crossplane's per-provider CRD/controller model and its structural resource explosion.
+* Cloud state becomes manageable with no cluster running — unblocking the `rhodes`
+  reconstruction (#370).
+* One toolchain runs locally now and in-cluster later, so the execution model can evolve
+  without re-choosing tools.
+* Terraform Workspaces consolidate into native Pulumi providers, removing a second IaC system.
+
+### Negative
+
+* **While executed locally (current phase)**: no continuous drift reconciliation (drift
+  surfaces only when a human runs `pulumi preview`) and no ArgoCD-UI visibility into cloud
+  state. These are precisely the properties the deferred **in-cluster phase** restores — so
+  they are phase limitations, not permanent regressions.
+* Migration must `pulumi import` every Crossplane-managed resource with zero recreation.
+* Pulumi's supply-chain surface (npm dependencies executing with cloud credentials) must be
+  managed — lightly now (`npm ci` strict-lockfile installs locally), and with the POC's
+  pod-hardening controls when the in-cluster phase lands (see Implementation).
+
+### Neutral
+
+* Proxmox/Unifi remain manual (#1094) — unchanged by this decision.
+* Garage as the state backend (#1097) is a premise, not an effect, of this ADR.
+
+***
+
+## Implementation Details / Status
+
+### Staged execution model
+
+Pulumi runs the same TypeScript program regardless of *where* it is executed, so the
+execution model is rolled out in two phases rather than decided once:
+
+* **Phase 1 — local / out-of-cluster (current).** `pulumi up`/`preview` run on the
+  operator's own machine against Garage-backed state; no Pulumi Operator, no CI job (not even
+  a read-only `preview`). Chosen for *now* because the migration is in flight: adding the
+  in-cluster Operator while Crossplane is still reconciling would create a dual-reconciler
+  window on the same live resources, and local execution is what the `rhodes` reconstruction
+  needs regardless. Only mitigation required at this stage: `npm ci` strict-lockfile installs.
+* **Phase 2 — in-cluster (deferred, the eventual target).** Once the migration settles and
+  Crossplane is decommissioned, Pulumi execution moves in-cluster via the Pulumi Kubernetes
+  Operator (`Stack` CRs, potentially ArgoCD-`ApplicationSet`-generated), restoring
+  continuous reconciliation and ArgoCD visibility. This is deferred, not rejected — it is
+  only unsafe *now*, mid-migration. When it lands, the POC's workspace-pod hardening becomes
+  relevant again: pinned image tag (`IfNotPresent` pulls), an ephemeral pod-owned npm cache,
+  and a per-Stack egress `CiliumNetworkPolicy`.
+
+```text
+Phase 1 (now): local, no cluster              Phase 2 (deferred): in-cluster
+┌──────────────────────────────┐             ┌──────────────────────────────┐
+│ operator's machine           │             │ Pulumi Kubernetes Operator   │
+│ npm ci → pulumi up / preview  │             │ Stack CRs → workspace pod    │
+└──────────────────────────────┘             │ (pinned image, ephemeral      │
+             │                                │  npm cache, egress NetworkPol)│
+             ▼                                └──────────────────────────────┘
+   Garage state (S3, #1097) ◀───── same state, same TypeScript program ─────▶
+             │
+             ▼
+   Cloud APIs (AWS, Cloudflare, Vault/OpenBao, Hetzner, Tailscale)
+```
+
+### Status
+
+* **Completed**: POC (#1089) validated Pulumi/Crossplane functional parity for
+  `ClusterVault`/`DomainIdentity` and Garage as the state backend. Footprint (V-005/V-006)
+  not measured.
+* **Pending**: Garage in production (#1097, blocking); `pulumi import` of all
+  Crossplane-managed resources; per-family migration (Vault/OpenBao, Cloudflare tokens, AWS
+  SES/IAM, then the Terraform Workspaces via `@pulumi/hcloud` / `@pulumi/tailscale`);
+  Crossplane decommissioning on `amiya.akn`; and — later — the Phase 2 in-cluster cutover.
+  All tracked on #1091.
+* **Standards**: shared components in `catalog/pulumi/`; per-project stacks in
+  `projects/<scope>/src/infrastructure/pulumi/`, mirroring the `catalog/crossplane/` +
+  `projects/<cluster>/src/infrastructure/crossplane/` split this replaces.
+
+***
+
+## Decision Evolution
+
+* **2026-07-02 (POC, #1089)**: Evaluated Pulumi against Crossplane via the in-cluster Pulumi
+  Kubernetes Operator. Confirmed functional parity and Garage as a state backend; did not
+  measure resource footprint (V-005/V-006 pending).
+* **2026-07-05 (this ADR)**: Decided to migrate from Crossplane to Pulumi, driven by the
+  per-provider structural overhead and the `rhodes` no-cluster requirement, with Terraform/
+  OpenTofu considered and set aside. Execution staged: local-first during the migration,
+  in-cluster (Pulumi Operator) deferred as the eventual target.
+
+***
+
+## References and Related Decisions
+
+* **Related ADRs**:
+  * [ADR-003: OpenBao Path Naming Conventions](./003-openbao-path-naming-conventions.md)
+    and [ADR-004: OpenBao Policy Naming Conventions](./004-openbao-policy-naming-conventions.md) —
+    conventions the migrated Vault/OpenBao resources must keep following.
+  * [ADR-008: `kazimierz`.AKN — Ansible + Docker Compose over Kubernetes](./008-kazimierz-ansible-over-kubernetes.md) —
+    an earlier case of choosing a lighter execution model over forcing an in-cluster pattern.
+* **Issue Tracking**:
+  * [#1091](https://github.com/chezmoidotsh/arcane/issues/1091) — the migration this ADR
+    decides; import/per-family/decommissioning work is tracked there.
+  * [#1089](https://github.com/chezmoidotsh/arcane/issues/1089) — Pulumi-vs-Crossplane POC;
+    parity and state-backend findings, footprint left unmeasured.
+  * [#1097](https://github.com/chezmoidotsh/arcane/issues/1097) — Garage in production as the
+    S3 state backend (premise).
+  * [#370](https://github.com/chezmoidotsh/arcane/issues/370) — `rhodes` reconstruction; the
+    no-cluster requirement.
+  * [#1092](https://github.com/chezmoidotsh/arcane/issues/1092) /
+    [#1093](https://github.com/chezmoidotsh/arcane/issues/1093) /
+    [#1095](https://github.com/chezmoidotsh/arcane/issues/1095) — native Pulumi providers
+    (Garage, Omni, Pocket-Id).
+  * [#1094](https://github.com/chezmoidotsh/arcane/issues/1094) — manual-infrastructure
+    inventory (Proxmox/Unifi non-goal).
+  * Parent epic: [#1072](https://github.com/chezmoidotsh/arcane/issues/1072).
+* **Implementation References**:
+  * [Pulumi DIY (S3-compatible) backends](https://www.pulumi.com/docs/iac/operations/stack-management/using-a-diy-backend/)
+  * [Pulumi Kubernetes Operator](https://github.com/pulumi/pulumi-kubernetes-operator) —
+    the Phase 2 execution target.
+  * [Garage](https://garagehq.deuxfleurs.fr/) — S3-compatible state backend.
+
+***
+
+## Changelog
+
+* **2026-07-05**: **FEATURE**: Initial creation of ADR documenting the migration from
+  Crossplane to Pulumi for cloud infrastructure management, with a staged execution model
+  (local-first, in-cluster deferred) — resolving the direction of #1091.


### PR DESCRIPTION
## Summary

Records the direction of the cloud-infrastructure migration as **ADR-015**: move cloud and cloud-adjacent management off Crossplane and onto Pulumi. This satisfies the "ADR accepted" acceptance criterion of the migration issue; it is documentation-only — no resources are imported and Crossplane is not touched (that work is blocked on Garage reaching production, #1097). The PR also hardens the `adr-authoring` skill with the lessons that surfaced while reviewing this very ADR.

**Related Issue:** #1091

## Rationale

Crossplane's per-provider model (one CRD set + controller per cloud API family) does not scale on homelab hardware — the OCI migration alone required 7 additional providers and around 500 extra Kubernetes resources. On top of that, being an in-cluster controller, Crossplane cannot manage cloud state during the `rhodes` reconstruction (#370), which requires infrastructure to be manageable with no cluster guaranteed to exist. Pulumi addresses both: npm-package providers with no permanent CRDs, and a single program that runs locally or in-cluster. Recording the decision now — ahead of the blocked migration work — settles the direction so the import/decommission phases have an accepted reference.

The skill changes are motivated separately: reviewing the first draft of this ADR against published ADR guidance exposed failure modes the skill did not guard against (claims presented as measured when they were not, the same argument restated across sections, options a decisive driver eliminates on sight, scope creep from bundling more than one decision). Encoding those as explicit anti-patterns keeps future ADRs from repeating them.

## Changes Made

### ADR-015 — Crossplane-to-Pulumi migration

- **[`docs/decisions/015-migrate-crossplane-to-pulumi.md`](docs/decisions/015-migrate-crossplane-to-pulumi.md)** — records the decision: why leave Crossplane, why Pulumi over Terraform/OpenTofu, and a staged execution model (local-first now, in-cluster via the Pulumi Operator deferred as the eventual target). Written under template v1.1.0 (Non-Goals section, `template-version` provenance).

### Tooling — `adr-authoring` skill

- **[`.agents/skills/adr-authoring/SKILL.md`](.agents/skills/adr-authoring/SKILL.md)** — adds a "Non-Goals" authoring standard and an "Anti-patterns to avoid" section (unsupported claim, fairy tale, dummy alternative, repetition, mega-ADR, free lunch), authoritative sources (Zimmermann, adr.github.io, AWS), and a "Template Versioning" scheme with a changelog. Trims the overlong front-matter `description`.
- **[`.agents/skills/adr-authoring/references/adr-template.md`](.agents/skills/adr-authoring/references/adr-template.md)** — adds the Non-Goals section, a `template-version` frontmatter field, and a version marker; bumped to v1.1.0.

## Technical Impact

### Decision recorded

The tool decision (Pulumi replaces Crossplane) is settled and argued against two real alternatives — keeping Crossplane, and Terraform/OpenTofu. Execution is framed as a staged rollout rather than a single choice, so the in-cluster phase is explicitly deferred, not rejected.

### Scope and non-goals

The ADR is explicit that it does **not** decide the permanent execution model, does **not** move Proxmox/Unifi under IaC (they stay manual, #1094), and does **not** re-open the state-backend choice (Garage, #1097). No cloud resources change in this PR.

### Tooling: reusable authoring guardrails

The anti-pattern guidance and Non-Goals standard are now part of the skill, so they apply to every future ADR, not just this one. The template is versioned from this point forward, and each new ADR records which template revision produced it.

## Testing Validation

- [x] `bash .agents/skills/create-pr/scripts/validate_commits.sh main` — all checks pass (only the DCO `Signed-off-by` WARN, which is the human committer's call)
- [x] `trunk check --filter=-conftest` — no issues on the changed files
- [x] ADR renders correctly and its table-of-contents anchors resolve
- [x] Template frontmatter is valid YAML after the versioning changes

## Related Issues

Addresses #1091 (the "ADR accepted" acceptance criterion; import and Crossplane decommissioning remain, blocked on #1097).

---
<sub>AI-assisted with anthropic:claude-opus-4-8 under human supervision</sub>
