### PR TITLE
Centralize Vault secret-push metadata into shared pulumi-lib helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -700,3 +700,6 @@ opencode.json
 # Tests/lib directory in yaldap flake — re-included after Python's lib/ rule
 !catalog/flakes/chezmoi.sh/yaldap/tests/lib
 !catalog/flakes/chezmoi.sh/yaldap/tests/lib/**
+
+# Allow pulumi library folder
+!catalog/pulumi/lib

--- a/catalog/pulumi/lib/.mocharc.json
+++ b/catalog/pulumi/lib/.mocharc.json
@@ -1,0 +1,6 @@
+{
+	"require": ["ts-node/register"],
+	"spec": ["src/*.test.ts"],
+	"timeout": 10000,
+	"node-option": ["disable-warning=MODULE_TYPELESS_PACKAGE_JSON"]
+}

--- a/catalog/pulumi/lib/README.md
+++ b/catalog/pulumi/lib/README.md
@@ -1,0 +1,168 @@
+# `@chezmoi.sh/pulumi-lib`
+
+A multi-helper shared library for the per-project Pulumi stacks in
+`projects/*/src/infrastructure/pulumi/`. Each helper lives in its own module
+under [`src/`](./src/) and is re-exported from
+[`src/index.ts`](./src/index.ts), so consumers import everything from the
+package root:
+
+```typescript
+import { vaultSecretMetadata } from "@chezmoi.sh/pulumi-lib";
+```
+
+This is a **library package, not a `ComponentResource` package** — it exports
+plain functions and interfaces, not Pulumi resources of its own. Consuming
+stacks depend on it through the **`file:` protocol**; the full rationale for
+that (Pulumi's runtime installs each stack with isolated plain `npm`, never the
+workspace root) lives in [`catalog/pulumi/README.md`](../README.md).
+
+## `vaultSecretMetadata(source, opts?)`
+
+Builds the three shared `customMetadata.data` fields every `vault.kv.SecretV2`
+in this homelab carries — the ones that are identical across every call site or
+derivable from the credential resource itself. The per-secret
+`description` / `owner` / `application` fields stay at the call site; spread
+this object's result alongside them.
+
+### Returned fields
+
+| Field             | Value                                                                                            | Source                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `created-by`      | Repo-relative path of the file that pushed the secret, e.g. `projects/amiya.akn/.../platform.ts` | Auto-detected from the V8 call stack at call time (see [Assumptions](#assumptions)). |
+| `renewal-process` | A single fixed sentence describing what rotation does.                                           | Hard-coded constant — identical for every secret.                                    |
+| `x-renewal-cmd`   | The exact `pulumi up --replace '<urn>'` command that rotates the credential.                     | `opts.renewalUrn ?? source.urn`, wrapped in `pulumi.interpolate`.                    |
+
+### Usage
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as vault from "@pulumi/vault";
+import { vaultSecretMetadata } from "@chezmoi.sh/pulumi-lib";
+import { Dns01TokenComponent } from "@chezmoi.sh/pulumi-cloudflare-dns01-token";
+
+const token = new Dns01TokenComponent("cert-manager", {
+	owner: "amiya.akn",
+	application: "cert-manager",
+	accountId: cloudflareAccountId,
+	zoneId: chezmoiShZoneId,
+});
+
+new vault.kv.SecretV2(
+	"cert-manager-token",
+	{
+		mount: "shared",
+		name: "third-parties/cloudflare/iam/amiya.akn/cert-manager-rw",
+		dataJson: pulumi.jsonStringify({ api_token: token.tokenValue }),
+		customMetadata: {
+			data: {
+				description: "Cloudflare API Token for cert-manager",
+				owner: "amiya.akn",
+				application: "cert-manager",
+				...vaultSecretMetadata(token, { renewalUrn: token.tokenUrn }),
+			},
+		},
+	},
+	{ parent: token },
+);
+```
+
+### Why a function, not a component
+
+The Vault-push convention deliberately stays a **plain function that returns a
+spreadable object**, not a `pulumi.ComponentResource` that owns the `SecretV2`.
+A component wrapper would have to re-parent the `SecretV2`, and **re-parenting
+changes the secret's URN** — Pulumi would then treat it as a new resource,
+deleting the old one and recreating it under the new URN. `SecretV2` deletion
+**destroys the secret at its path** in Vault, which is exactly the
+data-loss-on-deploy event this convention exists to prevent. Keeping the helper
+as a function leaves the `SecretV2` parented to the credential resource the
+caller already chose (above: `{ parent: token }`), so its URN — and lifecycle —
+never moves.
+
+### `opts.renewalUrn`
+
+Defaults to `source.urn`. **Pass it explicitly when `source` is a
+`ComponentResource` that encapsulates the real replace target.** Running
+`pulumi up --replace` on a component's own URN does not reliably force-replace
+its child resources — the engine may refresh the component envelope without
+rotating the credential underneath it. For `Dns01TokenComponent`, that means
+passing `tokenUrn` (the URN of the inner `cloudflare.AccountToken`), so the
+generated `x-renewal-cmd` targets the resource that actually holds the
+credential value:
+
+```typescript
+vaultSecretMetadata(token, { renewalUrn: token.tokenUrn });
+```
+
+For a plain (non-component) credential resource, omit `opts` and let it default
+to `source.urn`.
+
+## Assumptions
+
+This helper makes two execution-model assumptions that hold for every stack in
+this repo today but would need revisiting if either changes:
+
+1. **Unbundled ts-node / CommonJS execution.** `created-by` reads the call
+   site's file name from the V8 call stack via `Error.prepareStackTrace`. That
+   only works while sources are loaded unbundled — which is how Pulumi's Node.js
+   runtime runs every stack (ts-node over raw `.ts`). Revisit before
+   introducing a bundler: bundling collapses call-site frames and the stack walk
+   would throw rather than emit a wrong `created-by`.
+2. **Full repo checkout present at runtime.** The repo-root anchor (a directory
+   containing `.git` or `pnpm-workspace.yaml`) is located by walking up from the
+   caller's file. Pulumi runs each stack from a checkout of the whole repo, so
+   the anchor is always reachable. If it ever is not — e.g. a stack directory
+   vendored in isolation — the function **throws loudly** rather than guess,
+   because a wrong `created-by` (the whole point of the field) is worse than a
+   stack that fails to evaluate.
+
+## Installation
+
+This is a **self-contained, `private: true` package** — it is **not published
+to any registry** and is **not added as an npm `workspace:*` dependency**.
+Consuming stacks depend on it through the **`file:` protocol**, the only
+protocol that resolves identically whether npm runs from the workspace root or
+in complete isolation inside a single stack directory (which is how Pulumi's
+runtime installs dependencies). The full rationale lives in
+[`catalog/pulumi/README.md`](../README.md).
+
+Add it to the consuming stack's `package.json`:
+
+```json
+{
+	"dependencies": {
+		"@chezmoi.sh/pulumi-lib": "file:../../../../../catalog/pulumi/lib"
+	}
+}
+```
+
+Then install from the repository root for editing / type-checking across the
+workspace:
+
+```sh
+pnpm install -r   # installs + links every package in the workspace
+```
+
+`pulumi up` / `pulumi preview` then run their own `npm install` scoped to each
+stack's directory automatically — no per-stack install is needed by hand.
+
+## Testing
+
+The package ships unit tests in
+[`vault-secret-metadata.test.ts`](./src/vault-secret-metadata.test.ts) using
+**Mocha + Chai** with `@pulumi/pulumi/runtime` mocks (`setMocks`). The
+caller-detection path is exercised end to end: because the caller of
+`vaultSecretMetadata` in the suite is the test file itself, `created-by` must
+resolve to this package's own `catalog/pulumi/lib/src/vault-secret-metadata.test.ts`
+— proving the stack walk and repo-root anchor work together. Run from this
+directory:
+
+```sh
+npm test                  # Pulumi's npm-scoped execution model
+npm run typecheck:test    # tsc --noEmit against tsconfig.test.json
+```
+
+## License
+
+This package is released under the Apache 2.0 license. For more information, see
+the [LICENSE](../../../LICENSE) file.

--- a/catalog/pulumi/lib/osv-scanner.toml
+++ b/catalog/pulumi/lib/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "GHSA-8988-4f7v-96qf"
+reason = "Not fixable in place: @opentelemetry/core is pinned deep inside @pulumi/pulumi own gRPC trace exporter dependency tree, and 3.250.0 is currently the latest stable @pulumi/pulumi release -- no version to bump to yet. Low practical risk here: local CLI tool, not a service parsing untrusted W3C Baggage headers. See issue 1091."

--- a/catalog/pulumi/lib/package.json
+++ b/catalog/pulumi/lib/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "@chezmoi.sh/pulumi-lib",
+	"version": "0.1.0",
+	"private": true,
+	"description": "Shared Pulumi helpers for the arcane homelab (Vault secret-push convention, etc.)",
+	"main": "src/index.ts",
+	"scripts": {
+		"test": "mocha",
+		"test:watch": "mocha --watch",
+		"typecheck:test": "tsc --noEmit -p tsconfig.test.json"
+	},
+	"dependencies": {
+		"@pulumi/pulumi": "catalog:"
+	},
+	"devDependencies": {
+		"@types/chai": "catalog:",
+		"@types/mocha": "catalog:",
+		"@types/node": "catalog:",
+		"chai": "catalog:",
+		"mocha": "catalog:",
+		"ts-node": "catalog:",
+		"typescript": "catalog:"
+	}
+}

--- a/catalog/pulumi/lib/src/index.ts
+++ b/catalog/pulumi/lib/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./vault-secret-metadata";

--- a/catalog/pulumi/lib/src/vault-secret-metadata.test.ts
+++ b/catalog/pulumi/lib/src/vault-secret-metadata.test.ts
@@ -1,0 +1,78 @@
+import * as pulumi from "@pulumi/pulumi";
+import { expect } from "chai";
+import { before, describe, it } from "mocha";
+
+import { vaultSecretMetadata } from "./vault-secret-metadata";
+
+/**
+ * Unit tests for vaultSecretMetadata.
+ *
+ * The caller-detection logic is exercised for real: because the caller of
+ * vaultSecretMetadata in these tests is THIS file, `created-by` must resolve to
+ * this test file's own repo-relative path — proving the stack walk + repo-root
+ * anchor work end to end.
+ */
+
+before(async () => {
+	await pulumi.runtime.setMocks(
+		{
+			newResource(args: pulumi.runtime.MockResourceArgs) {
+				return { id: `${args.name}_id`, state: args.inputs };
+			},
+			call(args: pulumi.runtime.MockCallArgs) {
+				return args.inputs;
+			},
+		},
+		"test",
+		"test",
+	);
+});
+
+function unwrap<T>(output: pulumi.Output<T>): Promise<T> {
+	return new Promise((resolve) => output.apply((value) => resolve(value)));
+}
+
+describe("vaultSecretMetadata", () => {
+	it("returns exactly the three convention fields", () => {
+		const source = new pulumi.ComponentResource("test:Source", "src-1", {});
+		const meta = vaultSecretMetadata(source);
+		expect(Object.keys(meta).sort()).to.deep.equal(
+			["created-by", "renewal-process", "x-renewal-cmd"].sort(),
+		);
+	});
+
+	it("derives created-by from the caller's own file (this test file)", () => {
+		const source = new pulumi.ComponentResource("test:Source", "src-2", {});
+		const meta = vaultSecretMetadata(source);
+		expect(meta["created-by"]).to.equal(
+			"catalog/pulumi/lib/src/vault-secret-metadata.test.ts",
+		);
+	});
+
+	it("uses the single fixed renewal-process sentence", () => {
+		const source = new pulumi.ComponentResource("test:Source", "src-3", {});
+		const meta = vaultSecretMetadata(source);
+		expect(meta["renewal-process"]).to.equal(
+			"Rotate the credential below; this secret's value is recomputed from it " +
+				"and picks up the new one automatically on the next `pulumi up`.",
+		);
+	});
+
+	it("builds x-renewal-cmd from the source resource's own URN by default", async () => {
+		const source = new pulumi.ComponentResource("test:Source", "src-4", {});
+		const meta = vaultSecretMetadata(source);
+		const urn = await unwrap(source.urn);
+		expect(await unwrap(meta["x-renewal-cmd"])).to.equal(
+			`pulumi up --replace '${urn}'`,
+		);
+	});
+
+	it("honours an explicit renewalUrn override for component-backed credentials", async () => {
+		const source = new pulumi.ComponentResource("test:Source", "src-5", {});
+		const innerUrn = pulumi.output("urn:pulumi:test::test::test:Inner::inner");
+		const meta = vaultSecretMetadata(source, { renewalUrn: innerUrn });
+		expect(await unwrap(meta["x-renewal-cmd"])).to.equal(
+			"pulumi up --replace 'urn:pulumi:test::test::test:Inner::inner'",
+		);
+	});
+});

--- a/catalog/pulumi/lib/src/vault-secret-metadata.ts
+++ b/catalog/pulumi/lib/src/vault-secret-metadata.ts
@@ -1,0 +1,134 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * The three {@link vault.kv.SecretV2} `customMetadata.data` fields every secret
+ * pushed to Vault in this stack shares — the ones that are identical across
+ * every call site or derivable from the credential itself.
+ *
+ * The per-secret `description` / `owner` / `application` fields stay at the
+ * call site (they're inherently per-secret); spread this object alongside them:
+ *
+ * ```ts
+ * customMetadata: {
+ *   data: {
+ *     description: "...",
+ *     owner: "...",
+ *     application: "...",
+ *     ...vaultSecretMetadata(token),
+ *   },
+ * },
+ * ```
+ */
+export interface VaultSecretMetadata {
+	/** Repo-relative path of the file that pushed the secret (auto-detected). */
+	"created-by": string;
+	/** The single fixed sentence describing what rotation does. */
+	"renewal-process": string;
+	/** The exact `pulumi up --replace` command targeting the credential's URN. */
+	"x-renewal-cmd": pulumi.Output<string>;
+}
+
+/** The one sentence every pushed secret uses for its `renewal-process` field. */
+const RENEWAL_PROCESS =
+	"Rotate the credential below; this secret's value is recomputed from it " +
+	"and picks up the new one automatically on the next `pulumi up`.";
+
+/**
+ * Walk up from `filePath` until a directory containing a workspace/repo marker
+ * (`.git` or `pnpm-workspace.yaml`) is found, and return it. Throws loudly if
+ * none is found before the filesystem root — a secret pushed with a wrong
+ * `created-by` is worse than a stack that fails to evaluate.
+ */
+function findRepoRoot(filePath: string): string {
+	let dir = path.dirname(path.resolve(filePath));
+	while (true) {
+		if (
+			fs.existsSync(path.join(dir, "pnpm-workspace.yaml")) ||
+			fs.existsSync(path.join(dir, ".git"))
+		) {
+			return dir;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) {
+			throw new Error(
+				"vaultSecretMetadata: could not locate the repository root " +
+					"(no `pnpm-workspace.yaml` or `.git` found walking up from " +
+					`${filePath}). This helper assumes it runs inside a full repo ` +
+					`checkout with unbundled ts-node sources.`,
+			);
+		}
+		dir = parent;
+	}
+}
+
+/** True when `filePath` sits anywhere under a `node_modules` directory. */
+function isInsideNodeModules(filePath: string): boolean {
+	return filePath.split(path.sep).includes("node_modules");
+}
+
+/**
+ * Returns the repo-relative path of the file that called {@link vaultSecretMetadata}
+ * — i.e. the call site pushing the secret — by inspecting the V8 call stack.
+ *
+ * Frames are skipped when they are native/undefined, `node:`-prefixed, inside
+ * `node_modules` (which covers this library itself when installed via `file:`),
+ * or belong to this module (`__filename`). The first surviving frame is the
+ * caller's source file. Works both in-package (relative import during this
+ * library's own tests) and installed (via `file:` in a consuming stack).
+ */
+function callerRepoRelativePath(): string {
+	// prepareStackTrace is a global V8 hook; scope the override tightly and
+	// restore it even if a frame accessor throws.
+	const previous = Error.prepareStackTrace;
+	const here = path.resolve(__filename);
+	let stack: NodeJS.CallSite[];
+	try {
+		Error.prepareStackTrace = (_error, callSites) => callSites;
+		stack = (new Error() as unknown as { stack: NodeJS.CallSite[] }).stack;
+	} finally {
+		Error.prepareStackTrace = previous;
+	}
+
+	for (const frame of stack) {
+		const file = frame.getFileName();
+		if (!file) continue;
+		if (file.startsWith("node:")) continue;
+		const resolved = path.resolve(file);
+		if (resolved === here) continue;
+		if (isInsideNodeModules(resolved)) continue;
+		const root = findRepoRoot(resolved);
+		return path.relative(root, resolved).split(path.sep).join("/");
+	}
+	throw new Error(
+		"vaultSecretMetadata: could not determine the calling file from the stack. " +
+			"This helper assumes unbundled ts-node/CommonJS execution; if the stack " +
+			"is bundled the call-site frames collapse and `created-by` cannot resolve.",
+	);
+}
+
+/**
+ * Build the three shared `customMetadata.data` fields for a secret pushed to
+ * Vault, from the credential resource that backs it.
+ *
+ * @param source The Pulumi resource whose value is being pushed. Parent the
+ *   `vault.kv.SecretV2` to this same resource so the secret shares its lifecycle.
+ * @param opts.renewalUrn Override the URN used in `x-renewal-cmd`. Defaults to
+ *   `source.urn`. Pass this when `source` is a `ComponentResource` that
+ *   encapsulates the real replace target (e.g. `Dns01TokenComponent` → its
+ *   exposed `tokenUrn`), since `pulumi up --replace` on a component URN does
+ *   not reliably rotate its children.
+ */
+export function vaultSecretMetadata(
+	source: pulumi.Resource,
+	opts?: { renewalUrn?: pulumi.Input<pulumi.URN> },
+): VaultSecretMetadata {
+	return {
+		"created-by": callerRepoRelativePath(),
+		"renewal-process": RENEWAL_PROCESS,
+		"x-renewal-cmd": pulumi.interpolate`pulumi up --replace '${
+			opts?.renewalUrn ?? source.urn
+		}'`,
+	};
+}

--- a/catalog/pulumi/lib/tsconfig.json
+++ b/catalog/pulumi/lib/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "bin"
+	},
+	"files": ["src/index.ts"]
+}

--- a/catalog/pulumi/lib/tsconfig.test.json
+++ b/catalog/pulumi/lib/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"types": ["mocha", "node", "chai"]
+	},
+	"include": ["src/index.ts", "src/*.test.ts"]
+}

--- a/projects/amiya.akn/src/infrastructure/pulumi/package.json
+++ b/projects/amiya.akn/src/infrastructure/pulumi/package.json
@@ -6,6 +6,7 @@
 	"dependencies": {
 		"@chezmoi.sh/pulumi-cloudflare-dns01-token": "workspace:*",
 		"@chezmoi.sh/pulumi-cluster-vault": "workspace:*",
+		"@chezmoi.sh/pulumi-lib": "workspace:*",
 		"@pulumi/cloudflare": "catalog:",
 		"@pulumi/pulumi": "catalog:",
 		"@pulumi/tailscale": "catalog:",

--- a/projects/amiya.akn/src/infrastructure/pulumi/src/argotails.ts
+++ b/projects/amiya.akn/src/infrastructure/pulumi/src/argotails.ts
@@ -1,3 +1,4 @@
+import { vaultSecretMetadata } from "@chezmoi.sh/pulumi-lib";
 import * as pulumi from "@pulumi/pulumi";
 import * as tailscale from "@pulumi/tailscale";
 import * as vault from "@pulumi/vault";
@@ -37,26 +38,11 @@ if (!config.isBootstraping) {
 				client_secret: oauthClient.key,
 			}),
 			customMetadata: {
-				// Convention for every secret pushed to Vault in this stack:
-				//   description/owner/application — human identification, shown in
-				//                                    the Vault UI.
-				//   created-by                    — repo-relative path to this file,
-				//                                    for traceability.
-				//   renewal-process/x-renewal-cmd  — what rotating this secret does,
-				//                                    and the exact copy/paste command
-				//                                    to trigger it (built from the
-				//                                    credential's own URN).
 				data: {
 					description: "Tailscale OAuth Client for Argotails on amiya.akn",
 					owner: "amiya.akn",
 					application: "argotails",
-
-					"created-by":
-						"projects/amiya.akn/src/infrastructure/pulumi/src/argotails.ts",
-					"renewal-process":
-						"Rotate the client below; this secret's value is recomputed from " +
-						"it and picks up the new one automatically on the next `pulumi up`.",
-					"x-renewal-cmd": pulumi.interpolate`pulumi up --replace '${oauthClient.urn}'`,
+					...vaultSecretMetadata(oauthClient),
 				},
 			},
 		},

--- a/projects/amiya.akn/src/infrastructure/pulumi/src/cert-manager.ts
+++ b/projects/amiya.akn/src/infrastructure/pulumi/src/cert-manager.ts
@@ -1,4 +1,5 @@
 import { Dns01TokenComponent } from "@chezmoi.sh/pulumi-cloudflare-dns01-token";
+import { vaultSecretMetadata } from "@chezmoi.sh/pulumi-lib";
 import * as pulumi from "@pulumi/pulumi";
 import * as vault from "@pulumi/vault";
 
@@ -34,26 +35,13 @@ if (!config.isBootstraping) {
 				api_token: certManagerToken.tokenValue,
 			}),
 			customMetadata: {
-				// Convention for every secret pushed to Vault in this stack:
-				//   description/owner/application — human identification, shown in
-				//                                    the Vault UI.
-				//   created-by                    — repo-relative path to this file,
-				//                                    for traceability.
-				//   renewal-process/x-renewal-cmd  — what rotating this secret does,
-				//                                    and the exact copy/paste command
-				//                                    to trigger it (built from the
-				//                                    credential's own URN).
 				data: {
 					description: "Cloudflare API Token for cert-manager",
 					owner: "amiya.akn",
 					application: "cert-manager",
-
-					"created-by":
-						"projects/amiya.akn/src/infrastructure/pulumi/src/cert-manager.ts",
-					"renewal-process":
-						"Rotate the token below; this secret's value is recomputed from " +
-						"it and picks up the new one automatically on the next `pulumi up`.",
-					"x-renewal-cmd": pulumi.interpolate`pulumi up --replace '${certManagerToken.tokenUrn}'`,
+					...vaultSecretMetadata(certManagerToken, {
+						renewalUrn: certManagerToken.tokenUrn,
+					}),
 				},
 			},
 		},

--- a/projects/amiya.akn/src/infrastructure/pulumi/src/cloudflare-operator.ts
+++ b/projects/amiya.akn/src/infrastructure/pulumi/src/cloudflare-operator.ts
@@ -1,3 +1,4 @@
+import { vaultSecretMetadata } from "@chezmoi.sh/pulumi-lib";
 import * as cloudflare from "@pulumi/cloudflare";
 import * as pulumi from "@pulumi/pulumi";
 import * as vault from "@pulumi/vault";
@@ -63,26 +64,11 @@ if (!config.isBootstraping) {
 			name: "third-parties/cloudflare/iam/amiya.akn/cloudflare-operator",
 			dataJson: pulumi.jsonStringify({ api_token: token.value }),
 			customMetadata: {
-				// Convention for every secret pushed to Vault in this stack:
-				//   description/owner/application — human identification, shown in
-				//                                    the Vault UI.
-				//   created-by                    — repo-relative path to this file,
-				//                                    for traceability.
-				//   renewal-process/x-renewal-cmd  — what rotating this secret does,
-				//                                    and the exact copy/paste command
-				//                                    to trigger it (built from the
-				//                                    credential's own URN).
 				data: {
 					description: "Cloudflare API Token for tunnel operator",
 					owner: "amiya.akn",
 					application: "cloudflare-operator",
-
-					"created-by":
-						"projects/amiya.akn/src/infrastructure/pulumi/src/cloudflare-operator.ts",
-					"renewal-process":
-						"Rotate the token below; this secret's value is recomputed from " +
-						"it and picks up the new one automatically on the next `pulumi up`.",
-					"x-renewal-cmd": pulumi.interpolate`pulumi up --replace '${token.urn}'`,
+					...vaultSecretMetadata(token),
 				},
 			},
 		},

--- a/projects/amiya.akn/src/infrastructure/pulumi/src/tailscale-operator.ts
+++ b/projects/amiya.akn/src/infrastructure/pulumi/src/tailscale-operator.ts
@@ -1,3 +1,4 @@
+import { vaultSecretMetadata } from "@chezmoi.sh/pulumi-lib";
 import * as pulumi from "@pulumi/pulumi";
 import * as tailscale from "@pulumi/tailscale";
 import * as vault from "@pulumi/vault";
@@ -37,27 +38,12 @@ if (!config.isBootstraping) {
 				client_secret: oauthClient.key,
 			}),
 			customMetadata: {
-				// Convention for every secret pushed to Vault in this stack:
-				//   description/owner/application — human identification, shown in
-				//                                    the Vault UI.
-				//   created-by                    — repo-relative path to this file,
-				//                                    for traceability.
-				//   renewal-process/x-renewal-cmd  — what rotating this secret does,
-				//                                    and the exact copy/paste command
-				//                                    to trigger it (built from the
-				//                                    credential's own URN).
 				data: {
 					description:
 						"Tailscale OAuth Client for Tailscale Operator amiya.akn",
 					owner: "amiya.akn",
 					application: "tailscale-operator",
-
-					"created-by":
-						"projects/amiya.akn/src/infrastructure/pulumi/src/tailscale-operator.ts",
-					"renewal-process":
-						"Rotate the client below; this secret's value is recomputed from " +
-						"it and picks up the new one automatically on the next `pulumi up`.",
-					"x-renewal-cmd": pulumi.interpolate`pulumi up --replace '${oauthClient.urn}'`,
+					...vaultSecretMetadata(oauthClient),
 				},
 			},
 		},

--- a/projects/lungmen.akn/src/infrastructure/pulumi/package.json
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/package.json
@@ -6,6 +6,7 @@
 	"dependencies": {
 		"@chezmoi.sh/pulumi-cloudflare-dns01-token": "workspace:*",
 		"@chezmoi.sh/pulumi-cluster-vault": "workspace:*",
+		"@chezmoi.sh/pulumi-lib": "workspace:*",
 		"@pulumi/pulumi": "catalog:",
 		"@pulumi/tailscale": "catalog:",
 		"@pulumi/vault": "catalog:"

--- a/projects/lungmen.akn/src/infrastructure/pulumi/src/cert-manager.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/src/cert-manager.ts
@@ -1,4 +1,5 @@
 import { Dns01TokenComponent } from "@chezmoi.sh/pulumi-cloudflare-dns01-token";
+import { vaultSecretMetadata } from "@chezmoi.sh/pulumi-lib";
 import * as pulumi from "@pulumi/pulumi";
 import * as vault from "@pulumi/vault";
 import * as config from "../config";
@@ -31,13 +32,9 @@ new vault.kv.SecretV2(
 				description: "Cloudflare API Token for cert-manager",
 				owner: "lungmen.akn",
 				application: "cert-manager",
-
-				"created-by":
-					"projects/lungmen.akn/src/infrastructure/pulumi/src/cert-manager.ts",
-				"renewal-process":
-					"Rotate the token below; this secret's value is recomputed from " +
-					"it and picks up the new one automatically on the next `pulumi up`.",
-				"x-renewal-cmd": pulumi.interpolate`pulumi up --replace '${certManagerToken.tokenUrn}'`,
+				...vaultSecretMetadata(certManagerToken, {
+					renewalUrn: certManagerToken.tokenUrn,
+				}),
 			},
 		},
 	},

--- a/projects/lungmen.akn/src/infrastructure/pulumi/src/tailscale-operator.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/src/tailscale-operator.ts
@@ -1,3 +1,4 @@
+import { vaultSecretMetadata } from "@chezmoi.sh/pulumi-lib";
 import * as pulumi from "@pulumi/pulumi";
 import * as tailscale from "@pulumi/tailscale";
 import * as vault from "@pulumi/vault";
@@ -34,13 +35,7 @@ new vault.kv.SecretV2(
 					"Tailscale OAuth Client for Tailscale Operator lungmen.akn",
 				owner: "lungmen.akn",
 				application: "tailscale-operator",
-
-				"created-by":
-					"projects/lungmen.akn/src/infrastructure/pulumi/src/tailscale-operator.ts",
-				"renewal-process":
-					"Rotate the client below; this secret's value is recomputed from " +
-					"it and picks up the new one automatically on the next `pulumi up`.",
-				"x-renewal-cmd": pulumi.interpolate`pulumi up --replace '${oauthClient.urn}'`,
+				...vaultSecretMetadata(oauthClient),
 			},
 		},
 	},


### PR DESCRIPTION
## Summary

Adds `@chezmoi.sh/pulumi-lib`, a shared helper library for the per-project
Pulumi stacks. The first (and currently only) export is `vaultSecretMetadata`,
which encodes the `customMetadata` convention carried by every
`vault.kv.SecretV2` push in this homelab. The 15-line boilerplate block was
copy-pasted verbatim across 6 call sites in amiya.akn and lungmen.akn — the
same duplication flagged from three independent angles during the PR 1103
review, with one concrete drift bug already observed.

**Related Issue:** #1102

## Changes Made

### New package: `catalog/pulumi/lib`

- **[`catalog/pulumi/lib/src/vault-secret-metadata.ts`](catalog/pulumi/lib/src/vault-secret-metadata.ts)** — `vaultSecretMetadata(source, opts?)`: auto-detects the caller's repo-relative path via V8 call stack, builds `x-renewal-cmd` from `source.urn` (or `opts.renewalUrn` when the source is a ComponentResource wrapping the real credential), and returns a spreadable `VaultSecretMetadata` object
- **[`catalog/pulumi/lib/src/vault-secret-metadata.test.ts`](catalog/pulumi/lib/src/vault-secret-metadata.test.ts)** — Mocha + Chai unit tests with Pulumi mock runtime, verifying caller detection and URN interpolation end-to-end
- **[`catalog/pulumi/lib/src/index.ts`](catalog/pulumi/lib/src/index.ts)** — barrel re-export
- **[`catalog/pulumi/lib/README.md`](catalog/pulumi/lib/README.md)** — usage, assumptions (unbundled ts-node, full repo checkout), and rationale for plain function over ComponentResource

### Migrated call sites: `projects/amiya.akn`

Replaced the inline metadata block with `...vaultSecretMetadata(...)` in:

- **[`src/argotails.ts`](projects/amiya.akn/src/infrastructure/pulumi/src/argotails.ts)**
- **[`src/cert-manager.ts`](projects/amiya.akn/src/infrastructure/pulumi/src/cert-manager.ts)** — passes `renewalUrn: certManagerToken.tokenUrn` since the source is a `Dns01TokenComponent`
- **[`src/cloudflare-operator.ts`](projects/amiya.akn/src/infrastructure/pulumi/src/cloudflare-operator.ts)**
- **[`src/tailscale-operator.ts`](projects/amiya.akn/src/infrastructure/pulumi/src/tailscale-operator.ts)**

### Migrated call sites: `projects/lungmen.akn`

- **[`src/cert-manager.ts`](projects/lungmen.akn/src/infrastructure/pulumi/src/cert-manager.ts)** — same `renewalUrn` pattern as amiya
- **[`src/tailscale-operator.ts`](projects/lungmen.akn/src/infrastructure/pulumi/src/tailscale-operator.ts)**

## Technical Impact

### Infrastructure Components

Plain TypeScript library, no new Pulumi resources. The `vaultSecretMetadata`
helper returns a plain object; it does not own or create any `vault.kv.SecretV2`
resources. Resource parenting, URNs, and lifecycle are unchanged at every call
site — the spread replaces only the three previously duplicated fields.

### Security Implementation

`x-renewal-cmd` is now derived from the credential's own URN at runtime via
`pulumi.interpolate`, instead of being hard-coded as a string template that
could drift. The `renewalUrn` override ensures components like
`Dns01TokenComponent` point the rotation command to the inner token resource
rather than the component envelope.

### Integration Points

Consumed by `amiya.akn` and `lungmen.akn` stacks via `workspace:*` in their
`package.json` (resolved through the pnpm workspace added in the previous
commit). No other stacks or components are affected.

## Testing Validation

- [x] `pnpm test` passes in `catalog/pulumi/lib` (Mocha mock-based unit tests)
- [x] `pulumi preview` succeeds on amiya.akn without resource replacements
- [x] `pulumi preview` succeeds on lungmen.akn without resource replacements

## Related Issues

Closes #1102

---
<sub>AI-assisted with github-copilot:claude-sonnet-4.6 under human supervision</sub>
