### PR TITLE
Add empty crossplane infra placeholders so ArgoCD can prune them cleanly

### DIFF
--- a/projects/amiya.akn/dist/infrastructure/crossplane/core.v1.Namespace.crossplane.yaml
+++ b/projects/amiya.akn/dist/infrastructure/crossplane/core.v1.Namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/amiya.akn/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/amiya.akn/src/infrastructure/crossplane/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# NOTE: intentionally emptied down to a namespace placeholder — see PR 1106.
+# This lets the crossplane/crossplane-providers ApplicationSets keep
+# generating an Application here so a normal ArgoCD sync prunes every
+# resource this path previously declared. Once that sync is confirmed
+# clean, remove this directory entirely in a follow-up.
+
+resources:
+  - namespace.crossplane.yaml

--- a/projects/amiya.akn/src/infrastructure/crossplane/namespace.crossplane.yaml
+++ b/projects/amiya.akn/src/infrastructure/crossplane/namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/core.v1.Namespace.crossplane.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/core.v1.Namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/aws/core.v1.Namespace.crossplane.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/aws/core.v1.Namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/cloudflare/core.v1.Namespace.crossplane.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/cloudflare/core.v1.Namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/terraform/core.v1.Namespace.crossplane.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/terraform/core.v1.Namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/vault/core.v1.Namespace.crossplane.yaml
+++ b/projects/chezmoi.sh/dist/infrastructure/crossplane/providers/vault/core.v1.Namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# NOTE: intentionally emptied down to a namespace placeholder — see PR 1106.
+# This lets the crossplane/crossplane-providers ApplicationSets keep
+# generating an Application here so a normal ArgoCD sync prunes every
+# resource this path previously declared. Once that sync is confirmed
+# clean, remove this directory entirely in a follow-up.
+
+resources:
+  - namespace.crossplane.yaml

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/namespace.crossplane.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/kustomization.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# NOTE: intentionally emptied down to a namespace placeholder — see PR 1106.
+# This lets the crossplane/crossplane-providers ApplicationSets keep
+# generating an Application here so a normal ArgoCD sync prunes every
+# resource this path previously declared. Once that sync is confirmed
+# clean, remove this directory entirely in a follow-up.
+
+resources:
+  - namespace.crossplane.yaml

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/namespace.crossplane.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/aws/namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/cloudflare/kustomization.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/cloudflare/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# NOTE: intentionally emptied down to a namespace placeholder — see PR 1106.
+# This lets the crossplane/crossplane-providers ApplicationSets keep
+# generating an Application here so a normal ArgoCD sync prunes every
+# resource this path previously declared. Once that sync is confirmed
+# clean, remove this directory entirely in a follow-up.
+
+resources:
+  - namespace.crossplane.yaml

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/cloudflare/namespace.crossplane.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/cloudflare/namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/kustomization.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# NOTE: intentionally emptied down to a namespace placeholder — see PR 1106.
+# This lets the crossplane/crossplane-providers ApplicationSets keep
+# generating an Application here so a normal ArgoCD sync prunes every
+# resource this path previously declared. Once that sync is confirmed
+# clean, remove this directory entirely in a follow-up.
+
+resources:
+  - namespace.crossplane.yaml

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/namespace.crossplane.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/terraform/namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/kustomization.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# NOTE: intentionally emptied down to a namespace placeholder — see PR 1106.
+# This lets the crossplane/crossplane-providers ApplicationSets keep
+# generating an Application here so a normal ArgoCD sync prunes every
+# resource this path previously declared. Once that sync is confirmed
+# clean, remove this directory entirely in a follow-up.
+
+resources:
+  - namespace.crossplane.yaml

--- a/projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/namespace.crossplane.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/crossplane/providers/vault/namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/hass/dist/infrastructure/crossplane/core.v1.Namespace.crossplane.yaml
+++ b/projects/hass/dist/infrastructure/crossplane/core.v1.Namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/hass/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/hass/src/infrastructure/crossplane/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# NOTE: intentionally emptied down to a namespace placeholder — see PR 1106.
+# This lets the crossplane/crossplane-providers ApplicationSets keep
+# generating an Application here so a normal ArgoCD sync prunes every
+# resource this path previously declared. Once that sync is confirmed
+# clean, remove this directory entirely in a follow-up.
+
+resources:
+  - namespace.crossplane.yaml

--- a/projects/hass/src/infrastructure/crossplane/namespace.crossplane.yaml
+++ b/projects/hass/src/infrastructure/crossplane/namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/kazimierz.akn/dist/infrastructure/crossplane/core.v1.Namespace.crossplane.yaml
+++ b/projects/kazimierz.akn/dist/infrastructure/crossplane/core.v1.Namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/kazimierz.akn/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/kazimierz.akn/src/infrastructure/crossplane/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# NOTE: intentionally emptied down to a namespace placeholder — see PR 1106.
+# This lets the crossplane/crossplane-providers ApplicationSets keep
+# generating an Application here so a normal ArgoCD sync prunes every
+# resource this path previously declared. Once that sync is confirmed
+# clean, remove this directory entirely in a follow-up.
+
+resources:
+  - namespace.crossplane.yaml

--- a/projects/kazimierz.akn/src/infrastructure/crossplane/namespace.crossplane.yaml
+++ b/projects/kazimierz.akn/src/infrastructure/crossplane/namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/lungmen.akn/dist/infrastructure/crossplane/core.v1.Namespace.crossplane.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/crossplane/core.v1.Namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane

--- a/projects/lungmen.akn/src/infrastructure/crossplane/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/crossplane/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# NOTE: intentionally emptied down to a namespace placeholder — see PR 1106.
+# This lets the crossplane/crossplane-providers ApplicationSets keep
+# generating an Application here so a normal ArgoCD sync prunes every
+# resource this path previously declared. Once that sync is confirmed
+# clean, remove this directory entirely in a follow-up.
+
+resources:
+  - namespace.crossplane.yaml

--- a/projects/lungmen.akn/src/infrastructure/crossplane/namespace.crossplane.yaml
+++ b/projects/lungmen.akn/src/infrastructure/crossplane/namespace.crossplane.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane


### PR DESCRIPTION
## Summary

#1106 restored the `crossplane` ArgoCD app so its ApplicationSets stay
live long enough for a normal sync to prune what they manage — but #1106
was merged one commit early, before this part landed. Restoring the app
alone isn't enough: its two ApplicationSets discover Applications via a
git-directory generator over `projects/*/dist/infrastructure/crossplane(/providers/*)`,
and those directories were still fully removed. With zero generator
matches, the ApplicationSet controller deletes the Applications it
previously generated outright, instead of letting each one sync down to
an empty desired state first and prune its own resources through a real
diff — the same orphaned-resources risk #1106 was meant to fix, one layer
deeper.

**Related Issue:** #1091

## Root Cause

`crossplane.applicationset.yaml` and `crossplane-providers.applicationset.yaml`
(restored in #1106) generate one Application per matched directory:

- `projects/*/dist/infrastructure/crossplane` (5 projects)
- `projects/*/dist/infrastructure/crossplane/providers/*` (`chezmoi.sh`'s 4 provider families)

#1105 removed every one of those 9 directories. Since they're untracked by
git once empty (and `dist:render` refuses a kustomization that renders
zero resources — "kustomize produced no renderable resources" — so a
truly empty directory was never an option even in principle), the
generators simply have nothing to match. The ApplicationSet controller's
normal behavior for a match that disappears is to delete the
corresponding Application object — with no guarantee that deletion
cascades into a clean prune of the resources that Application owned,
rather than orphaning them.

## Fix

### Re-declare every consumer path as an empty placeholder

Each of the 9 directories now declares **only** a `crossplane` `Namespace`
— every other resource (provider installs, IAM policies, Vault mounts,
composite claims, provider configs) is gone:

- **[`projects/amiya.akn/src/infrastructure/crossplane/`](projects/amiya.akn/src/infrastructure/crossplane/)**
- **[`projects/chezmoi.sh/src/infrastructure/crossplane/`](projects/chezmoi.sh/src/infrastructure/crossplane/)** + **`providers/{aws,cloudflare,terraform,vault}/`**
- **[`projects/lungmen.akn/src/infrastructure/crossplane/`](projects/lungmen.akn/src/infrastructure/crossplane/)**
- **[`projects/hass/src/infrastructure/crossplane/`](projects/hass/src/infrastructure/crossplane/)**
- **[`projects/kazimierz.akn/src/infrastructure/crossplane/`](projects/kazimierz.akn/src/infrastructure/crossplane/)**

Each is just `namespace.crossplane.yaml` + a `kustomization.yaml`
referencing that one file, plus the corresponding rendered `dist/`
output. The ApplicationSets keep generating an Application for every one
of these 9 paths — the directories still exist and are still tracked by
git — but each Application's desired state is now just that one
namespace. A normal automated sync (`prune: true`) removes everything
else it previously owned through a real per-resource diff, instead of
the ApplicationSet controller deleting the whole Application object.

## Technical Impact

### Behavioural Changes

The `crossplane`/`crossplane-providers` ApplicationSets keep generating
the same 9 Applications they did before #1105, but each one's desired
state is now just a `Namespace` — every other Crossplane-managed resource
is pruned from the cluster on the next automated sync. This is the
intended, one-time cleanup effect of this PR.

### Regression Risk

Medium. This actively changes what gets synced: on merge, `amiya.akn`'s
automated ArgoCD sync will prune a non-trivial set of live
Crossplane-managed resources across `amiya.akn` and `chezmoi.sh` (IAM
policies, Vault mounts/policies, provider installs). Mitigations: every
one of those resources was already superseded 1:1 by the Pulumi stacks
from #1103, verified `pulumi preview`-clean at the time; and
`Prune=confirm` is set on all these Applications, so pruning still
requires manual confirmation in the ArgoCD UI/CLI rather than firing
unattended.

### Observability

`argocd app get crossplane` / `argocd app get crossplane-providers`
should show both ApplicationSets still generating all 9 Applications.
Each child Application (e.g. `crossplane-amiya.akn`,
`crossplane-providers-aws`) should show a pending prune down to a single
`Namespace` resource; confirm each one, then verify `kubectl get managed`
(or the relevant Crossplane CRDs) show no leftover resources on
`amiya.akn`.

## Testing Validation

- [x] `dist:render --all` regenerates cleanly (46 ok, 1 skipped) against the post-#1106 `main`, output matches what's committed
- [x] `trunk check` on all new files reports no issues
- [x] `check-zot-coverage.py` reports all prefixes covered across every project's `dist/`, including `xpkg.crossplane.io`
- [x] `opa test catalog/opa/policies/ -v` — 80/80
- [ ] ArgoCD sync on `amiya.akn` shows all 9 Crossplane Applications pruned down to just their `Namespace`, with no orphaned resources
- [ ] Follow-up PR removes the `crossplane` app, its `AppProject`, `catalog/crossplane/`, and these 9 placeholder directories once the above is confirmed

## Related Issues

Addresses #1091 (Crossplane decommissioning — corrects the remaining GC gap from #1105/#1106 before the app, the AppProject, catalog/crossplane, and these placeholders can all be safely removed together)

***

<sub>AI-assisted with anthropic:claude-sonnet-5 under human supervision</sub>
