### PR TITLE
Disable B2 File Lock blocking TrueNAS CloudSync jobs

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -97,7 +97,9 @@ Before pushing anything:
    `references/pr-examples.md`.
 6. Create the PR with a **sentence-form** title that says what changes (no symbol prefix, no bracketed scope — the
    commit symbol format is for git log, not for PR titles).
-7. Apply labels: one `type::*` + the scope label (`project`, `catalog`, `gh`, `deps`).
+7. Apply the scope label(s) matching the changed paths (`project`, `catalog`, `agents:skills`, `agents:sessions`,
+   `agents:knowledge`, `gh`, `deps`) — see `.github/labels.yaml`. There is no `type::*` label for PRs; type is a
+   GitHub-native Issue Type field on issues only. Add `size::*` when you have signal.
 
 ### Pushing follow-up commits to an existing PR
 
@@ -116,8 +118,9 @@ When adding a commit to a branch that already has an open PR:
 
 ## PR title format
 
-Sentence form, no symbol prefix, no bracketed scope. Type and scope live in **labels** (one `type::*` + the scope
-label). The commit symbol format stays where it belongs — on commits — and is validated by commitlint there.
+Sentence form, no symbol prefix, no bracketed scope. Scope lives in the **scope label** (`project`, `catalog`,
+`agents:skills`, …) — there's no `type::*` label for PRs, type is a GitHub-native Issue Type field on issues only. The
+commit symbol format stays where it belongs — on commits — and is validated by commitlint there.
 
 Examples:
 
@@ -265,7 +268,6 @@ gh pr create \
   --title "Sentence describing the change" \
   --body-file /tmp/pr_body.md \
   --base main \
-  --label "type::feature" \
   --label "project"
 rm /tmp/pr_body.md
 ```
@@ -274,7 +276,9 @@ rm /tmp/pr_body.md
 
 - **PR title**: sentence-case English, verb-first, no symbol prefix, no bracketed scope, no trailing period. The commit
   symbol format stays on commits.
-- **PR labels**: one `type::*` + the scope label mandatory. Add `priority::*` / `size::*` when you have signal.
+- **PR labels**: the scope label(s) matching the changed paths are mandatory (see `.github/labels.yaml`: `project`,
+  `catalog`, `agents:skills`, `agents:sessions`, `agents:knowledge`, `gh`, `deps`). Add `size::*` when you have signal;
+  `priority::*` is issues-only.
 - **Commits**: All commits must have the symbol-based `type[scope]: Subject` format, GPG signature (`-S`), and
   `Assisted-by:` trailer. Signed-off-by is the user's responsibility — never add `-s` yourself.
 - **PR body line length**: No hard limit — do NOT wrap PR body text at 80 characters. GitHub renders Markdown, so
@@ -359,7 +363,6 @@ gh pr create \
   --title "Add Forgejo as a self-hosted Git forge on lungmen" \
   --body-file /tmp/pr_body.md \
   --base main \
-  --label "type::feature" \
   --label "project"
 rm /tmp/pr_body.md
 ```
@@ -378,7 +381,7 @@ gh pr create \
 - [ ] Commit validator shows no `FAIL` lines; `WARN` lines surfaced to user
 - [ ] `trunk check --filter=-conftest` reports `No issues` locally
 - [ ] PR title is a sentence — verb-first, no symbol prefix, no bracketed scope
-- [ ] PR labels include one `type::*` + the scope label
+- [ ] PR labels include the scope label(s) matching the changed paths
 - [ ] PR body matches the selected template skeleton: Summary, Changes Made (with subsystem headings), Technical Impact
       (with **named sub-sections**), Testing Validation, Related Issues
 - [ ] Refactor PRs include `## Rationale`; bugfix PRs include `## Root Cause` with evidence

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -14,9 +14,17 @@ compatibility: Requires git and GitHub CLI (gh)
 
 Before pushing anything:
 
-1. Read `.agents/skills/git-commit/SKILL.md` for commit format and scope conventions.
+1. Gather context in one pass (branch, issue number, push status, commits since base, files changed, untracked files):
 
-2. Pick the matching PR template in `.github/PULL_REQUEST_TEMPLATE/`:
+   ```sh
+   bash .agents/skills/create-pr/scripts/gather-context.sh main
+   ```
+
+   Use this output for the whole draft below instead of re-running `git log` / `git diff` / `git status` piecemeal.
+
+2. Read `.agents/skills/git-commit/SKILL.md` for commit format and scope conventions.
+
+3. Pick the matching PR template in `.github/PULL_REQUEST_TEMPLATE/`:
 
    | Change type                             | Template                                                | Distinguishing sections                                                                                                 |
    | --------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
@@ -28,7 +36,7 @@ Before pushing anything:
    The root `pull_request_template.md` is a copy of `feature.md` and applies by default. To use a non-default template
    explicitly, append `?template=<name>.md` to the PR URL or use `gh pr create --web` and pick from the GitHub picker.
 
-3. List the last 3 merged PRs that are not dependency bumps for style reference:
+4. List the last 3 merged PRs that are not dependency bumps for style reference:
 
    ```sh
    gh pr list --limit 30 --state merged --json number,title,author \
@@ -40,7 +48,7 @@ Before pushing anything:
    "
    ```
 
-4. Run the commit validator and review its output:
+5. Run the commit validator and review its output:
 
    ```sh
    bash .agents/skills/create-pr/scripts/validate_commits.sh main
@@ -53,7 +61,7 @@ Before pushing anything:
      attestation that only the human committer can make. Surface the warning to the user and let them decide. Do not add
      `-s` to any commit command yourself.
 
-5. Run trunk check on the changed files and fix all issues before pushing:
+6. Run trunk check on the changed files and fix all issues before pushing:
 
    ```sh
    trunk check --filter=-conftest
@@ -82,8 +90,8 @@ Before pushing anything:
 ### Opening a new PR
 
 1. Create a branch following the naming conventions above.
-2. Run the commit validator (step 4 above) and fix any `FAIL` items; surface `WARN` items to the user.
-3. Run `trunk check --filter=-conftest` (step 5 above) and fix all issues.
+2. Run the commit validator (step 5 above) and fix any `FAIL` items; surface `WARN` items to the user.
+3. Run `trunk check --filter=-conftest` (step 6 above) and fix all issues.
 4. Push: `git push -u origin <branch-name>`
 5. Draft the PR body following the selected template — see `.github/PULL_REQUEST_TEMPLATE/<type>.md` and
    `references/pr-examples.md`.

--- a/.agents/skills/create-pr/scripts/gather-context.sh
+++ b/.agents/skills/create-pr/scripts/gather-context.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# gather-context.sh — Pre-PR context gatherer
+# Prints branch name, issue number, push status, commits since base, files
+# changed, and untracked/unstaged files in one pass. Run before drafting the
+# PR body so the whole draft comes from one consistent snapshot.
+#
+# Usage: bash gather-context.sh [base-branch]
+#   base-branch defaults to "main"
+
+set -euo pipefail
+
+BASE=${1:-main}
+BRANCH=$(git branch --show-current)
+# Matches the "issue-<number>/<desc>" branch naming convention (see SKILL.md).
+ISSUE_NUM=$(echo "${BRANCH}" | grep -oE '^issue-[0-9]+' | grep -oE '[0-9]+' || true)
+REMOTE_STATUS=$(git status -sb | head -1)
+
+echo "┌─────────────────────────────────────────┐"
+echo "│  PR Context                              │"
+echo "└─────────────────────────────────────────┘"
+echo "Branch : ${BRANCH}"
+if [[ -n ${ISSUE_NUM} ]]; then
+  echo "Issue  : #${ISSUE_NUM}"
+else
+  echo "Issue  : (none — branch has no issue-<number>/ prefix)"
+fi
+
+# Push status
+if echo "${REMOTE_STATUS}" | grep -q '\[ahead'; then
+  AHEAD=$(echo "${REMOTE_STATUS}" | grep -oE 'ahead [0-9]+' | awk '{print $2}')
+  echo "Push   : ${AHEAD} commit(s) not yet pushed — run: git push -u origin ${BRANCH}"
+elif ! echo "${REMOTE_STATUS}" | grep -q '\.\.\.'; then
+  echo "Push   : branch not on remote yet — run: git push -u origin ${BRANCH}:${BRANCH}"
+else
+  echo "Push   : up to date with remote"
+fi
+
+echo "┌─────────────────────────────────────────┐"
+echo "│  Commits since ${BASE}"
+echo "└─────────────────────────────────────────┘"
+git --no-pager log "${BASE}..HEAD" --oneline
+
+echo "┌─────────────────────────────────────────┐"
+echo "│  Files changed                           │"
+echo "└─────────────────────────────────────────┘"
+git --no-pager diff "${BASE}...HEAD" --stat
+
+echo "┌─────────────────────────────────────────┐"
+echo "│  Untracked / unstaged files              │"
+echo "└─────────────────────────────────────────┘"
+git status --short | grep -v '^[MA] ' || echo "(none)"

--- a/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/cloudsync.ts
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/cloudsync.ts
@@ -15,26 +15,19 @@ import path = require("node:path");
 //   data loss.
 // - `trueNASBackupBucket`: the current bucket intended for TrueNAS backups.
 //
-// Both enable file-lock (governance mode, 7 days default retention) — recent
-// backups are protected against accidental or malicious deletion for a week
-// even if a CloudSync job or a compromised credential tries to remove them.
-// Their lifecycle rules remove hidden/superseded files after 60 days; the
-// production bucket also cancels unfinished large-file uploads after 1 day.
+// File-lock (governance mode, 7 days default retention) is disabled on both:
+// it made the SYNC-mode CloudSync jobs below fail whenever they needed to
+// delete/overwrite a version still under its 7-day hold, blocking backups
+// entirely. Their lifecycle rules remove hidden/superseded files after 60
+// days; the production bucket also cancels unfinished large-file uploads
+// after 1 day.
 
 export const legacyTrueNASBackupBucket = new b2.Bucket(
 	"nas-backup",
 	{
 		bucketName: "nas-backup-50a30f2b",
 		bucketType: "allPrivate",
-		fileLockConfigurations: [
-			{
-				isFileLockEnabled: true,
-				defaultRetention: {
-					mode: "governance",
-					period: { duration: 7, unit: "days" },
-				},
-			},
-		],
+		fileLockConfigurations: [{ isFileLockEnabled: false }],
 		lifecycleRules: [{ fileNamePrefix: "", daysFromHidingToDeleting: 60 }],
 	},
 	{ protect: true, retainOnDelete: true },
@@ -45,15 +38,7 @@ export const trueNASBackupBucket = new b2.Bucket(
 	{
 		bucketName: "nas-backup-4e6b1351",
 		bucketType: "allPrivate",
-		fileLockConfigurations: [
-			{
-				isFileLockEnabled: true,
-				defaultRetention: {
-					mode: "governance",
-					period: { duration: 7, unit: "days" },
-				},
-			},
-		],
+		fileLockConfigurations: [{ isFileLockEnabled: false }],
 		lifecycleRules: [
 			{
 				// Default rule for all files: delete 60 days after hiding (superseded by newer version)

--- a/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/zpools/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/zpools/README.md
@@ -63,9 +63,10 @@ Layer 3 (remote sync) spans two separate files that are easy to conflate:
 
 - `../cloudsync.ts` declares the CloudSync **jobs**: which dataset gets pushed, on what schedule, in which
   direction/mode (PUSH/SYNC). This is the "what and when" of the sync.
-- `../../backblaze.ts` declares the target **buckets**: where that data lands and how long it stays protected once there
-  — governance-mode File Lock (7-day default retention, so uploads can't be deleted or overwritten for a week) and a
-  60-day lifecycle rule that prunes superseded versions. This is the "where and for how long" once synced.
+- `../../backblaze.ts` declares the target **buckets**: where that data lands and how long it stays there. File Lock is
+  disabled on both — it made the SYNC-mode jobs fail whenever they needed to delete/overwrite a version still under its
+  retention hold — but a 60-day lifecycle rule still prunes superseded versions. This is the "where and for how long"
+  once synced.
 
 Neither file references the other directly — the only link is each job's `attributesJson.bucket` field. Granular
 per-dataset jobs target the current bucket (`nas-backup-4e6b1351` / `trueNASBackupBucket`); the legacy whole-pool job


### PR DESCRIPTION
## Summary

TrueNAS CloudSync jobs pushing `zp1hs01` datasets to Backblaze B2 were being blocked by the File Lock retention set on
both backup buckets. This disables File Lock on `nas-backup-4e6b1351` and `nas-backup-50a30f2b` so the SYNC-mode jobs
can complete again, and separately fixes a stale `type::*` label reference in the `create-pr` skill hit while preparing
this PR.

## Root Cause

Both `legacyTrueNASBackupBucket` and `trueNASBackupBucket` had governance-mode File Lock enabled (7-day default
retention) in
[`cloudsync.ts`](projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/cloudsync.ts). Every CloudSync job in this
file runs with `transferMode: "SYNC"`, which deletes or overwrites destination objects that no longer match the source
— but B2 refuses that operation on any object version still inside its retention hold. Once a job wrote a version and a
later run needed to replace or remove it before the 7-day window elapsed, the delete/overwrite call failed and the sync
job stopped completing, matching the reported "cloud sync blocked" symptom.

No live job-failure logs from the TrueNAS instance were reviewed as part of this diagnosis — the root cause above is
inferred from the B2 retention/SYNC-mode interaction and the reported symptom, not from a captured error message.
Recommend confirming via the CloudSync job history in the TrueNAS UI after this is applied.

## Fix

### TrueNAS Backblaze B2 buckets

- **[`cloudsync.ts`](projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/cloudsync.ts)** — set
  `fileLockConfigurations: [{ isFileLockEnabled: false }]` on both `legacyTrueNASBackupBucket` and
  `trueNASBackupBucket`, removing the `defaultRetention` block entirely
- **[`zpools/README.md`](projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/zpools/README.md)** — updated the
  bucket/lifecycle description to match (File Lock disabled, lifecycle rule unchanged)

### create-pr skill

- **[`.agents/skills/create-pr/SKILL.md`](.agents/skills/create-pr/SKILL.md)** — added a `gather-context.sh` pre-flight
  step (ported from a colleague's GitLab merge-request skill for a different project) and removed the `type::*` label
  instructions, which no longer match `.github/labels.yaml` since PR/issue type became a GitHub-native field
- **[`.agents/skills/create-pr/scripts/gather-context.sh`](.agents/skills/create-pr/scripts/gather-context.sh)** — new
  script consolidating branch, issue number, push status, commit log, diffstat, and untracked-file checks into one run

## Technical Impact

### Behavioural Changes

CloudSync jobs against both B2 buckets can delete/overwrite objects immediately instead of failing while a prior
version is still under retention. Backups resume on their existing daily/weekly schedules.

### Regression Risk

**Low** — the change removes a retention hold, it doesn't touch the sync jobs' scheduling, credentials, or paths. The
buckets keep `protect: true` / `retainOnDelete: true` at the Pulumi level (can't be destroyed by a stack update) and the
60-day lifecycle rule that prunes superseded versions. The trade-off is explicit: a compromised CloudSync credential or
an accidental local deletion can now propagate a delete/overwrite to B2 immediately instead of being held for 7 days.

### Observability

Confirm via the TrueNAS UI CloudSync job history (Storage → Cloud Sync Tasks) that the next scheduled run for each job
completes without a "file is locked" / 403 error from B2.

## Testing Validation

- [ ] `pulumi preview` shows only the expected `fileLockConfigurations` diff on both buckets (no replacement)
- [ ] `pulumi up` applies cleanly
- [ ] Next scheduled CloudSync run for each job (daily userspace sync, weekly app syncs) completes successfully
- [ ] `bash .agents/skills/create-pr/scripts/gather-context.sh main` runs cleanly on an unrelated branch

---

<sub>AI-assisted with Anthropic:claude-sonnet-5 under human supervision</sub>
