### PR TITLE
Correct stale comment on the Pulumi SDK trunk ignore rule

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -111,8 +111,10 @@ lint:
       linters: [ruff]
       paths:
         - catalog/ansible/collections/**/*.py
-    - # Pulumi SDKs dynamically bridged from Terraform providers — 100% generated,
-      # never hand-edited, excluded from all linters (also gitignored)
+    - # Pulumi SDKs dynamically bridged from Terraform providers — 100%
+      # generated, never hand-edited, excluded from all linters. Source is
+      # committed (pnpm install can't regenerate a missing SDK directory);
+      # build artifacts (node_modules/, bin/) stay gitignored per SDK.
       linters: [ALL]
       paths:
         - catalog/pulumi/sdks/**


### PR DESCRIPTION
## Summary

Small follow-up to #1126: the `catalog/pulumi/sdks/**` trunk ignore rule already excluded all four
dynamically-bridged Pulumi SDKs from every linter before that PR, with a comment saying "also gitignored".
#1126 committed each SDK's source, so that comment is now stale — this corrects it to describe the actual
reason (`pnpm install` cannot regenerate a missing SDK directory) and clarifies that only build artifacts
(`node_modules/`, `bin/`) stay gitignored per SDK.

**Related Issue:** #1119

## Changes Made

### Trunk config (`.trunk/trunk.yaml`)

- **[`.trunk/trunk.yaml`](.trunk/trunk.yaml)** — Updated the comment on the `catalog/pulumi/sdks/**` ignore rule; no behavioral change, the rule itself already covered all four SDKs

## Technical Impact

Comment-only change, no linter behavior affected.

## Testing Validation

- [x] `trunk check --filter=-conftest .trunk/trunk.yaml` — no issues

## Related Issues

Addresses #1119

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
