### PR TITLE
Drop PBS verify job's periodic re-verification of old backups

### DIFF
--- a/projects/chezmoi.sh/src/infrastructure/pulumi/stack/pbs/jobs.ts
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/stack/pbs/jobs.ts
@@ -25,12 +25,16 @@ export const backupsPruneJob = new pbs.PruneJob(
 );
 
 // -----------------------------------------------------------------------------
-// Verification: weekly, checksum-verifies every backup in the datastore
+// Verification: weekly, checksum-verifies each backup exactly once
 // -----------------------------------------------------------------------------
-// Weekly is a reasonable default given the retention depth above -- deep
-// enough to catch bitrot before the oldest kept snapshot is pruned away.
-// `outdatedAfter: 30` skips backups re-verified within the last 30 days, so a
-// second manual verify run doesn't redundantly re-check everything.
+// `ignoreVerified: true` with no `outdatedAfter` means a verified snapshot is
+// never re-checked. PBS does not cache verification state per chunk across
+// separate job runs -- re-verifying later would mean re-downloading every
+// chunk again from B2, not just what changed. That periodic re-check exists
+// to catch storage-level bitrot, which B2 already guards against at the
+// object level (checksums, replication); it isn't worth its own egress cost
+// here. The one-time first verify (never skipped) still confirms every
+// backup is restorable before it's ever relied on.
 export const backupsVerifyJob = new pbs.VerifyJob(
 	"pbs-verify-backups",
 	{
@@ -38,8 +42,7 @@ export const backupsVerifyJob = new pbs.VerifyJob(
 		store: backupsDatastore.name,
 		schedule: "Sun 03:30",
 		ignoreVerified: true,
-		outdatedAfter: 30,
-		comment: "Weekly checksum verification",
+		comment: "Weekly checksum verification of new backups",
 	},
 	{ parent: backupsDatastore },
 );


### PR DESCRIPTION
## Summary

Drops `outdatedAfter: 30` from the PBS verify job. Weekly first-time verification of new backups stays as-is
(never skipped, and is what actually guarantees every backup is restorable before it's relied on) — this only
removes the periodic re-check of snapshots already verified.

PBS does not cache verification state per chunk across separate job runs: dedup savings only apply within a
single job execution, so a re-check at the 30-day mark re-downloads every chunk of an already-verified snapshot
again from B2, not just what changed. That cost buys protection against storage-level bitrot, which B2 already
guards against at the object level (checksums, replication) — not worth its own egress here. It also didn't line
up with retention: `keepMonthly: 3` (~90 days) means most snapshots would be pruned before a 90+ day re-verify
interval could ever fire again.

Follow-up refinement to the PBS config-as-code work (issue 1053, closed).

## Changes Made

### PBS verify job (`stack/pbs/jobs.ts`)

- **[`jobs.ts`](projects/chezmoi.sh/src/infrastructure/pulumi/stack/pbs/jobs.ts)** — Removed `outdatedAfter: 30` from `backupsVerifyJob`; `ignoreVerified: true` with no `outdatedAfter` means a verified snapshot is never re-checked, only new ones

## Technical Impact

### Cost / Reliability

Removes the recurring full-datastore re-download this job was performing every 30 days against the B2-backed
datastore, while keeping the coverage guarantee that actually matters (every backup verified once, before it
could ever be relied on or pruned).

## Testing Validation

- [x] `tsc --noEmit` on the stack — clean
- [x] `trunk check --filter=-conftest` — no issues on changed files
- [ ] `pulumi preview` against the live `chezmoi_sh` stack shows only the expected `outdatedAfter` diff on `backupsVerifyJob`

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
