### PR TITLE
Fix invalid BIND zonesub syntax that broke talosnet-dns

### DIFF
--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/talosnet-dns/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/talosnet-dns/flake.nix
@@ -42,7 +42,7 @@
       # Proxmox template (talosnet-dns.<date>-amd64.tar.xz). Component
       # versions track the nixpkgs pin. Bump this date before every
       # `mise run lxc:build`; append -N for multiple builds on the same day.
-      version = "2026.07.27";
+      version = "2026.07.29-2";
 
       # bindTsigSecret — HMAC-SHA256 TSIG key securing RFC2136 dynamic
       # updates to talosnet.chezmoi.sh (bind.sops.env). Read from the

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/talosnet-dns/modules/bind.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/talosnet-dns/modules/bind.nix
@@ -83,7 +83,9 @@ in
       slaves = lib.optionals (bindTsigSecret != "") [ ''key "external-dns."'' ];
       extraConfig = lib.mkIf (bindTsigSecret != "") ''
         update-policy {
-          grant "external-dns." zonesub chezmoi.sh. A TXT;
+          # zonesub takes no name argument -- it implicitly means "this zone" (chezmoi.sh,
+          # the enclosing zone block). Anything after it is the type list.
+          grant "external-dns." zonesub A TXT;
         };
       '';
     };


### PR DESCRIPTION
## Summary

Deploying PR #1147's zone-wide `update-policy` grant to talosnet-dns took `bind.service` down for about 8 minutes: `zonesub` doesn't take a zone-name argument, so `named` parsed the literal zone name as a bogus record type and refused to start. Fixed the grant syntax, rebuilt, and confirmed the live server is healthy again.

## Root Cause

BIND9's `update-policy` `zonesub` ruletype is equivalent to `subdomain` except it takes **no name field** — the zone is implicit (the enclosing `zone { }` block). The previous grant was:

```
grant "external-dns." zonesub chezmoi.sh. A TXT;
```

`named` parsed `chezmoi.sh.` as the first token after `zonesub` — which for this ruletype is expected to be a record **type**, not a name — and failed to load:

```
named[605]: /nix/store/.../named.conf:37: 'chezmoi.sh.' is not a valid type
named[605]: loading configuration: failure
named[605]: exiting (due to fatal error)
```

`systemctl status bind` confirmed: `Active: failed (Result: exit-code)`, `ExecStart=... (code=exited, status=1/FAILURE)`.

The upgrade tooling's own smoke-test (temporary CT, step 2/7) surfaced `bind.service loaded failed failed` *before* touching production, but the script logged it as informational and proceeded to replace the running container's rootfs anyway — a separate gap, not fixed in this PR (noted below).

## Fix

### talosnet-dns

- **[`modules/bind.nix`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/talosnet-dns/modules/bind.nix)** — `zonesub chezmoi.sh. A TXT` → `zonesub A TXT`, with a comment explaining why `zonesub` takes no name argument
- **[`flake.nix`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/talosnet-dns/flake.nix)** — image version bumped to `2026.07.29-2` (rebuilt twice the same day: once broken, once fixed)

## Technical Impact

### Behavioural Changes

None beyond what PR #1147 already intended — the TSIG key can update `A`/`TXT` records anywhere in the `chezmoi.sh` zone (not just `talosnet.chezmoi.sh`), which was the whole point of that change. This PR only fixes the syntax that was preventing it from loading at all.

### Regression Risk

Low. Single-line config fix, verified by extracting the actual generated `named.conf` from the built tarball before redeploying (not just re-running the same broken build), and confirmed live afterward — see Testing Validation.

### Observability

`systemctl status bind` on the container and `dig @10.128.0.3 <hostname>` are the two checks that caught this and confirmed the fix; no automated alerting exists on this LXC's service health today.

## Testing Validation

- [x] Extracted `named.conf` from the rebuilt tarball and confirmed the corrected `grant "external-dns." zonesub A TXT;` line before redeploying
- [x] `mise run lxc:upgrade` completed with `bind: active` in the step 6 health check (previous run showed `bind: failed`)
- [x] `systemctl status bind` on the live container: `Active: active (running)`, `ExecStart=... (code=exited, status=0/SUCCESS)`
- [x] `dig @10.128.0.3 oci.chezmoi.sh +short` resolves correctly (`10.128.0.4`, matching the static record)
- [ ] RFC2136 dynamic write path (external-dns-bind actually creating a record under the widened grant) not re-verified end-to-end after this fix — the original PR #1147 already flagged this as unvalidated live

## Future Enhancements

- `.mise/lib/lxc.sh`'s upgrade flow should abort before step 4 (stopping the production container) if the step 2 smoke-test shows a failed service, instead of only logging it

---

<sub>AI-assisted with anthropic:claude-sonnet-5 under human supervision</sub>
