### PR TITLE
Replace OpenBao's break-glass Pulumi token with the root token

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,9 +470,6 @@ importers:
       '@pulumi/vault':
         specifier: 'catalog:'
         version: 7.10.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@26.1.0)(typescript@5.9.3))(typescript@5.9.3)
-      pulumi-time:
-        specifier: ^0.14.0
-        version: 0.14.0(@pulumi/pulumi@3.250.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@26.1.0)(typescript@5.9.3))(typescript@5.9.3))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -862,9 +859,6 @@ packages:
 
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
-
-  async-mutex@0.5.0:
-    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1454,11 +1448,6 @@ packages:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
-  pulumi-time@0.14.0:
-    resolution: {integrity: sha512-Jqa0/6zZ+OGUraqZWnaFKBCGKQWPneBklBkIkO5Y1SNaycMr57wPWpoE5FFuAedYyZAMeGT9pNimkQd6suRgKA==}
-    peerDependencies:
-      '@pulumi/pulumi': '>=3.190.0 <4'
-
   read-cmd-shim@6.0.0:
     resolution: {integrity: sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -1617,9 +1606,6 @@ packages:
         optional: true
       '@swc/wasm':
         optional: true
-
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tuf-js@4.1.0:
     resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
@@ -2335,10 +2321,6 @@ snapshots:
 
   assertion-error@1.1.0: {}
 
-  async-mutex@0.5.0:
-    dependencies:
-      tslib: 2.8.1
-
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -2959,11 +2941,6 @@ snapshots:
       '@types/node': 20.19.43
       long: 5.3.2
 
-  pulumi-time@0.14.0(@pulumi/pulumi@3.250.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@26.1.0)(typescript@5.9.3))(typescript@5.9.3)):
-    dependencies:
-      '@pulumi/pulumi': 3.250.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@26.1.0)(typescript@5.9.3))(typescript@5.9.3)
-      async-mutex: 0.5.0
-
   read-cmd-shim@6.0.0: {}
 
   readdirp@3.6.0:
@@ -3164,8 +3141,6 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
-
-  tslib@2.8.1: {}
 
   tuf-js@4.1.0(supports-color@8.1.1):
     dependencies:

--- a/projects/rhodes.akn/docs/disaster-recovery/README.md
+++ b/projects/rhodes.akn/docs/disaster-recovery/README.md
@@ -17,9 +17,12 @@ You must also have:
 - Access to Omni (`omnictl config new/add` already run) to provision the cluster in Step 1.
 - A valid `SOPS_AGE_KEY_FILE` (via `mise install` / this repo's environment) to decrypt every `sops/` secret applied
   along this chain (`vault/sops`, `pocket-id/sops`, `argocd/sops`).
-- Access to the `rhodes.akn` Pulumi stack (`pulumi login`, correct stack selected) — needed for Step 3's recovery-mode
-  `pulumi up`, OpenBao's break-glass admin token (Step 5), and for the Cloudflare/DNS-01 credentials cert-manager
-  (applied in Step 2) expects from ESO once Step 7 pushes them into Vault.
+- Access to the `rhodes-akn-infra` Pulumi stack (`pulumi login`, correct stack selected) — needed for Step 3's
+  recovery-mode `pulumi up` and for the Cloudflare/DNS-01 credentials cert-manager (applied in Step 2) expects from ESO
+  once Step 7 pushes them into Vault.
+- The root token, retrieved ahead of time from your personal secret manager — needed for Step 5 (regaining OpenBao admin
+  access) and for Step 7's `pulumi up`. Not tracked anywhere in this repo — see
+  [openbao.md § Technical framework](openbao.md#technical-framework-and-conventions).
 
 ## Required inputs
 
@@ -173,10 +176,6 @@ kubectl --context <CLUSTER_CONTEXT> get pods -n cloudnative-pg-system
 
 ## Step 5 — Restore OpenBao
 
-> [!NOTE] Pocket-Id hasn't been restored yet (Step 6 comes after this one), so use **Option A (break-glass Pulumi
-> token)** from `openbao.md`'s own Step 5 — Option B (Pocket-Id SSO) only becomes available once Pocket-Id and the
-> Gateway are both up, which isn't guaranteed until Step 7.
-
 Follow [OpenBao Disaster Recovery](openbao.md) in full. It restores the `openbao-database` CNPG cluster from its Garage
 S3 backup and regains admin access to the already-configured instance. Return here once its own Quick verifications
 pass.
@@ -190,9 +189,14 @@ into OpenBao is validated later, in Step 8.
 
 ## Step 7 — Turn Pulumi's `recovery` flag off
 
-OpenBao being reachable and unsealed (Step 5) is the signal to flip Pulumi back out of recovery mode:
+OpenBao being reachable and unsealed (Step 5) is the signal to flip Pulumi back out of recovery mode. This `pulumi up`
+talks to Vault directly (creating ESO's auth backend, KV mount, role, and Pocket-Id's SSO auth backend), so its Vault
+provider needs to authenticate — export the same root token from Step 5:
 
 ```sh
+export VAULT_ADDR=http://localhost:8200   # or https://vault.chezmoi.sh if the Gateway/cert are already up
+export VAULT_TOKEN="<root token from your secret manager>"
+
 cd projects/rhodes.akn/src/infrastructure/pulumi
 pulumi config set recovery false
 pulumi up --refresh --parallel 15
@@ -205,8 +209,8 @@ own OIDC `ExternalSecret` (Step 9) depends on this having succeeded.
 
 Walk the [Quick verifications](#quick-verifications) list below for Steps 1-7. Now that Step 7 has run, also confirm the
 one thing that couldn't be checked earlier: **Pocket-Id SSO into OpenBao** — log into `https://vault.chezmoi.sh/ui` via
-Pocket-Id OIDC as an `admin`-group user. This is [openbao.md](openbao.md)'s Option B, and confirms Pocket-Id's OIDC
-round-trip end to end.
+Pocket-Id OIDC as an `admin`-group user. This confirms Pocket-Id's OIDC round-trip into Vault end to end, now that both
+are up — day-to-day admin access no longer needs the root token past this point.
 
 ## Step 9 — Bootstrap ArgoCD and final validation
 
@@ -286,3 +290,7 @@ applied by hand — and reconcile it through GitOps from here on. No further man
   this step's `dist/`-rendered one). Fixed `-n cnpg-system` to the actual `-n cloudnative-pg-system` in Step 4 and Quick
   verifications, and noted external-dns pods also block on Step 5 (their `ExternalSecret`s can't sync until OpenBao is
   restored).
+- _2026-07-29_: Dropped OpenBao's Pulumi-managed break-glass admin token entirely — the root token and its Shamir
+  recovery key shares are held in the operator's personal secret manager instead, making it unnecessary. Step 5 no
+  longer has an Option A/B split or a Pocket-Id-readiness dependency; Step 7 now calls out exporting the same root token
+  so its `pulumi up` can authenticate its Vault provider. See `openbao.md`'s History for the full rationale.

--- a/projects/rhodes.akn/docs/disaster-recovery/README.md
+++ b/projects/rhodes.akn/docs/disaster-recovery/README.md
@@ -66,13 +66,13 @@ kubectl --context <CLUSTER_CONTEXT> label namespace proxmox-system pod-security.
 Then apply each app, one at a time:
 
 ```sh
-kubectl --context <CLUSTER_CONTEXT> apply --server-side -f projects/rhodes.akn/dist/infrastructure/kubernetes/cilium/
-kubectl --context <CLUSTER_CONTEXT> apply --server-side -f projects/rhodes.akn/dist/infrastructure/kubernetes/proxmox/
-kubectl --context <CLUSTER_CONTEXT> apply --server-side -f projects/rhodes.akn/dist/infrastructure/kubernetes/cert-manager/
-kubectl --context <CLUSTER_CONTEXT> apply --server-side -f projects/rhodes.akn/dist/infrastructure/kubernetes/cloudnative-pg/
-kubectl --context <CLUSTER_CONTEXT> apply --server-side -f projects/rhodes.akn/dist/infrastructure/kubernetes/external-secrets/
-kubectl --context <CLUSTER_CONTEXT> apply --server-side -f projects/rhodes.akn/dist/infrastructure/kubernetes/external-dns/
-kubectl --context <CLUSTER_CONTEXT> apply --server-side -f projects/rhodes.akn/dist/infrastructure/kubernetes/ingress-gateway/
+kubectl --context <CLUSTER_CONTEXT> apply --server-side --force-conflicts -f projects/rhodes.akn/dist/infrastructure/kubernetes/cilium/
+kubectl --context <CLUSTER_CONTEXT> apply --server-side --force-conflicts -f projects/rhodes.akn/dist/infrastructure/kubernetes/proxmox/
+kubectl --context <CLUSTER_CONTEXT> apply --server-side --force-conflicts -f projects/rhodes.akn/dist/infrastructure/kubernetes/cert-manager/
+kubectl --context <CLUSTER_CONTEXT> apply --server-side --force-conflicts -f projects/rhodes.akn/dist/infrastructure/kubernetes/cloudnative-pg/
+kubectl --context <CLUSTER_CONTEXT> apply --server-side --force-conflicts -f projects/rhodes.akn/dist/infrastructure/kubernetes/external-secrets/
+kubectl --context <CLUSTER_CONTEXT> apply --server-side --force-conflicts -f projects/rhodes.akn/dist/infrastructure/kubernetes/external-dns/
+kubectl --context <CLUSTER_CONTEXT> apply --server-side --force-conflicts -f projects/rhodes.akn/dist/infrastructure/kubernetes/ingress-gateway/
 ```
 
 > [!WARNING] Run these one at a time and confirm each succeeds before the next — the list above doesn't chain with `&&`,

--- a/projects/rhodes.akn/docs/disaster-recovery/openbao.md
+++ b/projects/rhodes.akn/docs/disaster-recovery/openbao.md
@@ -7,7 +7,8 @@ prerequisites and where this fits in the full recovery chain.
 This document covers restoring a **previously-initialized** instance whose storage (all mounts, policies, roles, auth
 backends, secrets) is restored from backup and arrives already configured — there is no `bao operator init`, no
 `bao auth enable` here, both already happened on the source instance and are baked into the data being restored. What
-this document solves is **regaining admin access** to that already-configured instance without a root token.
+this document solves is **regaining admin access** to that already-configured instance using the root token held outside
+this repo.
 
 ## Technical framework and conventions
 
@@ -20,22 +21,10 @@ this document solves is **regaining admin access** to that already-configured in
   (`sops/softhsm-tokens.secret.yaml`) — this is the second, and only other, piece of state needed to bring OpenBao back.
   **If this secret is ever lost, the restored Postgres data can never be decrypted again** — there is no fallback; the
   instance would have to be reinitialized from empty, discarding all data.
-- **No root token and no recovery keys are held for this instance.** Two admin-recovery paths exist instead of the usual
-  `bao operator generate-root` ceremony (which requires recovery key shares this instance's operators do not have):
-  1. **Pocket-Id SSO**, logging in as a member of the `admin` OIDC group → binds `sso-admin-policy` (`stack/vault.ts`),
-     which grants `path "*"` except seal/unseal, replication, rekey/rotate, and the root-token endpoint —
-     root-equivalent for virtually every practical recovery action. Depends on Pocket-Id itself being reachable — see
-     `projects/rhodes.akn/docs/disaster-recovery/pocket-id.md`.
-  2. **The `dr-recovery-admin-token`** — a Pulumi-managed break-glass token (`stack/vault.ts`, same `sso-admin-policy`,
-     `noParent: true`, `ttl: 8760h`), recreated on roughly a 6-month cadence via a rotation trigger. It is independent
-     of the cluster and of Pocket-Id entirely — retrievable from Pulumi state (Garage S3) alone.
-
-  > [!WARNING]
-  >
-  > **If both paths are unavailable** (Pocket-Id also unrecoverable, and the break-glass token expired with no
-  > `pulumi up` having run in over a year), Vault admin access is **unrecoverable** short of a full `bao operator init`,
-  > which destroys all existing data. This is a known, accepted gap for this instance, not something this procedure
-  > closes — see Known issues.
+- **A root token and its Shamir recovery key shares are held for this instance**, in the operator's personal secret
+  manager — outside git, outside Pulumi, never in this repo. There is no Pulumi-managed break-glass token and no
+  dependency on Pocket-Id (or anything else) being reachable first: the root token works the moment OpenBao is unsealed
+  (Step 4), full stop. See Step 5 below for how to use it.
 
 - **Kubernetes auth backends should self-heal, but this is unverified in practice.** Both the `kubernetes/` backend
   (used for the Pulumi Vault provider's own authentication) and the `rhodes.akn` ESO backend are configured via the
@@ -70,10 +59,8 @@ You must also have:
 - `s3cmd`, `kustomize`, `ksops` on PATH (`s3cmd` needs no config file; credentials are passed as flags in each command
   below). `kustomize` and `ksops` need no configuration either.
 - A valid `SOPS_AGE_KEY_FILE` (via `mise install` / this repo's environment) to decrypt the `vault/sops/` secrets.
-- **Either** Pocket-Id already restored and reachable (`projects/rhodes.akn/docs/disaster-recovery/pocket-id.md`),
-  **or** access to the `rhodes.akn` Pulumi stack (`pulumi login`, correct stack selected) to retrieve the break-glass
-  token — you need at least one of these for Step 5, and **Option B (Pocket-Id) additionally requires the Gateway and a
-  valid TLS certificate to be up** (see the callout in Step 5).
+- The root token, retrieved ahead of time from the operator's personal secret manager — needed for Step 5. Not tracked
+  anywhere in this repo.
 
 ## Required inputs
 
@@ -171,39 +158,27 @@ token/PIN restored in Step 1 correctly decrypts it via PKCS#11 auto-unseal.
 
 ## Step 5 — Regain admin access
 
-Pick whichever of the two paths from Technical framework is available:
-
-**Option A — break-glass Pulumi token (no dependency on Pocket-Id, no dependency on the Gateway):**
-
-```sh
-cd projects/rhodes.akn/src/infrastructure/pulumi
-pulumi stack output drRecoveryAdminTokenValue --show-secrets
-```
-
-At this point in a real recovery, the Gateway and a valid TLS certificate are unlikely to be up yet (ArgoCD hasn't
-bootstrapped, cert-manager may not have issued anything). Reach OpenBao directly instead of through `vault.chezmoi.sh`:
+Retrieve the root token from your personal secret manager (out of band — not tracked anywhere in this repo). At this
+point in a real recovery, the Gateway and a valid TLS certificate are unlikely to be up yet (ArgoCD hasn't bootstrapped,
+cert-manager may not have issued anything), so reach OpenBao directly instead of through `vault.chezmoi.sh`:
 
 ```sh
 kubectl --context <CLUSTER_CONTEXT> port-forward -n vault svc/openbao 8200:8200 &
 
 export VAULT_ADDR=http://localhost:8200
-export VAULT_TOKEN="<value from above>"
-bao token lookup   # → confirms the token is valid and shows its policies
+export VAULT_TOKEN="<root token from your secret manager>"
+bao token lookup   # → confirms it's the root token (policies: ["root"])
 ```
 
-Once the Gateway and a valid certificate are confirmed up (see Known issues / regular operation), `VAULT_ADDR` can
-switch to `https://vault.chezmoi.sh`.
+From here, `VAULT_TOKEN` is a root session — use it like any admin token for the rest of the chain: `bao secrets list` /
+`bao auth list` to confirm mounts and backends restored correctly, the manual `bao write auth/rhodes.akn/config ...` in
+Step 6 if the Kubernetes auth backend didn't self-heal, or simply keeping the port-forward/env vars exported so
+`rhodes-akn-infra`'s own `pulumi up` (Step 7) can authenticate its Vault provider against the same `VAULT_ADDR` — export
+the same `VAULT_TOKEN` before running it.
 
-**Option B — Pocket-Id SSO (requires `projects/rhodes.akn/docs/disaster-recovery/pocket-id.md` already done):**
-
-> [!IMPORTANT]
->
-> Unlike Option A, this path is **not** available until the Gateway and a valid TLS certificate are serving
-> `vault.chezmoi.sh`. Pocket-Id's OIDC device-flow login requires HTTPS — there is no port-forward equivalent for it. If
-> the Gateway/cert-manager aren't up yet, use Option A first, even if Pocket-Id itself is already restored.
-
-Log into the OpenBao UI (`https://vault.chezmoi.sh/ui`) via the Pocket-Id OIDC method, as a user in the `admin` OIDC
-group. This binds `sso-admin-policy` automatically — no CLI steps needed beyond a normal SSO login.
+Once the Gateway and a valid certificate are confirmed up, `VAULT_ADDR` can switch to `https://vault.chezmoi.sh`, and
+Pocket-Id SSO (as a member of the `admin` OIDC group, binding `sso-admin-policy`) becomes available as an ongoing
+day-to-day admin path — see [README.md](README.md)'s Step 8 for confirming that round-trip.
 
 ## Step 6 — Verify Kubernetes auth backends self-healed
 
@@ -229,34 +204,24 @@ verification flagged in Technical framework for the next operator.
 
 - **CNPG cluster healthy**: `kubectl --context <CTX> get cluster openbao-database -n vault` → `Cluster in healthy state`
 - **Unsealed**: `bao status -tls-skip-verify` (via `kubectl exec`) → `Sealed: false`
-- **Admin access**: `bao token lookup` (Option A) or a successful OIDC login (Option B)
+- **Admin access**: `bao token lookup` with the root token exported as `VAULT_TOKEN` → `policies: ["root"]`
 - **Kubernetes auth**: ESO `ExternalSecret`s across the cluster report `SecretSynced`, not `SecretSyncedError`
 - **UI reachable**: `https://vault.chezmoi.sh/ui` loads and shows the unsealed/unauthenticated login screen
 
 ## Known issues
 
-### No fallback if both admin-recovery paths fail
+### Admin recovery depends on the external secret manager
 
-Neither the root token nor recovery keys are held for this instance. If Pocket-Id cannot be restored (see its own
-disaster recovery doc) **and** the break-glass Pulumi token has expired with no `pulumi up` run in the preceding year,
-there is no way to authenticate as an admin to the restored OpenBao. The only remaining option is a full
-`bao operator init` against empty storage, which discards every secret, policy, and role this instance holds for every
-downstream cluster. Mitigate by periodically exercising this document as an actual drill (not just reading it), which
-exercises both recovery paths and catches an expired break-glass token before it's needed for real.
-
-### Recovery keys were never generated for this instance
-
-Because no recovery keys exist, neither `bao operator generate-root` nor `bao operator rekey -target=recovery` can ever
-be used on this instance — both require providing a threshold of the _existing_ recovery keys as authorization, which is
-a Shamir-style ceremony, not an ACL-gated one; a privileged token (even `sso-admin-policy`) cannot substitute for it.
-This was a deliberate trade-off in favor of the two paths in Step 5, not an oversight, but it is worth revisiting if
-this instance's operators ever change.
+The root token and its Shamir recovery key shares live in the operator's personal secret manager, entirely outside this
+repo. If that secret manager is itself unreachable, Vault admin access to the restored instance is blocked until it
+comes back — this procedure has no fallback of its own for that case. Mitigate via the secret manager's own
+backup/recovery procedures, out of scope here.
 
 ## References
 
 - [DB-20260723-00: Restore a CNPG cluster from its S3 object-store backup](../../../../docs/procedures/databases/DB-20260723-00.cnpg-restore-from-object-store.md)
   — the CNPG restore mechanics used in Step 2
-- [Pocket-Id Disaster Recovery](pocket-id.md) — the SSO admin-recovery dependency in Step 5, Option B
+- [Pocket-Id Disaster Recovery](pocket-id.md) — restoring Pocket-Id itself, independent of OpenBao's own recovery
 - [ADR-002: OpenBao Secrets Mount Topology and Organizational Structure](../../../../docs/decisions/002-openbao-secrets-topology.md),
   [ADR-003: OpenBao Path and Naming Conventions](../../../../docs/decisions/003-openbao-path-naming-conventions.md),
   [ADR-004: OpenBao Policy Naming and Scope Conventions](../../../../docs/decisions/004-openbao-policy-naming-conventions.md)
@@ -281,3 +246,10 @@ this instance's operators ever change.
   prerequisites already listed there. Removed the `dr:openbao:secrets` mise task — two commands, not worth a wrapper.
 - _2026-07-28_: Fixed Step 1's `database.externalsecret.yaml` apply landing in the wrong namespace — added the missing
   `-n vault` flag.
+- _2026-07-29_: Replaced the whole break-glass admin-token mechanism (a Pulumi-managed `sso-admin-policy` token,
+  previously drafted as its own `rhodes-akn-recovery-token` stack to keep it out of `rhodes-akn-infra`'s `recovery`
+  gate) with the actual root token: it and its Shamir recovery key shares are held in the operator's personal secret
+  manager, which makes the whole Pulumi-managed-token indirection unnecessary. Simplified Step 5 to a single path
+  (retrieve the root token, export `VAULT_TOKEN`, done) — dropped the Option A/B split and the Pocket-Id-readiness
+  dependency it implied, and dropped the "no fallback if both paths fail" and "no recovery keys exist" Known Issues,
+  both now factually wrong.

--- a/projects/rhodes.akn/src/infrastructure/pulumi/package.json
+++ b/projects/rhodes.akn/src/infrastructure/pulumi/package.json
@@ -14,8 +14,7 @@
 		"@pulumi/kubernetes": "catalog:",
 		"@pulumi/proxmox": "workspace:*",
 		"@pulumi/pulumi": "catalog:",
-		"@pulumi/vault": "catalog:",
-		"pulumi-time": "^0.14.0"
+		"@pulumi/vault": "catalog:"
 	},
 	"devDependencies": {
 		"typescript": "catalog:"

--- a/projects/rhodes.akn/src/infrastructure/pulumi/stack/vault.ts
+++ b/projects/rhodes.akn/src/infrastructure/pulumi/stack/vault.ts
@@ -1,15 +1,8 @@
 import { ClusterVaultComponent } from "@chezmoi.sh/pulumi-cluster-vault";
 import * as pulumi from "@pulumi/pulumi";
 import * as vault from "@pulumi/vault";
-import * as time from "pulumi-time";
 
 const config = new pulumi.Config();
-
-// DR break-glass admin token — see projects/rhodes.akn/docs/disaster-recovery/openbao.md.
-// Exported so it can be retrieved from Pulumi state (`pulumi stack output
-// drRecoveryAdminTokenValue --show-secrets`) even if the cluster itself is
-// unreachable, since Pulumi state lives on Garage S3, independent of the cluster.
-export let drRecoveryAdminTokenValue: pulumi.Output<string> | undefined;
 
 // Everything that configures Vault/OpenBao itself for this cluster: the cluster's own
 // auth backend + mounts, the shared/personal KV mounts, and pocket-id's SSO auth
@@ -196,41 +189,6 @@ path "sys/rotate/*" { capabilities = ["deny"] }
 path "auth/token/root" { capabilities = ["deny"] }
 `,
 	});
-
-	// ---------------------------------------------------------------------------
-	// DR break-glass admin token
-	// ---------------------------------------------------------------------------
-	// Root token and recovery keys are not held anywhere for this instance (see
-	// projects/rhodes.akn/docs/disaster-recovery/openbao.md) — Pocket-Id SSO is the normal admin recovery path,
-	// but that depends on Pocket-Id itself being reachable. This token is the
-	// fallback that doesn't depend on anything else being up. Recreated every
-	// ~6 months via the `rotation` trigger below; ttl is intentionally longer
-	// (8760h, this cluster's max_lease_ttl ceiling) than the rotation cadence so
-	// a missed `pulumi up` doesn't silently let the token expire before the next
-	// one runs. `pulumi up` is never run on a schedule in this repo, so
-	// "rotates every 6 months" means "at the next manual apply after 6 months
-	// have elapsed," not wall-clock automation.
-	const drRecoveryAdminTokenRotation = new time.Rotating(
-		"dr-recovery-admin-token-rotation",
-		{
-			rotationDays: 182,
-		},
-	);
-
-	const drRecoveryAdminToken = new vault.Token(
-		"dr-recovery-admin-token",
-		{
-			displayName: pulumi.interpolate`dr-recovery-admin-${drRecoveryAdminTokenRotation.id}`,
-			policies: [ssoAdminPolicy.name],
-			noParent: true,
-			renewable: true,
-			ttl: "8760h",
-			metadata: { purpose: "dr-break-glass-admin" },
-		},
-		{ replaceOnChanges: ["displayName"] },
-	);
-
-	drRecoveryAdminTokenValue = pulumi.secret(drRecoveryAdminToken.clientToken);
 
 	// ---------------------------------------------------------------------------
 	// Pocket-ID OIDC roles


### PR DESCRIPTION
## Summary

`rhodes.akn`'s OpenBao disaster-recovery docs previously relied on a Pulumi-managed,
rotating "break-glass" admin token as one of two admin-recovery paths (alongside
Pocket-Id SSO). The actual root token and its Shamir recovery key shares are held
for this instance, in the operator's personal secret manager, outside git and
outside Pulumi — making the Pulumi-managed indirection unnecessary. This PR removes
it and rewrites Step 5 of the recovery chain around the root token directly. Also
includes a small pre-existing fix (Step 2's `kubectl apply` commands all needed
`--force-conflicts`, not just `cilium`'s).

**Related Issue:** none — surfaced while reviewing the disaster-recovery docs.

## Rationale

The break-glass token added real complexity for no remaining benefit once a root
token was confirmed to already exist outside the repo: a dedicated Pulumi stack
concept was even drafted mid-review to keep the token's lifecycle independent of
`rhodes-akn-infra`'s `recovery` config flag (which would otherwise have deleted the
token from Pulumi's desired state the moment Step 3 turned recovery mode on — right
before Step 5 needed it). Once the root token was located, that whole indirection —
plus the Option A/B split and the Pocket-Id-readiness dependency it implied — became
unnecessary. Simpler is safer here: fewer moving parts to get wrong during an actual
recovery.

## Changes Made

### `projects/rhodes.akn/src/infrastructure/pulumi/stack/vault.ts`

- Removed the `dr-recovery-admin-token` `vault.Token` and its `time.Rotating`
  rotation trigger, and the `drRecoveryAdminTokenValue` stack output.

### `projects/rhodes.akn/src/infrastructure/pulumi/package.json`

- Removed the now-unused `pulumi-time` dependency (only consumer was the removed
  rotation trigger).

### `projects/rhodes.akn/docs/disaster-recovery/openbao.md`

- Rewrote the "Technical framework" bullet: root token + Shamir recovery keys are
  held in the operator's personal secret manager, not "none held" with two
  workaround paths.
- Step 5 is now a single path: retrieve the root token, export `VAULT_TOKEN`, done
  — no more Option A/B split, no dependency on Pocket-Id being restored first.
- Dropped the "no fallback if both paths fail" and "no recovery keys exist" Known
  Issues — both were factually wrong once the root token was confirmed to exist.

### `projects/rhodes.akn/docs/disaster-recovery/README.md`

- Prerequisites and Step 5 updated to match — the root token replaces the two
  separate stack/Pocket-Id dependencies previously listed.
- Step 7 now calls out exporting the same root token, since that `pulumi up`
  authenticates a Vault provider (creates ESO's auth backend, KV mount/role, and
  Pocket-Id's SSO auth backend).
- Step 2's `kubectl apply` commands (proxmox, cert-manager, cloudnative-pg,
  external-secrets, external-dns, ingress-gateway) now all use `--force-conflicts`,
  matching `cilium`'s existing flag — same SSA-ownership-conflict class of failure
  can recur on any of them during a live drill.

### Removed

- Removed: `stack/vault.ts`'s `dr-recovery-admin-token` / `dr-recovery-admin-token-rotation`
  resources — replaced by the root token held in the operator's personal secret
  manager (see Rationale).

## Technical Impact

### Architecture Simplification

| Before | After |
| --- | --- |
| Pulumi-managed rotating break-glass token (`vault.Token` + `time.Rotating`), gated behind `rhodes-akn-infra`'s `recovery` flag | Root token retrieved directly from the operator's personal secret manager, no Pulumi involvement |
| Step 5 had an Option A (break-glass token) / Option B (Pocket-Id SSO) split, Option A conditioned on Pocket-Id's restore state | Step 5 is one path: export `VAULT_TOKEN` from the secret manager |

### Security Boundary Preservation

No change to Vault's ACL policies, mounts, or auth backends — this only changes
*how an operator authenticates during recovery*, not what that session can do.
Removing the Pulumi-managed token also removes one place a privileged Vault
credential could leak (Pulumi state), since the root token was never going to be
tracked there either way.

### Behavioural Changes

Operational only: an operator doing disaster recovery for `rhodes.akn` now
retrieves the root token from their personal secret manager instead of running
`pulumi stack output drRecoveryAdminTokenValue --show-secrets`. No infrastructure
behavior changes.

### Migration Path

Nothing to roll out — the removed Pulumi stack (a short-lived draft explored mid-review
to keep the break-glass token's state independent from `rhodes-akn-infra`) was
destroyed before ever being committed, so there is no existing token or stack to
migrate away from.

## Testing Validation

- [x] `tsc --noEmit` passes for `rhodes-akn-infra` after removing the token resources
- [x] `pnpm install` / lockfile refreshed after dropping `pulumi-time`
- [x] `trunk check` reports no new issues
- [ ] Next real disaster-recovery drill exercises Step 5 with the root token end to end

## Related Issues

No linked issue — found and fixed during a documentation review session.

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
