### PR TITLE
Document the amiya.akn to rhodes.akn migration path

### DIFF
--- a/docs/migrations/amiya.akn->rhodes.akn.md
+++ b/docs/migrations/amiya.akn->rhodes.akn.md
@@ -1,0 +1,130 @@
+# Migration: amiya.akn → rhodes.akn (core platform)
+
+This migrates the core-platform role (OpenBao, Pocket-Id, ArgoCD hub) from `amiya.akn` to `rhodes.akn`. It follows the
+[Rhodes·AKN Disaster Recovery](../../projects/rhodes.akn/docs/disaster-recovery/README.md) chain almost exactly — same 9
+steps, same order, same tooling — because `rhodes.akn`'s DR procedure was written for this migration in the first place:
+`amiya.akn` becoming unreachable and `amiya.akn` being decommissioned in favor of `rhodes.akn` are the same event from
+the new cluster's point of view. Follow that document step by step; this page only covers where this migration actually
+diverges from a genuine DR drill.
+
+## Step 1 — this is a real first run, not a recreation
+
+DR's Step 1 assumes the cluster template and machine classes already existed and are being re-applied after a loss.
+Here, `projects/rhodes.akn/src/infrastructure/omni/rhodes.clustertemplate.yaml` is being applied for real for the first
+time — it was drafted proactively on 2026-07-23, ahead of this migration (see that file's own history and
+[README.md's History](../../projects/rhodes.akn/docs/disaster-recovery/README.md#history)).
+
+> [!NOTE] The action itself is identical to DR's own Step 1: apply the cluster template via `omnictl`, following
+> [OMNI-20260721-00](../procedures/omni/OMNI-20260721-00.omni-cluster-creation.md) through its CNI/CSI/CCM validation
+> checklist. `rhodes.akn` is already allocated cluster ID 1 / pod CIDR `172.30.0.0/19` in
+> [docs/network/ipam.md](../network/ipam.md) — that decision predates this migration and needs no revisiting here.
+
+## Step 2 (openbao.md / pocket-id.md) — CNPG restore already points at amiya's backups
+
+Informational only — nothing to do here beyond following the linked procedures as written.
+
+Both `projects/rhodes.akn/src/apps/vault/cnpg.cluster.yaml` and
+`projects/rhodes.akn/src/apps/pocket-id/cnpg.cluster.yaml` already have `spec.bootstrap.recovery.source` and
+`spec.externalClusters[].plugin.parameters.barmanObjectName` set to `amiya-akn`, not `selfhosted`. That `ObjectStore`
+(`cnpg.objectstore.amiya-akn.yaml` in each app's directory) targets `s3://cnpg-amiya-akn/{openbao,pocket-id}` —
+`amiya.akn`'s own Garage S3 backups, not `rhodes.akn`'s own (`cnpg.objectstore.yaml`, `selfhosted`).
+
+This means when walking `openbao.md`/`pocket-id.md` Step 2 —
+[DB-20260723-00](../procedures/databases/DB-20260723-00.cnpg-restore-from-object-store.md) — for this migration, the
+manifests already resolve against the right source. There is nothing to edit; just verify the restore against the
+`amiya-akn` `externalClusters` entry instead of assuming `rhodes.akn`'s own object store, as DB-20260723-00 generically
+does.
+
+## Between DR Steps 5/6 and Step 9 — validate over real HTTPS via `/etc/hosts`
+
+Once OpenBao (DR Step 5) and Pocket-Id (DR Step 6) are both up, add temporary entries on the operator's own machine:
+
+```text
+<rhodes external Gateway IP>  vault.chezmoi.sh
+<rhodes external Gateway IP>  auth.chezmoi.sh
+```
+
+The IP comes from rhodes's `external` Cilium LoadBalancer pool, `10.0.0.64/29` (see
+[docs/network/ipam.md](../network/ipam.md)).
+
+> [!IMPORTANT] This validates against the real hostname over a real, already-valid TLS certificate (issued by
+> cert-manager in DR Step 2/9) instead of the port-forward fallback `openbao.md` Step 5 / `pocket-id.md` Step 4 describe
+> for a genuine DR drill. This matters specifically for Pocket-Id: passkey/WebAuthn login requires a secure context
+> (HTTPS + correct hostname) and does not work over a bare port-forward (see `pocket-id.md`'s own `[!IMPORTANT]`
+> callout). The hosts-file override is what lets passkey login be validated end to end before touching production DNS.
+
+Remove these entries only once the real DNS cutover below is confirmed working — do not leave them in place
+indefinitely.
+
+## DNS cutover — handing `vault.chezmoi.sh` / `auth.chezmoi.sh` from amiya to rhodes
+
+`amiya.akn` publishes both hostnames two ways today: `external-dns-unifi` (LAN-only,
+`txtOwnerId: external-dns.amiyaakn`, `policy: sync`) and `cloudflare-operator` + `cloudflare-public-gateway` (public
+Cloudflare DNS — genuinely internet-reachable). `rhodes.akn` only has `external-dns-unifi`
+(`txtOwnerId: external-dns.rhodesakn`, `policy: sync`) and `external-dns-bind` (talosnet-internal split-horizon only) —
+there is no `cloudflare-operator` / `cloudflare-public-gateway` component on `rhodes.akn`.
+
+> [!IMPORTANT] This is an intended behavior change, not a gap to fill in later: after this migration, `vault.chezmoi.sh`
+> and `auth.chezmoi.sh` become LAN (VLAN 5) / Tailscale-only — no longer reachable from the public internet. If a
+> public-facing entry point is wanted again later, that's a separate piece of work, out of scope here.
+
+Because `amiya`'s and `rhodes`'s `external-dns-unifi` instances use different `txtOwnerId` values, neither one will ever
+delete a record it doesn't own — the
+[TXT registry's](https://kubernetes-sigs.github.io/external-dns/latest/docs/registry/txt/) ownership model rules out
+accidental deletion entirely. The real risk is different: both run `policy: sync`, so while both clusters' `HTTPRoute`s
+for the same hostname exist at once, each instance keeps re-asserting _its own_ cluster's IP on every reconcile loop — a
+last-writer-wins flapping race, not a deletion risk. `--migrate-from-txt-owner` is explicitly flagged unsafe by upstream
+for exactly this dual-owner-in-one-zone case, so the safe cutover is to decommission amiya's claim on the hostname
+before or atomically with rhodes's:
+
+1. Confirm rhodes's own `HTTPRoute`s for `vault.chezmoi.sh`/`auth.chezmoi.sh` are already applied and healthy — they
+   are, by DR Step 9 (ArgoCD adopts `dist/apps/{vault,pocket-id}/`).
+2. Remove/scale down amiya's `vault`/`pocket-id` Applications (or at minimum their `HTTPRoute`s), so amiya's
+   `external-dns-unifi` retracts its owned A/TXT records for both hostnames.
+3. Confirm rhodes's `external-dns-unifi` then asserts the record pointing at rhodes's Gateway IP — it was likely already
+   trying to, intermittently, since Step 9; this just stops the fight.
+4. On the public Cloudflare side, there's nothing to create on rhodes — decommissioning amiya's
+   `cloudflare-operator`-managed records for these two hostnames (part of amiya's own decommission) simply drops public
+   reachability, matching the intended LAN/VPN-only end state above.
+5. Verify resolution from a few vantage points (a LAN client via UniFi DNS, and `dig`/`curl` against `ns.chezmoi.sh` for
+   the internal split-horizon zone) now returns rhodes's IP before moving on.
+
+## After cutover — remove the hosts overrides and re-provision lungmen's Vault backend
+
+Remove the temporary `/etc/hosts` entries added above.
+
+`lungmen.akn` depends on `amiya.akn`'s OpenBao for its own ESO auth backend/KV mount, via
+`projects/lungmen.akn/src/infrastructure/pulumi/stack/vault.ts` (`new ClusterVaultComponent("lungmen.akn", {...})`),
+provisioned against whatever Vault instance the Pulumi Vault provider currently points at. Once `vault.chezmoi.sh`
+resolves to rhodes (previous section done), re-run lungmen's own Pulumi stack so it (re)creates lungmen's mount,
+policies, Kubernetes auth backend, and ESO role on rhodes's OpenBao instead of amiya's:
+
+```sh
+cd projects/lungmen.akn/src/infrastructure/pulumi
+pulumi up --refresh --parallel 15
+```
+
+Verify with `kubectl get externalsecret -A` on `lungmen.akn`'s own context — all should report `SecretSynced` afterward.
+
+---
+
+## References
+
+- [Rhodes·AKN Disaster Recovery](../../projects/rhodes.akn/docs/disaster-recovery/README.md) — the 9-step chain this
+  migration follows
+- [OpenBao Disaster Recovery](../../projects/rhodes.akn/docs/disaster-recovery/openbao.md),
+  [Pocket-Id Disaster Recovery](../../projects/rhodes.akn/docs/disaster-recovery/pocket-id.md) — component-specific
+  restore steps
+- [OMNI-20260721-00: Talos cluster bring-up on Proxmox](../procedures/omni/OMNI-20260721-00.omni-cluster-creation.md) —
+  cluster provisioning (Step 1)
+- [DB-20260723-00: Restore a CNPG cluster from its S3 object-store backup](../procedures/databases/DB-20260723-00.cnpg-restore-from-object-store.md)
+  — the generic CNPG restore procedure used by `openbao.md`/`pocket-id.md` Step 2
+- [ADR-014: Homelab network topology (dual-NIC + SDN VNet)](../decisions/014-network-topology.md) — pod CIDR allocation
+  referenced in Step 1
+- [docs/network/ipam.md](../network/ipam.md) — pod CIDR, Cilium LoadBalancer pool allocations
+- [external-dns TXT registry](https://kubernetes-sigs.github.io/external-dns/latest/docs/registry/txt/) — ownership
+  model behind the DNS cutover section
+
+## History
+
+- _2026-07-29_: Initial creation.

--- a/projects/rhodes.akn/docs/disaster-recovery/README.md
+++ b/projects/rhodes.akn/docs/disaster-recovery/README.md
@@ -75,8 +75,16 @@ kubectl --context <CLUSTER_CONTEXT> apply --server-side --force-conflicts -f pro
 kubectl --context <CLUSTER_CONTEXT> apply --server-side --force-conflicts -f projects/rhodes.akn/dist/infrastructure/kubernetes/cloudnative-pg/
 kubectl --context <CLUSTER_CONTEXT> apply --server-side --force-conflicts -f projects/rhodes.akn/dist/infrastructure/kubernetes/external-secrets/
 kubectl --context <CLUSTER_CONTEXT> apply --server-side --force-conflicts -f projects/rhodes.akn/dist/infrastructure/kubernetes/external-dns/
+kustomize build --enable-alpha-plugins --enable-exec projects/rhodes.akn/src/infrastructure/kubernetes/external-dns/sops \
+  | kubectl --context <CLUSTER_CONTEXT> apply -f -
 kubectl --context <CLUSTER_CONTEXT> apply --server-side --force-conflicts -f projects/rhodes.akn/dist/infrastructure/kubernetes/ingress-gateway/
 ```
+
+> [!NOTE] The `external-dns/sops` line above is separate because `dist:render` never bakes ksops-sourced secrets into
+> `dist/` (see its `_has_ksops` check) — every `sops/` directory in this chain needs this same explicit
+> `kustomize build ... | kubectl apply` treatment, same as `openbao.md` Step 1 and `pocket-id.md` Step 1 already do for
+> their own `sops/` directories. This one delivers the BIND RFC2136/TSIG credential the `external-dns-bind` release
+> (applied by the `dist/` line just above) needs.
 
 > [!WARNING] Run these one at a time and confirm each succeeds before the next — the list above doesn't chain with `&&`,
 > so pasting the whole block at once won't stop on a failure. Two pairs must stay in this order: `cert-manager` before
@@ -246,6 +254,8 @@ applied by hand — and reconcile it through GitOps from here on. No further man
 - **ESO fully synced**: `kubectl get externalsecret -A` shows `SecretSynced`, not `SecretSyncedError` (Step 7)
 - **Cert-manager / ExternalDNS / Gateway**: a `Certificate` issues successfully and DNS records appear in Cloudflare
   (Step 2, functional immediately)
+- **external-dns/sops applied**: `kubectl --context <CTX> get secret external-dns-bind-secret -n external-dns-system`
+  exists (Step 2)
 - **ArgoCD**: the `seed` `Application` and every adopted `Application` report `Synced`/`Healthy` (Step 9)
 
 ## References
@@ -294,3 +304,6 @@ applied by hand — and reconcile it through GitOps from here on. No further man
   recovery key shares are held in the operator's personal secret manager instead, making it unnecessary. Step 5 no
   longer has an Option A/B split or a Pocket-Id-readiness dependency; Step 7 now calls out exporting the same root token
   so its `pulumi up` can authenticate its Vault provider. See `openbao.md`'s History for the full rationale.
+- _2026-07-29_: Added the missing external-dns/sops apply to Step 2 — dist:render never bakes ksops-sourced secrets into
+  dist/, so this one needed the same explicit kustomize+ksops treatment openbao.md/pocket-id.md already use for their
+  own sops/ dirs.


### PR DESCRIPTION
## Summary

Adds a short migration guide for moving the core-platform role (OpenBao, Pocket-Id, ArgoCD hub) from `amiya.akn` to `rhodes.akn`, and fixes a gap found while writing it: `rhodes.akn`'s disaster-recovery Step 2 never applied the SOPS-encrypted `external-dns` BIND TSIG secret.

**Related Issue:** #370

## Changes Made

### New: amiya.akn → rhodes.akn migration guide

- **[`docs/migrations/amiya.akn->rhodes.akn.md`](docs/migrations/amiya.akn->rhodes.akn.md)** — This migration reuses `rhodes.akn`'s own [disaster-recovery chain](projects/rhodes.akn/docs/disaster-recovery/README.md) almost verbatim, so this document only records where running it live as a migration diverges from a genuine DR drill: Omni provisioning is a real first run (not a recreation), CNPG restore already targets `amiya.akn`'s backups in the manifests, a temporary `/etc/hosts` override is used to validate passkey login over real HTTPS before DNS moves, the DNS cutover needs a coordinated `external-dns` ownership handoff and intentionally drops public reachability, and `lungmen.akn`'s Vault backend must be re-provisioned once the switch is done.

### Fix: missing SOPS secret in the DR chain

- **[`projects/rhodes.akn/docs/disaster-recovery/README.md`](projects/rhodes.akn/docs/disaster-recovery/README.md)** — Step 2 now also applies `external-dns/sops/bind.secret.yaml` via `kustomize build --enable-alpha-plugins --enable-exec | kubectl apply`. `dist:render` deliberately excludes any `ksops`-sourced directory from `dist/`, so Step 2's plain `kubectl apply -f dist/.../external-dns/` never applied this secret — `openbao.md`/`pocket-id.md` already handle their own `sops/` directories this way; Step 2 was the one place in the chain missing the equivalent call.

## Technical Impact

### Documentation

Both changes are documentation-only — no manifests, Pulumi code, or cluster state are touched. The Step 2 fix corrects an operational procedure that would otherwise leave `external-dns-bind` without its TSIG credential on the next real run of the DR chain (including this migration).

## Testing Validation

- [ ] Markdown renders correctly and internal links resolve (`docs/migrations/`, `docs/procedures/`, `docs/network/`, `docs/decisions/` cross-references)
- [ ] `trunk check` passes (already verified locally — no issues)
- [ ] Manual read-through of the updated Step 2 against `external-dns/kustomization.yaml` / `sops/bind.secret.yaml` to confirm the secret name/namespace cited in the new Quick-verification bullet is correct

## Related Issues

Addresses #370

---

<sub>AI-assisted with anthropic:claude-sonnet-5 under human supervision</sub>
