### PR TITLE
Expose Pangolin Integration API over Tailscale on kazimierz.akn

### DIFF
--- a/projects/kazimierz.akn/src/infrastructure/ansible/inventory/host_vars/kazimierz.yml
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/inventory/host_vars/kazimierz.yml
@@ -81,6 +81,10 @@ pangolin_domains:
 # Gerbil WireGuard tunnel base endpoint
 pangolin_gerbil_base_endpoint: "pangolin.chezmoi.sh"
 
+# Integration API for remote/programmatic control -- tailnet-only, see
+# roles/pangolin/README.md
+pangolin_enable_integration_api: true
+
 # SMTP configuration
 pangolin_smtp_host: in-v3.mailjet.com
 pangolin_smtp_port: 465

--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/README.md
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/README.md
@@ -40,6 +40,15 @@ pangolin_public_ip: "" # e.g. "{{ ansible_default_ipv4.address }}"
 `pangolin_bind_ip` should be set to the host's public IP whenever Tailscale (or anything else) also wants port 443 --
 otherwise Traefik and that other listener fight over the same port on all interfaces.
 
+### Integration API (tailnet-only remote control)
+
+Set `pangolin_enable_integration_api: true` to turn on Pangolin's
+[Integration API](https://docs.pangolin.net/self-host/advanced/integration-api) for programmatic control (creating
+sites, resources, users, etc. via API key). This is a separate service from the `/api/v1` the web dashboard itself
+already routes publicly through Traefik -- it listens on its own port (`pangolin_integration_port`, default 3003), bound
+to `127.0.0.1` only, and is re-exposed on the tailnet via `tailscale serve` (requires `tailscaled` running and logged in
+on the host). It is never reachable from the public internet. Swagger docs are served at `/v1/docs` once enabled.
+
 ## Directory Structure
 
 ```text
@@ -94,6 +103,7 @@ templates are idempotent and the role stops/restarts the stack automatically whe
 | `setup`         | Setup-token extraction only        |
 | `scripts`       | GeoIP update script                |
 | `systemd`       | GeoIP update timer/service         |
+| `tailscale`     | Integration API Tailscale Serve    |
 
 ## References
 

--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/defaults/main.yml
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/defaults/main.yml
@@ -58,6 +58,14 @@ pangolin_disable_user_create_org: true
 # Log level: debug, info, warn, error
 pangolin_log_level: "info"
 
+# Integration API (programmatic remote control, separate from the /api/v1
+# the dashboard itself already exposes publicly). Disabled by default; when
+# enabled it is bound to 127.0.0.1 only and re-exposed on the tailnet via
+# `tailscale serve` (see tasks/main.yml) -- never routed through the public
+# Traefik domain.
+pangolin_enable_integration_api: false
+pangolin_integration_port: 3003
+
 # -------------------------------------------------------------------------
 # Docker Image Versions
 # -------------------------------------------------------------------------

--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/tasks/main.yml
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/tasks/main.yml
@@ -260,6 +260,24 @@
     - docker
   ignore_errors: true # Allow follow-up diagnostics even if first converge fails
 
+# Integration API Tailscale Exposure
+# The Integration API is bound to 127.0.0.1 only (docker-compose.yml.j2) and
+# re-exposed on the tailnet via `tailscale serve`, mirroring the ara_server
+# role. It is never routed through the public Traefik domain. Idempotent, so
+# safe to run on every play; if the flag is later turned off, the stale serve
+# mapping is left in place and must be removed manually with
+# `tailscale serve --https={{ pangolin_integration_port }} off`.
+- name: Expose Integration API on the tailnet via Tailscale Serve
+  ansible.builtin.command:
+    cmd: >-
+      tailscale serve --bg --https={{ pangolin_integration_port }}
+      http://127.0.0.1:{{ pangolin_integration_port }}
+  when: pangolin_enable_integration_api
+  changed_when: false
+  tags:
+    - pangolin
+    - tailscale
+
 # ==========================================================================
 # Initial Setup Token Extraction
 # ==========================================================================

--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/templates/config.yml.j2
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/templates/config.yml.j2
@@ -19,6 +19,9 @@ domains:
 server:
   secret: "{{ pangolin_server_secret | trim }}"
   maxmind_db_path: "./config/geoip/GeoLite2-Country.mmdb"
+{% if pangolin_enable_integration_api %}
+  integration_port: {{ pangolin_integration_port }}
+{% endif %}
   cors:
     allowed_origins: {{ pangolin_cors_allowed_origins | to_json }}
 
@@ -29,6 +32,7 @@ flags:
   require_email_verification: {{ pangolin_require_email_verification | lower }}
   disable_signup_without_invite: {{ pangolin_disable_signup_without_invite | lower }}
   disable_user_create_org: {{ pangolin_disable_user_create_org | lower }}
+  enable_integration_api: {{ pangolin_enable_integration_api | lower }}
 
 {% if pangolin_postgres_connection_string %}
 postgres:

--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/templates/docker-compose.yml.j2
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/templates/docker-compose.yml.j2
@@ -9,6 +9,12 @@ services:
     restart: {{ pangolin_docker_restart_policy }}
     volumes:
       - ./config:/app/config
+{% if pangolin_enable_integration_api %}
+    ports:
+      # Integration API -- localhost only, re-exposed on the tailnet via
+      # `tailscale serve` (see tasks/main.yml). Never published publicly.
+      - 127.0.0.1:{{ pangolin_integration_port }}:{{ pangolin_integration_port }}
+{% endif %}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3001/api/v1/"]
       interval: "3s"


### PR DESCRIPTION
## Summary

Enables Pangolin's [Integration API](https://docs.pangolin.net/self-host/advanced/integration-api) for remote/programmatic control (creating sites, resources, users, etc. via API key) on the `kazimierz.akn` gateway, without opening any new public surface. The API is only reachable over the Tailscale network.

## Changes Made

### Pangolin role (`catalog`-style, lives under `projects/kazimierz.akn`)

- **[`roles/pangolin/defaults/main.yml`](projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/defaults/main.yml)** — new `pangolin_enable_integration_api` (default `false`) and `pangolin_integration_port` (default `3003`) variables
- **[`roles/pangolin/templates/config.yml.j2`](projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/templates/config.yml.j2)** — writes `flags.enable_integration_api` and `server.integration_port` when the flag is on
- **[`roles/pangolin/templates/docker-compose.yml.j2`](projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/templates/docker-compose.yml.j2)** — publishes the Integration API port bound to `127.0.0.1` only (never on the public/`pangolin_bind_ip` interface)
- **[`roles/pangolin/tasks/main.yml`](projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/tasks/main.yml)** — runs `tailscale serve --bg --https=<port> http://127.0.0.1:<port>` after the compose deploy to re-expose the API on the tailnet, mirroring the existing `ara_server` role
- **[`roles/pangolin/README.md`](projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/README.md)** — documents the new option and tag
- **[`inventory/host_vars/kazimierz.yml`](projects/kazimierz.akn/src/infrastructure/ansible/inventory/host_vars/kazimierz.yml)** — turns the flag on for the `kazimierz` host

## Technical Impact

### Infrastructure Components

No new services. The existing `pangolin` container gains one additional locally-bound port; `tailscale serve` (already running `tailscaled` on the host for SSH and the `ara_server` role) picks up one more mapping.

### Security Implementation

The Integration API is a separate service from the `/api/v1` the web dashboard already routes publicly through Traefik. It is bound to `127.0.0.1` in the Docker Compose file and re-exposed only via `tailscale serve`, so it is unreachable from the public internet and requires tailnet membership plus a Pangolin API key to use.

### External Access Points

New tailnet-only endpoint: `https://kazimierz-akn.ts.net:3003` (Swagger docs at `/v1/docs`). No new public DNS records, ports, or firewall rules.

## Testing Validation

- [ ] `ansible-lint` passes on the `pangolin` role (ran locally, only a pre-existing unrelated `no-handler` finding)
- [ ] Playbook run against `kazimierz` completes and the `pangolin` container stays healthy
- [ ] `tailscale serve status` on the host shows the `:3003` mapping
- [ ] `https://kazimierz-akn.ts.net:3003/v1/docs` loads from a tailnet-joined device
- [ ] The endpoint is unreachable from outside the tailnet

## Future Enhancements

- Automatic `tailscale serve --https=<port> off` when the flag is disabled (currently a manual step, documented in a code comment)

## Related Issues

None — standalone enhancement requested directly by the maintainer.

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
