### PR TITLE
Watch PRs for merges and comments after creation

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Opens a well-formed pull request for the Arcane repository following project conventions. Use when asked to create,
   open, or submit a pull request, or to push a branch and request a review. Enforces sentence-form PR titles (the
   symbol-based `type[scope]: Subject` format stays on commits — labels carry type and scope on the PR), branch naming
-  conventions, structured PR body, and Assisted-by transparency trailer.
+  conventions, structured PR body, and Assisted-by transparency trailer. Arms a background monitor after creation that
+  watches for merges and new comments/reviews so follow-up feedback gets picked up automatically.
 compatibility: Requires git and GitHub CLI (gh)
 ---
 
@@ -100,6 +101,51 @@ Before pushing anything:
 7. Apply the scope label(s) matching the changed paths (`project`, `catalog`, `agents:skills`, `agents:sessions`,
    `agents:knowledge`, `gh`, `deps`) — see `.github/labels.yaml`. There is no `type::*` label for PRs; type is a
    GitHub-native Issue Type field on issues only. Add `size::*` when you have signal.
+8. Launch the post-creation monitor (see "Post-creation monitoring" below) so merges and new comments are picked up
+   without the user having to check back manually.
+
+### Post-creation monitoring
+
+Right after `gh pr create` succeeds, arm a watcher for that PR number using the Monitor tool — persistent, so it keeps
+running for the rest of the session instead of timing out:
+
+```js
+Monitor({
+  command: "bash .agents/skills/create-pr/scripts/monitor-pr.sh <pr-number> 60",
+  description: "PR #<pr-number> merge/comments watch",
+  persistent: true,
+});
+```
+
+The script (`scripts/monitor-pr.sh`) polls every 60s and emits one line per event, then exits once the PR leaves the
+`OPEN` state:
+
+- `[comment] <user>: <body>` — a top-level PR conversation comment
+- `[review comment] <user> on <path>:<line>: <body>` — an inline diff comment
+- `[review <STATE>] <user>: <body>` — a submitted review (`APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` with a body)
+- `[state] PR #<n> is now MERGED` or `CLOSED` — terminal, the monitor exits after this line
+
+**On a `MERGED` event:** tell the user the PR merged, stop treating the branch as active work. Do not delete the local
+or remote branch automatically — offer to, but deletion is destructive and needs confirmation per the repo's operating
+constraints.
+
+**On a `CLOSED` (not merged) event:** tell the user and ask whether to keep working on the branch or drop it.
+
+**On a `[comment]` / `[review comment]` / `[review CHANGES_REQUESTED]` event:** read the feedback and decide whether
+it's mechanical enough to act on without a round-trip:
+
+- **Mechanical and unambiguous** (typo, requested rename, missing test the reviewer pointed at, lint/CI fix, a small
+  clarification) — implement it directly: edit, then follow "Pushing follow-up commits to an existing PR" below
+  (validate commits, `trunk check`, push). Reply on the same thread (`gh pr comment <n> --body "..."` for top-level,
+  `gh api repos/<owner>/<repo>/pulls/<n>/comments/<comment-id>/replies` for inline) summarizing what changed and in
+  which commit.
+- **A design change, ambiguous, or touches security/secrets/shared infra** — do not push unilaterally. Surface the
+  comment to the user and wait for direction, same as any other risky/hard-to-reverse action.
+- **A `[review APPROVED]` or plain `[review COMMENTED]` with no actionable ask** — no action needed, just note it to the
+  user if relevant.
+
+This mirrors the existing "confirm before pushing/commenting" rule in `AGENTS.md`: the monitor's job is to bring
+feedback to your attention immediately, not to grant blanket authority to push unreviewed changes.
 
 ### Pushing follow-up commits to an existing PR
 
@@ -388,6 +434,7 @@ gh pr create \
 - [ ] File paths in Changes Made use `[`path`](path)` link syntax
 - [ ] Attribution footer included
 - [ ] Issue referenced (`Closes #number` or `Addresses #number (Phase N)`)
+- [ ] Post-creation monitor launched (`scripts/monitor-pr.sh`, `Monitor` tool, `persistent: true`)
 
 ## References
 
@@ -396,3 +443,4 @@ gh pr create \
 - Real PR examples: `.agents/skills/create-pr/references/pr-examples.md`
 - Project overview: `AGENTS.md`
 - Commit config: `.commitlintrc.js`
+- Post-creation watcher: `.agents/skills/create-pr/scripts/monitor-pr.sh`

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -131,18 +131,32 @@ constraints.
 
 **On a `CLOSED` (not merged) event:** tell the user and ask whether to keep working on the branch or drop it.
 
-**On a `[comment]` / `[review comment]` / `[review CHANGES_REQUESTED]` event:** read the feedback and decide whether
-it's mechanical enough to act on without a round-trip:
+**On a `[comment]` / `[review comment]` / `[review CHANGES_REQUESTED]` event:** first judge whether the feedback is
+actually pertinent — a reviewer (human or bot) can be wrong, out of date, or flagging something already handled
+elsewhere. Don't act just because a comment exists.
 
-- **Mechanical and unambiguous** (typo, requested rename, missing test the reviewer pointed at, lint/CI fix, a small
+- **Pertinent and mechanical** (typo, requested rename, missing test the reviewer pointed at, lint/CI fix, a small
   clarification) — implement it directly: edit, then follow "Pushing follow-up commits to an existing PR" below
-  (validate commits, `trunk check`, push). Reply on the same thread (`gh pr comment <n> --body "..."` for top-level,
-  `gh api repos/<owner>/<repo>/pulls/<n>/comments/<comment-id>/replies` for inline) summarizing what changed and in
-  which commit.
-- **A design change, ambiguous, or touches security/secrets/shared infra** — do not push unilaterally. Surface the
-  comment to the user and wait for direction, same as any other risky/hard-to-reverse action.
+  (validate commits, `trunk check`, push).
+- **Pertinent but a design change, ambiguous, or touches security/secrets/shared infra** — do not push unilaterally.
+  Surface the comment to the user and wait for direction, same as any other risky/hard-to-reverse action. Leave the
+  thread unresolved until that direction lands.
+- **Not pertinent** (already handled, misunderstanding, doesn't apply here) — reply explaining why, don't change code
+  just to appease the comment.
 - **A `[review APPROVED]` or plain `[review COMMENTED]` with no actionable ask** — no action needed, just note it to the
-  user if relevant.
+  user if relevant. Reviews themselves aren't resolvable on GitHub, only their individual review-comment threads are.
+
+**Always reply on the specific thread, never a generic top-level summary comment** — a reviewer re-reading the PR should
+see the answer to their exact comment, in place, not have to cross-reference a separate comment listing everything at
+once:
+
+- Top-level PR conversation comment (`[comment]`): `gh pr comment <n> --body "..."`.
+- Inline review comment (`[review comment]`) that was pertinent and is now addressed (code changed, or a valid "not
+  applicable, because …" explanation given): reply **and** mark the thread resolved in one step —
+  `bash .agents/skills/create-pr/scripts/resolve-review-comment.sh <pr-number> <comment-id> "<reply-body>"`. Only
+  resolve once the fix is actually pushed (or the explanation is final) — a promise to fix later stays unresolved.
+- Inline review comment that's pertinent but needs the user's call: reply (if there's something worth saying yet) but
+  leave the thread unresolved — resolving is a claim that the concern is settled, and it isn't yet.
 
 This mirrors the existing "confirm before pushing/commenting" rule in `AGENTS.md`: the monitor's job is to bring
 feedback to your attention immediately, not to grant blanket authority to push unreviewed changes.
@@ -436,6 +450,8 @@ gh pr create \
 - [ ] Issue referenced (`Closes #number` or `Addresses #number (Phase N)`)
 - [ ] Post-creation monitor launched (`.agents/skills/create-pr/scripts/monitor-pr.sh`, `Monitor` tool,
       `persistent: true`)
+- [ ] Every actioned review comment got a reply on its own thread (not a generic summary comment), and pertinent ones
+      that are now addressed were marked resolved
 
 ## References
 
@@ -445,3 +461,4 @@ gh pr create \
 - Project overview: `AGENTS.md`
 - Commit config: `.commitlintrc.js`
 - Post-creation watcher: `.agents/skills/create-pr/scripts/monitor-pr.sh`
+- Reply-and-resolve helper: `.agents/skills/create-pr/scripts/resolve-review-comment.sh`

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -6,7 +6,7 @@ description: >
   symbol-based `type[scope]: Subject` format stays on commits — labels carry type and scope on the PR), branch naming
   conventions, structured PR body, and Assisted-by transparency trailer. Arms a background monitor after creation that
   watches for merges and new comments/reviews so follow-up feedback gets picked up automatically.
-compatibility: Requires git and GitHub CLI (gh)
+compatibility: Requires git, GitHub CLI (gh), and jq
 ---
 
 # Arcane Pull Request Skill
@@ -117,8 +117,8 @@ Monitor({
 });
 ```
 
-The script (`scripts/monitor-pr.sh`) polls every 60s and emits one line per event, then exits once the PR leaves the
-`OPEN` state:
+The script (`.agents/skills/create-pr/scripts/monitor-pr.sh`) polls every 60s and emits one line per event, then exits
+once the PR leaves the `OPEN` state:
 
 - `[comment] <user>: <body>` — a top-level PR conversation comment
 - `[review comment] <user> on <path>:<line>: <body>` — an inline diff comment
@@ -434,7 +434,8 @@ gh pr create \
 - [ ] File paths in Changes Made use `[`path`](path)` link syntax
 - [ ] Attribution footer included
 - [ ] Issue referenced (`Closes #number` or `Addresses #number (Phase N)`)
-- [ ] Post-creation monitor launched (`scripts/monitor-pr.sh`, `Monitor` tool, `persistent: true`)
+- [ ] Post-creation monitor launched (`.agents/skills/create-pr/scripts/monitor-pr.sh`, `Monitor` tool,
+      `persistent: true`)
 
 ## References
 

--- a/.agents/skills/create-pr/scripts/monitor-pr.sh
+++ b/.agents/skills/create-pr/scripts/monitor-pr.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# monitor-pr.sh — Post-creation PR watcher
+# Polls a PR for new issue comments, review comments, and reviews, plus its
+# open/closed/merged state. Emits one line per event (for use as a Monitor
+# tool event stream) and exits once the PR leaves the OPEN state.
+#
+# Usage: bash monitor-pr.sh <pr-number> [poll-seconds]
+#   poll-seconds defaults to 60 (stay above GitHub API rate-limit concerns)
+
+set -euo pipefail
+
+pr_number=${1:?usage: monitor-pr.sh <pr-number> [poll-seconds]}
+poll_seconds=${2:-60}
+repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+while true; do
+  state=$(gh pr view "${pr_number}" --repo "${repo}" --json state --jq .state)
+  if [[ ${state} != "OPEN" ]]; then
+    echo "[state] PR #${pr_number} is now ${state}"
+    exit 0
+  fi
+
+  # Issue-style comments (the main PR conversation thread)
+  gh api "repos/${repo}/issues/${pr_number}/comments?since=${since}" \
+    --jq '.[] | "[comment] \(.user.login): \(.body | gsub("\n";" "))"' || true
+
+  # Inline review comments (attached to a diff line)
+  gh api "repos/${repo}/pulls/${pr_number}/comments?since=${since}" \
+    --jq '.[] | "[review comment] \(.user.login) on \(.path):\(.line // .original_line): \(.body | gsub("\n";" "))"' || true
+
+  # Review submissions (APPROVED / CHANGES_REQUESTED / COMMENTED with a body)
+  # -- no `since` support on this endpoint, filter client-side instead. Piped
+  # through jq directly (not `gh api --jq`, which doesn't accept --arg).
+  gh api "repos/${repo}/pulls/${pr_number}/reviews" | jq -r --arg since "${since}" \
+    '.[] | select(.submitted_at > $since and (.body != "" or .state != "COMMENTED")) | "[review \(.state)] \(.user.login): \(.body | gsub("\n";" "))"' || true
+
+  since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  sleep "${poll_seconds}"
+done

--- a/.agents/skills/create-pr/scripts/monitor-pr.sh
+++ b/.agents/skills/create-pr/scripts/monitor-pr.sh
@@ -15,6 +15,11 @@ repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 while true; do
+  # Captured before this iteration's API calls, not after -- an event posted
+  # mid-iteration is still >= poll_start, so the next iteration's `since`
+  # filter is guaranteed to include it instead of skipping it.
+  poll_start=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
   state=$(gh pr view "${pr_number}" --repo "${repo}" --json state --jq .state)
   if [[ ${state} != "OPEN" ]]; then
     echo "[state] PR #${pr_number} is now ${state}"
@@ -35,6 +40,6 @@ while true; do
   gh api "repos/${repo}/pulls/${pr_number}/reviews" | jq -r --arg since "${since}" \
     '.[] | select(.submitted_at > $since and (.body != "" or .state != "COMMENTED")) | "[review \(.state)] \(.user.login): \(.body | gsub("\n";" "))"' || true
 
-  since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  since=${poll_start}
   sleep "${poll_seconds}"
 done

--- a/.agents/skills/create-pr/scripts/resolve-review-comment.sh
+++ b/.agents/skills/create-pr/scripts/resolve-review-comment.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# resolve-review-comment.sh — Reply to and resolve one inline review comment
+# Posts a threaded reply to a specific PR review comment, then marks its
+# review thread resolved. Only applies to inline review comments (attached
+# to a diff line) -- top-level PR conversation comments have no resolve
+# concept on GitHub.
+#
+# Usage: bash resolve-review-comment.sh <pr-number> <comment-id> <reply-body>
+#   comment-id is the REST "databaseId" of the inline comment (the id shown
+#   by `gh api repos/<owner>/<repo>/pulls/<pr>/comments`), not the thread id.
+
+set -euo pipefail
+
+pr_number=${1:?usage: resolve-review-comment.sh <pr-number> <comment-id> <reply-body>}
+comment_id=${2:?usage: resolve-review-comment.sh <pr-number> <comment-id> <reply-body>}
+reply_body=${3:?usage: resolve-review-comment.sh <pr-number> <comment-id> <reply-body>}
+repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+owner=${repo%%/*}
+name=${repo##*/}
+
+gh api "repos/${repo}/pulls/${pr_number}/comments/${comment_id}/replies" -f body="${reply_body}" --jq '.id'
+
+# $owner/$repo/$pr below are GraphQL variables (bound via -f/-F), not shell
+# variables -- the query must stay single-quoted.
+# shellcheck disable=SC2016
+thread_id=$(gh api graphql -f query='
+  query($owner:String!, $repo:String!, $pr:Int!) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$pr) {
+        reviewThreads(first:100) {
+          nodes { id comments(first:1) { nodes { databaseId } } }
+        }
+      }
+    }
+  }' -f owner="${owner}" -f repo="${name}" -F pr="${pr_number}" \
+  --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].databaseId == ${comment_id}) | .id")
+
+if [[ -z ${thread_id} ]]; then
+  echo "No review thread found starting at comment ${comment_id} -- reply posted, nothing to resolve" >&2
+  exit 0
+fi
+
+# $threadId below is a GraphQL variable too, see above.
+# shellcheck disable=SC2016
+gh api graphql -f query='
+  mutation($threadId:ID!) {
+    resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } }
+  }' -f threadId="${thread_id}" --jq '.data.resolveReviewThread.thread'

--- a/.agents/skills/create-pr/scripts/resolve-review-comment.sh
+++ b/.agents/skills/create-pr/scripts/resolve-review-comment.sh
@@ -14,6 +14,19 @@ set -euo pipefail
 pr_number=${1:?usage: resolve-review-comment.sh <pr-number> <comment-id> <reply-body>}
 comment_id=${2:?usage: resolve-review-comment.sh <pr-number> <comment-id> <reply-body>}
 reply_body=${3:?usage: resolve-review-comment.sh <pr-number> <comment-id> <reply-body>}
+
+# comment_id gets interpolated into a jq filter below (gh api --jq has no
+# --arg passthrough); reject anything non-numeric here so a bad id fails
+# fast with a clear message instead of a cryptic jq parse error downstream.
+[[ ${pr_number} =~ ^[0-9]+$ ]] || {
+  echo "pr-number must be numeric, got: ${pr_number}" >&2
+  exit 1
+}
+[[ ${comment_id} =~ ^[0-9]+$ ]] || {
+  echo "comment-id must be numeric, got: ${comment_id}" >&2
+  exit 1
+}
+
 repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 owner=${repo%%/*}
 name=${repo##*/}
@@ -28,12 +41,12 @@ thread_id=$(gh api graphql -f query='
     repository(owner:$owner, name:$repo) {
       pullRequest(number:$pr) {
         reviewThreads(first:100) {
-          nodes { id comments(first:1) { nodes { databaseId } } }
+          nodes { id comments(first:100) { nodes { databaseId } } }
         }
       }
     }
   }' -f owner="${owner}" -f repo="${name}" -F pr="${pr_number}" \
-  --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(.comments.nodes[0].databaseId == ${comment_id}) | .id")
+  --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(any(.comments.nodes[]; .databaseId == ${comment_id})) | .id")
 
 if [[ -z ${thread_id} ]]; then
   echo "No review thread found starting at comment ${comment_id} -- reply posted, nothing to resolve" >&2


### PR DESCRIPTION
## Summary

The `create-pr` skill previously ended as soon as `gh pr create` succeeded, so review feedback (comments, inline review comments, requested changes) only got noticed if someone thought to check back on the PR manually. This adds a post-creation step that arms a background poller for the just-opened PR, watching for new comments/reviews and for the PR leaving the `OPEN` state (merged/closed).

## Changes Made

### `create-pr` skill

- **[`.agents/skills/create-pr/scripts/monitor-pr.sh`](.agents/skills/create-pr/scripts/monitor-pr.sh)** — new polling script. Emits one line per event (`[comment]`, `[review comment]`, `[review STATE]`, `[state]`) and exits once the PR leaves `OPEN`.
- **[`.agents/skills/create-pr/SKILL.md`](.agents/skills/create-pr/SKILL.md)** — adds step 8 to the "Opening a new PR" workflow and a new "Post-creation monitoring" section documenting how to arm the `Monitor` tool against the script, how to interpret each event type, and how to decide whether feedback is mechanical enough to action directly (implement + follow-up commit + reply on the thread) versus something that needs the user's input first (design changes, ambiguity, anything touching security/secrets/shared infra).

## Technical Impact

### Infrastructure Components

None — this only changes an `.agents/skills/` workflow document and adds one shell script; no runtime infrastructure is affected.

### Integration Points

Uses the existing `gh api` / `gh pr view` tooling already relied on elsewhere in the skill (`validate_commits.sh`, `gather-context.sh`). Polls every 60s by default via GitHub's REST API (issue comments, PR review comments, PR reviews endpoints), well within normal rate limits for a single open PR.

## Testing Validation

- [x] `bash .agents/skills/create-pr/scripts/monitor-pr.sh <pr-number> 60` runs cleanly against a real open PR (smoke-tested against PR #1161)
- [x] All three `gh api ... --jq` / `jq` filters verified against live API responses (empty-set and non-empty)
- [x] `trunk check --filter=-conftest` reports no issues on the changed files
- [ ] End-to-end: open a PR, have a reviewer leave a comment, confirm the monitor surfaces it

## Related Issues

None — standalone workflow improvement requested directly by the maintainer.

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
