### PR TITLE
Fix Tailscale Serve conflict between ARA and Pangolin Integration API on kazimierz

### DIFF
--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/ara_server/tasks/main.yml
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/ara_server/tasks/main.yml
@@ -20,7 +20,7 @@
 #   included, so a container was never actually necessary here.
 #
 # Access:
-#   - ARA web interface: https://<tailscale-hostname>.ts.net/ara-report
+#   - ARA web interface: https://<tailscale-hostname>.ts.net:10000
 #   - API endpoint: http://127.0.0.1:<ara_port> (default 8000)
 #
 # Data Storage:

--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/ara_server/tasks/main.yml
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/ara_server/tasks/main.yml
@@ -20,7 +20,7 @@
 #   included, so a container was never actually necessary here.
 #
 # Access:
-#   - ARA web interface: https://<tailscale-hostname>.ts.net
+#   - ARA web interface: https://<tailscale-hostname>.ts.net/ara-report
 #   - API endpoint: http://127.0.0.1:<ara_port> (default 8000)
 #
 # Data Storage:

--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/ara_server/templates/ara-server-tailscale-serve.conf.j2
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/ara_server/templates/ara-server-tailscale-serve.conf.j2
@@ -17,10 +17,18 @@ After=tailscaled.service
 # recovers. Without it, a failing ExecStartPost fails the whole unit
 # (verified live: "netMap is nil" from a logged-out tailscaled took down
 # ara-server entirely, even though ARA itself would have started fine).
-# Served at /ara-report rather than the root path, since the Pangolin
-# Integration API (pangolin role) shares this same :443 serve listener at /.
-# ExecStopPost targets only this path -- a bare `tailscale serve reset` would
-# wipe the whole tailnet serve config, including Pangolin's mapping, on
-# every ara-server restart.
-ExecStartPost=-+/usr/bin/tailscale serve --bg --https=443 --set-path=/ara-report http://127.0.0.1:{{ ara_port }}
-ExecStopPost=-+/usr/bin/tailscale serve --https=443 --set-path=/ara-report off
+# Served on :10000 (Tailscale Serve's other valid HTTPS port, alongside
+# 443 and 8443) rather than sharing :443's root path with the Pangolin
+# Integration API (pangolin role). ARA is a Django app with no subpath
+# awareness configured (no FORCE_SCRIPT_NAME) -- its static assets and
+# internal links are absolute-root, so mounting it at a path under :443
+# via --set-path would break navigation/assets once Tailscale strips the
+# prefix on the way in but doesn't rewrite those absolute paths back out
+# (see https://github.com/tailscale/tailscale/issues/12413 for the same
+# failure mode on another app). A dedicated port keeps ARA at its own
+# root, sidestepping that entirely.
+# ExecStopPost targets only :10000 -- a bare `tailscale serve reset` would
+# wipe the whole tailnet serve config, including Pangolin's mapping on
+# :443, on every ara-server restart.
+ExecStartPost=-+/usr/bin/tailscale serve --bg --https=10000 http://127.0.0.1:{{ ara_port }}
+ExecStopPost=-+/usr/bin/tailscale serve --https=10000 off

--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/ara_server/templates/ara-server-tailscale-serve.conf.j2
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/ara_server/templates/ara-server-tailscale-serve.conf.j2
@@ -17,5 +17,10 @@ After=tailscaled.service
 # recovers. Without it, a failing ExecStartPost fails the whole unit
 # (verified live: "netMap is nil" from a logged-out tailscaled took down
 # ara-server entirely, even though ARA itself would have started fine).
-ExecStartPost=-+/usr/bin/tailscale serve --bg http://127.0.0.1:{{ ara_port }}
-ExecStopPost=-+/usr/bin/tailscale serve reset
+# Served at /ara-report rather than the root path, since the Pangolin
+# Integration API (pangolin role) shares this same :443 serve listener at /.
+# ExecStopPost targets only this path -- a bare `tailscale serve reset` would
+# wipe the whole tailnet serve config, including Pangolin's mapping, on
+# every ara-server restart.
+ExecStartPost=-+/usr/bin/tailscale serve --bg --https=443 --set-path=/ara-report http://127.0.0.1:{{ ara_port }}
+ExecStopPost=-+/usr/bin/tailscale serve --https=443 --set-path=/ara-report off

--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/defaults/main.yml
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/defaults/main.yml
@@ -60,9 +60,10 @@ pangolin_log_level: "info"
 
 # Integration API (programmatic remote control, separate from the /api/v1
 # the dashboard itself already exposes publicly). Disabled by default; when
-# enabled it is bound to 127.0.0.1 only and re-exposed on the tailnet via
-# `tailscale serve` (see tasks/main.yml) -- never routed through the public
-# Traefik domain.
+# enabled it is bound to 127.0.0.1 only and re-exposed on the tailnet at the
+# root path (/) via `tailscale serve` (see tasks/main.yml) -- never routed
+# through the public Traefik domain. This is just the local target port;
+# the tailnet serve port is always 443 (see tasks/main.yml).
 pangolin_enable_integration_api: false
 pangolin_integration_port: 3003
 

--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/tasks/main.yml
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/tasks/main.yml
@@ -262,15 +262,19 @@
 
 # Integration API Tailscale Exposure
 # The Integration API is bound to 127.0.0.1 only (docker-compose.yml.j2) and
-# re-exposed on the tailnet via `tailscale serve`, mirroring the ara_server
-# role. It is never routed through the public Traefik domain. Idempotent, so
-# safe to run on every play; if the flag is later turned off, the stale serve
-# mapping is left in place and must be removed manually with
-# `tailscale serve --https={{ pangolin_integration_port }} off`.
+# re-exposed on the tailnet via `tailscale serve` at the root path (/) on
+# :443. Tailscale Serve only accepts 443, 8443 or 10000 as HTTPS serve ports
+# (pangolin_integration_port, 3003, is just the local target port) so this
+# and the ara_server role's /ara-report mapping are path-multiplexed on the
+# same :443 listener rather than each claiming their own port. It is never
+# routed through the public Traefik domain. Idempotent, so safe to run on
+# every play; if the flag is later turned off, the stale serve mapping is
+# left in place and must be removed manually with
+# `tailscale serve --https=443 off`.
 - name: Expose Integration API on the tailnet via Tailscale Serve
   ansible.builtin.command:
     cmd: >-
-      tailscale serve --bg --https={{ pangolin_integration_port }}
+      tailscale serve --bg --https=443
       http://127.0.0.1:{{ pangolin_integration_port }}
   when: pangolin_enable_integration_api
   changed_when: false

--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/tasks/main.yml
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/tasks/main.yml
@@ -264,13 +264,12 @@
 # The Integration API is bound to 127.0.0.1 only (docker-compose.yml.j2) and
 # re-exposed on the tailnet via `tailscale serve` at the root path (/) on
 # :443. Tailscale Serve only accepts 443, 8443 or 10000 as HTTPS serve ports
-# (pangolin_integration_port, 3003, is just the local target port) so this
-# and the ara_server role's /ara-report mapping are path-multiplexed on the
-# same :443 listener rather than each claiming their own port. It is never
-# routed through the public Traefik domain. Idempotent, so safe to run on
-# every play; if the flag is later turned off, the stale serve mapping is
-# left in place and must be removed manually with
-# `tailscale serve --https=443 off`.
+# (pangolin_integration_port, 3003, is just the local target port) -- the
+# ara_server role uses its own dedicated listener on :10000, so the two
+# never share a port or a path. It is never routed through the public
+# Traefik domain. Idempotent, so safe to run on every play; if the flag is
+# later turned off, the stale serve mapping is left in place and must be
+# removed manually with `tailscale serve --https=443 off`.
 - name: Expose Integration API on the tailnet via Tailscale Serve
   ansible.builtin.command:
     cmd: >-

--- a/projects/kazimierz.akn/src/infrastructure/ansible/site.yml
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/site.yml
@@ -76,8 +76,10 @@
     # -------------------------------------------------------------------------
     # API server URL (uses environment variable if set, otherwise public URL)
     arnos_ara_api_server: "{{ lookup('env', 'ARA_API_SERVER') | default(arnos_ara_public_url) }}"
-    # Public URL accessible via Tailscale
-    arnos_ara_public_url: https://kazimierz-akn.tail831c5d.ts.net
+    # Public URL accessible via Tailscale -- ARA has its own dedicated
+    # Tailscale Serve listener on :10000 (see ara_server role), separate
+    # from Pangolin's Integration API on :443.
+    arnos_ara_public_url: "https://kazimierz-akn.tail831c5d.ts.net:10000"
 
   pre_tasks:
     - name: "[Notification] Send Slack notification about playbook start"


### PR DESCRIPTION
## Summary

Tailscale Serve on kazimierz.akn couldn't expose both ARA and Pangolin's
Integration API at once. Pangolin's serve command targeted an invalid HTTPS
port, and ARA's teardown wiped the whole tailnet serve config on every
restart. Both are fixed by giving each service its own dedicated Tailscale
Serve port.

**Related Issue:** None — found via direct investigation, not filed as a
GitHub issue.

## Root Cause

Two independent bugs in `projects/kazimierz.akn/src/infrastructure/ansible/roles/`:

1. `pangolin/tasks/main.yml` ran `tailscale serve --bg --https={{ pangolin_integration_port }} ...` with `pangolin_integration_port: 3003`. Tailscale Serve only accepts **443, 8443, or 10000** as HTTPS serve ports — 3003 is not a valid choice, so the command failed outright.
2. `ara_server/templates/ara-server-tailscale-serve.conf.j2` ran `tailscale serve reset` in `ExecStopPost`, which clears **the entire** tailnet serve config, not just ARA's own mapping. Since this fires on every ARA restart, any Pangolin serve mapping present at that moment was silently deleted until Pangolin's role happened to re-run.

An earlier revision of this PR fixed both by path-multiplexing the two
services on `:443` (Pangolin at `/`, ARA at `/ara-report`). Review caught
that this breaks ARA's own web UI: ARA is a Django app with no subpath
awareness configured (no `FORCE_SCRIPT_NAME`), so its static assets and
internal links are absolute-root. Tailscale Serve strips the `/ara-report`
prefix before forwarding the *request* to ARA, but does not rewrite the
absolute-root links ARA's templates emit in the *response* — so once
rendered in the browser those links miss the prefix and 404 against
Pangolin's router instead. See
[tailscale/tailscale#12413](https://github.com/tailscale/tailscale/issues/12413)
for the same failure mode on another app mounted the same way.

## Fix

### `pangolin` role

- **[`pangolin/tasks/main.yml`](projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/tasks/main.yml)** — Integration API now served at `--https=443` (root path `/`) instead of the invalid `--https=3003`; `pangolin_integration_port` remains the local target port only.
- **[`pangolin/defaults/main.yml`](projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/defaults/main.yml)** — comment updated to clarify the port split.

### `ara_server` role

- **[`ara_server/templates/ara-server-tailscale-serve.conf.j2`](projects/kazimierz.akn/src/infrastructure/ansible/roles/ara_server/templates/ara-server-tailscale-serve.conf.j2)** — ARA now gets its own dedicated Tailscale Serve listener on `--https=10000` (Tailscale Serve's other valid HTTPS port), keeping it at its own root instead of sharing a port/path with Pangolin. `ExecStopPost` now tears down only `:10000` instead of running a global `serve reset`.
- **[`ara_server/tasks/main.yml`](projects/kazimierz.akn/src/infrastructure/ansible/roles/ara_server/tasks/main.yml)** — access-URL comment updated to the new `:10000` port.

### `chezmoi.sh` Ansible site

- **[`infrastructure/ansible/site.yml`](projects/kazimierz.akn/src/infrastructure/ansible/site.yml)** — `arnos_ara_public_url` (used to build the ARA link in Slack run notifications) updated to `https://kazimierz-akn.tail831c5d.ts.net:10000`.

## Technical Impact

### Behavioural Changes

ARA's web interface moves from `https://<tailscale-hostname>.ts.net/` to
`https://<tailscale-hostname>.ts.net:10000/`. Pangolin's Integration API
becomes reachable at `https://<tailscale-hostname>.ts.net/` when
`pangolin_enable_integration_api` is enabled — previously it never actually
worked, since the serve command failed on the invalid port. Slack run
notifications now link to ARA's new `:10000` URL.

### Regression Risk

Low. Both changes are scoped to Tailscale Serve configuration only — neither
role's Docker/systemd deployment, ports, or public Traefik routing changes.
Worst case on a bad flag typo is that one or both services become
unreachable over Tailscale, with the public path (Traefik/Pangolin
dashboard) entirely unaffected. Since ARA and Pangolin's Integration API no
longer share a port at all, there is no longer any interaction risk between
the two services' serve mappings.

### Observability

`tailscale serve status` on the kazimierz.akn host should show `/` mapped on
`:443` (Pangolin) and `/` mapped on `:10000` (ARA) as two independent
listeners after a re-run of both roles. `journalctl -u ara-server` will show
the `ExecStopPost` teardown command, scoped to `:10000`, on restart.

## Testing Validation

- [ ] `tailscale serve status` lists `/` on `:443` (Pangolin) and `/` on `:10000` (ARA) as separate listeners
- [ ] ARA web interface reachable at `https://<tailscale-hostname>.ts.net:10000` with working navigation/static assets
- [ ] Pangolin Integration API reachable at `https://<tailscale-hostname>.ts.net/` when enabled
- [ ] Restarting `ara-server` does not remove Pangolin's serve mapping on `:443`
- [ ] Slack run notification links to the correct `:10000` ARA URL
- [ ] YAML syntax validated (`yaml.safe_load`) on all changed files

## Related Issues

No linked issue.

---

<sub>AI-assisted with claude:claude-sonnet-5 under human supervision</sub>
