### PR TITLE
Serve themed error page for unmatched hosts on kazimierz

### DIFF
--- a/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/templates/dynamic_config.yml.j2
+++ b/projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/templates/dynamic_config.yml.j2
@@ -14,6 +14,13 @@ http:
           - "400-599"
         service: error-pages-service
         query: "/{status}.html"
+    # Forces the themed 404 template regardless of the requested path --
+    # used by the catch-all router below, which points directly at
+    # error-pages-service rather than through the `errors` middleware (there
+    # is no real backend to produce a 400-599 status for it to intercept).
+    force-404-page:
+      replacePath:
+        path: "/404.html"
 
   routers:
     # HTTP to HTTPS redirect router
@@ -57,6 +64,21 @@ http:
         - error-pages
       tls:
         certResolver: letsencrypt
+
+    # Catch-all router for hosts that don't match any of the routers above
+    # (e.g. a made-up toto.chezmoi.sh) -- without it, Traefik never enters
+    # any router's middleware chain for an unmatched Host and falls back to
+    # its own bare "404 page not found" instead of the themed error page.
+    # Lowest priority so it never shadows the domain-specific routers.
+    catchall-router:
+      rule: "HostRegexp(`.+`)"
+      service: error-pages-service
+      entryPoints:
+        - websecure
+      priority: 1
+      middlewares:
+        - force-404-page
+      tls: {}
 
   services:
     next-service:


### PR DESCRIPTION
## Summary

Browsing to an unmatched `*.chezmoi.sh` hostname on kazimierz.akn (e.g. a
made-up `toto.chezmoi.sh`) served Traefik's bare, unthemed "404 page not
found" instead of the already-deployed themed error page.

**Related Issue:** None — found via direct investigation, not filed as a
GitHub issue.

## Root Cause

A themed `error-pages` service (`ghcr.io/tarampampam/error-pages`) and an
`errors` middleware wired to intercept backend status codes 400-599 already
existed in `dynamic_config.yml.j2` and `docker-compose.yml.j2`. But every
Traefik router (`next-router`, `api-router`, `ws-router`, plus the HTTP
redirect router) only matched `Host()` rules built from `pangolin_domains`
— the actual configured domains. There was no catch-all router.

Traefik only enters a router's middleware chain for requests that match a
router in the first place. For a Host that doesn't match any router at all,
Traefik short-circuits with its own hardcoded plain-text 404 before the
`error-pages` middleware — or the themed service behind it — is ever
invoked. The themed error-page infrastructure was real and functional, just
unreachable for unmatched hosts.

## Fix

### `pangolin` role

- **[`pangolin/templates/dynamic_config.yml.j2`](projects/kazimierz.akn/src/infrastructure/ansible/roles/pangolin/templates/dynamic_config.yml.j2)** — adds a lowest-priority `catchall-router` matching `HostRegexp(`.+`)`, pointed directly at the existing `error-pages-service` (no new container, no new dependency). Also adds a small `force-404-page` middleware (`replacePath` to `/404.html`) so the router deterministically renders the themed 404 template regardless of the requested path, since there's no real backend response to trigger the existing status-based `errors` middleware on this path.

## Technical Impact

### Behavioural Changes

Any request to `websecure` whose Host doesn't match a configured Pangolin
domain now gets the themed 404 page instead of Traefik's plain-text 404.
Configured domains are unaffected — the catch-all router has `priority: 1`,
the lowest possible, so it can never shadow the domain-specific routers.

### Regression Risk

Low. The new router only activates when no other router matches — it
cannot intercept traffic for any of the `pangolin_domains` currently
configured. Note: TLS itself is unaffected by this change — an arbitrary
unmatched hostname may still show a certificate warning in the browser
depending on how the entrypoint's default cert resolver handles that SNI;
this PR only fixes the HTTP-layer 404 response, not certificate issuance
for arbitrary hosts.

### Observability

`curl -k -H "Host: does-not-exist.chezmoi.sh" https://<kazimierz-ip>/` should
return the themed error-pages HTML instead of Traefik's plain-text 404.
Traefik's access log (`/var/log/traefik/access.log`) will show
`catchall-router@file` as the matched router for these requests.

## Testing Validation

- [ ] `curl -k -H "Host: toto.chezmoi.sh" https://<kazimierz-ip>/` returns the themed error page, not plain-text 404
- [ ] Existing configured domains (dashboard, API, WebSocket) still route correctly
- [ ] Traefik dynamic config reloads without errors after Ansible re-run
- [ ] Jinja template renders as valid YAML (validated locally with `pangolin_domains` sample data)

## Related Issues

No linked issue.

---

<sub>AI-assisted with claude:claude-sonnet-5 under human supervision</sub>
