### PR TITLE
Give Vault OIDC logins a 6h token instead of 30m

### DIFF
--- a/projects/rhodes.akn/src/infrastructure/pulumi/stack/vault.ts
+++ b/projects/rhodes.akn/src/infrastructure/pulumi/stack/vault.ts
@@ -78,8 +78,8 @@ if (!config.getBoolean("recovery")) {
 		oidcClientId: "762ac35a-f6ea-4831-ab61-a7e923e4b5cf",
 		oidcClientSecret: config.requireSecret("pocket_id_oidc_client_secret"),
 		tune: {
-			defaultLeaseTtl: "30m",
-			maxLeaseTtl: "2h",
+			defaultLeaseTtl: "6h",
+			maxLeaseTtl: "6h",
 			listingVisibility: "unauth",
 			tokenType: "default-service",
 		},


### PR DESCRIPTION
## Summary

Vault's Pocket-Id OIDC auth backend on rhodes.akn issued 30-minute tokens (2h max lease), forcing UI/CLI re-authentication every half hour. Raises both the default and max lease TTL to 6h so an OIDC session lasts a full workday.

**Related Issue:** None — ad-hoc operational tuning.

## Changes Made

### rhodes.akn — Vault

- **[`projects/rhodes.akn/src/infrastructure/pulumi/stack/vault.ts`](projects/rhodes.akn/src/infrastructure/pulumi/stack/vault.ts)** — `pocket-id` auth backend's `tune.defaultLeaseTtl`/`tune.maxLeaseTtl` raised from `30m`/`2h` to `6h`/`6h`

## Technical Impact

### Security Implementation

Longer-lived Vault sessions trade a smaller re-auth burden for a longer window an already-issued token stays valid if leaked or left on a shared machine. Applies to both the `default` and `admin` OIDC roles equally (no role-level TTL override exists, so both inherit the mount tune). Judged acceptable for this homelab's threat model — sessions are still bound to a token that can be revoked, and the OIDC login itself (short-lived) is what gates re-issuance.

### Integration Points

Only affects `pocket-id`'s own auth mount tune, not the OIDC clients that authenticate against it.

## Testing Validation

- [x] `pulumi preview` (scoped via `--target` to only this resource) showed a clean update: `defaultLeaseTtl: "30m" => "6h"`, `maxLeaseTtl: "2h" => "6h"`, nothing else
- [x] Applied directly, Pulumi reported `1 updated` with no errors
- [ ] Confirm next Vault UI/CLI OIDC login issues a token with a 6h TTL (`vault token lookup` shows `ttl`/`creation_ttl` around `21600`)

## Related Issues

None.

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
