### PR TITLE
Allow Pocket-Id egress to jsdelivr for OIDC client logos

### DIFF
--- a/projects/rhodes.akn/dist/apps/pocket-id/cilium.io.v2.CiliumNetworkPolicy.allow-pocket-id-to-internet.yaml
+++ b/projects/rhodes.akn/dist/apps/pocket-id/cilium.io.v2.CiliumNetworkPolicy.allow-pocket-id-to-internet.yaml
@@ -5,8 +5,10 @@ metadata:
   annotations:
     policy.networking.k8s.io/description: |
       Allows Pocket ID to send authentication codes and notifications
-      through Mailjet SMTP service on port 465 (SMTPS) and access
-      MaxMind GeoIP service to download GeoIP databases.
+      through Mailjet SMTP service on port 465 (SMTPS), access
+      MaxMind GeoIP service to download GeoIP databases, and fetch
+      OIDC client logos from selfh.st/icons (served via jsdelivr) when
+      an OIDC client's logoUrl/darkLogoUrl is set via the API.
   labels:
     app.kubernetes.io/instance: pocket-id
     app.kubernetes.io/name: pocket-id
@@ -23,6 +25,7 @@ spec:
   - toFQDNs:
     - matchName: download.maxmind.com
     - matchName: mm-prod-geoip-databases.a2649acb697e2c09b632799562c076f2.r2.cloudflarestorage.com
+    - matchName: cdn.jsdelivr.net
     toPorts:
     - ports:
       - port: "443"

--- a/projects/rhodes.akn/src/apps/pocket-id/security/network-policy.allow-to-internet.yaml
+++ b/projects/rhodes.akn/src/apps/pocket-id/security/network-policy.allow-to-internet.yaml
@@ -4,8 +4,10 @@ metadata:
   annotations:
     policy.networking.k8s.io/description: |
       Allows Pocket ID to send authentication codes and notifications
-      through Mailjet SMTP service on port 465 (SMTPS) and access
-      MaxMind GeoIP service to download GeoIP databases.
+      through Mailjet SMTP service on port 465 (SMTPS), access
+      MaxMind GeoIP service to download GeoIP databases, and fetch
+      OIDC client logos from selfh.st/icons (served via jsdelivr) when
+      an OIDC client's logoUrl/darkLogoUrl is set via the API.
   name: allow-pocket-id-to-internet
 spec:
   endpointSelector:
@@ -22,6 +24,8 @@ spec:
         # Allow access to MaxMind GeoIP service for IP geolocation
         - matchName: download.maxmind.com
         - matchName: mm-prod-geoip-databases.a2649acb697e2c09b632799562c076f2.r2.cloudflarestorage.com
+        # OIDC client logo fetch (selfh.st/icons, served via jsdelivr)
+        - matchName: cdn.jsdelivr.net
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

Setting an OIDC client's `logoUrl`/`darkLogoUrl` via the Pocket-Id API fails with a generic `HTTP 500 {"error":"Something went wrong"}`, because Pocket-Id's egress NetworkPolicy on rhodes.akn only allows Mailjet (SMTP) and MaxMind (GeoIP) — the server-side image fetch it needs to perform to set a client logo has nowhere to go.

**Related Issue:** None — surfaced while wiring OIDC client logos into Pulumi (branch `feat/pulumi-pocketid-pangolin-providers`).

## Root Cause

`CiliumNetworkPolicy allow-pocket-id-to-internet` on rhodes.akn restricts Pocket-Id's egress to an explicit FQDN allowlist: `in-v3.mailjet.com:465` and `download.maxmind.com`/`mm-prod-geoip-databases...cloudflarestorage.com:443`. When an OIDC client's `logoUrl`/`darkLogoUrl` is set, Pocket-Id fetches that URL server-side and stores the resulting image — but `cdn.jsdelivr.net` (used to serve icons from selfh.st/icons) isn't in the allowlist, so Cilium drops the connection and Pocket-Id surfaces it as a generic 500.

Confirmed by reproducing the exact failure directly against the API (`PUT /api/oidc/clients/{id}` with `logoUrl` set) outside of any Pulumi involvement — same error, same clients that already have logos set (via the UI, which presumably isn't network-policy-gated the same way, or predates this policy).

## Fix

### rhodes.akn — Pocket-Id NetworkPolicy

- **[`projects/rhodes.akn/src/apps/pocket-id/security/network-policy.allow-to-internet.yaml`](projects/rhodes.akn/src/apps/pocket-id/security/network-policy.allow-to-internet.yaml)** — add `cdn.jsdelivr.net` to the existing port-443 egress rule (same rule as MaxMind, just one more allowed FQDN)
- **[`projects/rhodes.akn/dist/apps/pocket-id/cilium.io.v2.CiliumNetworkPolicy.allow-pocket-id-to-internet.yaml`](projects/rhodes.akn/dist/apps/pocket-id/cilium.io.v2.CiliumNetworkPolicy.allow-pocket-id-to-internet.yaml)** — regenerated via `dist:render`

## Technical Impact

### Behavioural Changes

Pocket-Id can now reach `cdn.jsdelivr.net` over HTTPS. No other egress is affected — the existing Mailjet/MaxMind rules are untouched.

### Regression Risk

**Low.** This only adds an FQDN to an already-restrictive allowlist (default-deny egress otherwise); it doesn't relax any existing rule or open unrestricted internet access. The added domain (`cdn.jsdelivr.net`) is a widely-used, well-known static asset CDN.

### Observability

After sync, setting a client's `logoUrl` should return `200`/success instead of the 500. `cilium monitor` or Hubble flow logs for the `pocket-id` namespace would show the previously-dropped connection to `cdn.jsdelivr.net:443` now succeeding.

## Testing Validation

- [x] Root cause confirmed by reproducing the failure directly via `curl -X PUT .../api/oidc/clients/{id}` with `logoUrl` set, outside of Pulumi
- [x] `dist:render --changed` regenerated the manifest cleanly, matches the src change
- [ ] After ArgoCD sync: retry the same `logoUrl` update and confirm it succeeds (this is what unblocks the pending Pulumi PR)

## Related Issues

None.

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
