### PR TITLE
Install Newt on rhodes.akn and fix its lungmen.akn Vault path

### DIFF
--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/newt/apps.v1.Deployment.newt-newt-main-tunnel.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/newt/apps.v1.Deployment.newt-newt-main-tunnel.yaml
@@ -48,7 +48,7 @@ spec:
               name: newt-credentials
         - name: LOG_LEVEL
           value: INFO
-        image: oci.chezmoi.sh/docker.io/fosrl/newt:1.15.0@sha256:d69d047c816ca7721eae90d5f3cd3be53b615b3d498678be21488d666538ee5c
+        image: oci.chezmoi.sh/docker.io/fosrl/newt:1.12.5
         imagePullPolicy: IfNotPresent
         name: newt
         ports:

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/newt/apps.v1.Deployment.newt-newt-main-tunnel.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/newt/apps.v1.Deployment.newt-newt-main-tunnel.yaml
@@ -48,7 +48,7 @@ spec:
               name: newt-credentials
         - name: LOG_LEVEL
           value: INFO
-        image: oci.chezmoi.sh/docker.io/fosrl/newt:1.12.5@sha256:3c009663332145cae39b940b07857469038d5e9d71aacb1497e78795ba4e3b9b
+        image: oci.chezmoi.sh/docker.io/fosrl/newt:1.15.0@sha256:d69d047c816ca7721eae90d5f3cd3be53b615b3d498678be21488d666538ee5c
         imagePullPolicy: IfNotPresent
         name: newt
         ports:

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/newt/external-secrets.io.v1.ExternalSecret.newt-credentials.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/newt/external-secrets.io.v1.ExternalSecret.newt-credentials.yaml
@@ -9,15 +9,15 @@ metadata:
 spec:
   data:
   - remoteRef:
-      key: shared/third-parties/pangolin/newt/lungmen.akn
+      key: lungmen.akn/pangolin/newt/site
       property: endpoint
     secretKey: endpoint
   - remoteRef:
-      key: shared/third-parties/pangolin/newt/lungmen.akn
+      key: lungmen.akn/pangolin/newt/site
       property: token_id
     secretKey: token_id
   - remoteRef:
-      key: shared/third-parties/pangolin/newt/lungmen.akn
+      key: lungmen.akn/pangolin/newt/site
       property: token_secret
     secretKey: token_secret
   refreshInterval: 1h

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/newt/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/newt/kustomization.yaml
@@ -47,7 +47,5 @@ labels:
     includeSelectors: true
 
 images:
-  # renovate: datasource=docker depName=docker.io/fosrl/newt
   - name: docker.io/fosrl/newt
     newName: oci.chezmoi.sh/docker.io/fosrl/newt
-    newTag: 1.15.0@sha256:d69d047c816ca7721eae90d5f3cd3be53b615b3d498678be21488d666538ee5c

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/newt/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/newt/kustomization.yaml
@@ -50,4 +50,4 @@ images:
   # renovate: datasource=docker depName=docker.io/fosrl/newt
   - name: docker.io/fosrl/newt
     newName: oci.chezmoi.sh/docker.io/fosrl/newt
-    newTag: 1.12.5@sha256:3c009663332145cae39b940b07857469038d5e9d71aacb1497e78795ba4e3b9b
+    newTag: 1.15.0@sha256:d69d047c816ca7721eae90d5f3cd3be53b615b3d498678be21488d666538ee5c

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/newt/newt.externalsecret.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/newt/newt.externalsecret.yaml
@@ -7,15 +7,15 @@ spec:
   data:
     - secretKey: endpoint
       remoteRef:
-        key: shared/third-parties/pangolin/newt/lungmen.akn
+        key: lungmen.akn/pangolin/newt/site
         property: endpoint
     - secretKey: token_id
       remoteRef:
-        key: shared/third-parties/pangolin/newt/lungmen.akn
+        key: lungmen.akn/pangolin/newt/site
         property: token_id
     - secretKey: token_secret
       remoteRef:
-        key: shared/third-parties/pangolin/newt/lungmen.akn
+        key: lungmen.akn/pangolin/newt/site
         property: token_secret
   secretStoreRef:
     kind: ClusterSecretStore

--- a/projects/rhodes.akn/dist/apps/pocket-id/cilium.io.v2.CiliumNetworkPolicy.allow-pocket-id-from-newt.yaml
+++ b/projects/rhodes.akn/dist/apps/pocket-id/cilium.io.v2.CiliumNetworkPolicy.allow-pocket-id-from-newt.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows Newt to route traffic to the Pocket ID application.
+  labels:
+    app.kubernetes.io/instance: pocket-id
+    app.kubernetes.io/name: pocket-id
+  name: allow-pocket-id-from-newt
+  namespace: pocket-id
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: pocket-id
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        app.kubernetes.io/name: newt
+        io.kubernetes.pod.namespace: newt-system
+    toPorts:
+    - ports:
+      - port: "1411"
+        protocol: TCP

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/apps.v1.Deployment.newt-newt-main-tunnel.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/apps.v1.Deployment.newt-newt-main-tunnel.yaml
@@ -48,7 +48,7 @@ spec:
               name: newt-credentials
         - name: LOG_LEVEL
           value: INFO
-        image: oci.chezmoi.sh/docker.io/fosrl/newt:1.15.0@sha256:d69d047c816ca7721eae90d5f3cd3be53b615b3d498678be21488d666538ee5c
+        image: oci.chezmoi.sh/docker.io/fosrl/newt:1.12.5
         imagePullPolicy: IfNotPresent
         name: newt
         ports:

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/apps.v1.Deployment.newt-newt-main-tunnel.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/apps.v1.Deployment.newt-newt-main-tunnel.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: newt
+    app.kubernetes.io/instance: newt
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: newt
+    app.kubernetes.io/version: 1.12.5
+    helm.sh/chart: newt-1.5.0
+    newt.instance: main-tunnel
+  name: newt-newt-main-tunnel
+  namespace: newt-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: newt
+      app.kubernetes.io/name: newt
+      newt.instance: main-tunnel
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: newt
+        app.kubernetes.io/instance: newt
+        app.kubernetes.io/name: newt
+        newt.instance: main-tunnel
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - env:
+        - name: PANGOLIN_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              key: PANGOLIN_ENDPOINT
+              name: newt-credentials
+        - name: NEWT_ID
+          valueFrom:
+            secretKeyRef:
+              key: NEWT_ID
+              name: newt-credentials
+        - name: NEWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: NEWT_SECRET
+              name: newt-credentials
+        - name: LOG_LEVEL
+          value: INFO
+        image: oci.chezmoi.sh/docker.io/fosrl/newt:1.12.5@sha256:3c009663332145cae39b940b07857469038d5e9d71aacb1497e78795ba4e3b9b
+        imagePullPolicy: IfNotPresent
+        name: newt
+        ports:
+        - containerPort: 51820
+          name: wg
+          protocol: UDP
+        - containerPort: 51821
+          name: tester
+          protocol: UDP
+        resources:
+          limits:
+            cpu: 200m
+            ephemeral-storage: 256Mi
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            ephemeral-storage: 128Mi
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534
+      serviceAccountName: newt-newt-sa

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/apps.v1.Deployment.newt-newt-main-tunnel.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/apps.v1.Deployment.newt-newt-main-tunnel.yaml
@@ -48,7 +48,7 @@ spec:
               name: newt-credentials
         - name: LOG_LEVEL
           value: INFO
-        image: oci.chezmoi.sh/docker.io/fosrl/newt:1.12.5@sha256:3c009663332145cae39b940b07857469038d5e9d71aacb1497e78795ba4e3b9b
+        image: oci.chezmoi.sh/docker.io/fosrl/newt:1.15.0@sha256:d69d047c816ca7721eae90d5f3cd3be53b615b3d498678be21488d666538ee5c
         imagePullPolicy: IfNotPresent
         name: newt
         ports:

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/cilium.io.v2.CiliumNetworkPolicy.allow-intra-namespace.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/cilium.io.v2.CiliumNetworkPolicy.allow-intra-namespace.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Permits intra-namespace communication in the newt-system namespace.
+      DNS is not repeated here -- the cluster-wide allow-dns
+      CiliumClusterwideNetworkPolicy already covers every namespaced pod.
+  labels:
+    app.kubernetes.io/name: newt
+  name: allow-intra-namespace
+  namespace: newt-system
+spec:
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: newt-system
+  endpointSelector: {}
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: newt-system

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/cilium.io.v2.CiliumNetworkPolicy.allow-newt-to-pangolin.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/cilium.io.v2.CiliumNetworkPolicy.allow-newt-to-pangolin.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows Newt to connect to the Pangolin API and tunnel endpoint.
+  labels:
+    app.kubernetes.io/name: newt
+  name: allow-newt-to-pangolin
+  namespace: newt-system
+spec:
+  egress:
+  - toFQDNs:
+    - matchName: pangolin.chezmoi.sh
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: TCP
+    - ports:
+      - port: "51820"
+        protocol: UDP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: newt

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/cilium.io.v2.CiliumNetworkPolicy.allow-newt-to-pocket-id.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/cilium.io.v2.CiliumNetworkPolicy.allow-newt-to-pocket-id.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows Newt to access the Pocket ID application.
+  labels:
+    app.kubernetes.io/name: newt
+  name: allow-newt-to-pocket-id
+  namespace: newt-system
+spec:
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        app.kubernetes.io/name: pocket-id
+        io.kubernetes.pod.namespace: pocket-id
+    toPorts:
+    - ports:
+      - port: "1411"
+        protocol: TCP
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: newt

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/core.v1.Service.newt-newt-main-tunnel.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/core.v1.Service.newt-newt-main-tunnel.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: newt
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: newt
+    app.kubernetes.io/version: 1.12.5
+    helm.sh/chart: newt-1.5.0
+    newt.instance: main-tunnel
+  name: newt-newt-main-tunnel
+  namespace: newt-system
+spec:
+  ports:
+  - name: wg
+    port: 51820
+    protocol: UDP
+    targetPort: 51820
+  selector:
+    app.kubernetes.io/instance: newt
+    app.kubernetes.io/name: newt
+    newt.instance: main-tunnel
+  type: ClusterIP

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/core.v1.ServiceAccount.newt-newt-sa.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/core.v1.ServiceAccount.newt-newt-sa.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: newt
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: newt
+    app.kubernetes.io/version: 1.12.5
+    helm.sh/chart: newt-1.5.0
+  name: newt-newt-sa
+  namespace: newt-system

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/external-secrets.io.v1.ExternalSecret.newt-credentials.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/external-secrets.io.v1.ExternalSecret.newt-credentials.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  labels:
+    app.kubernetes.io/name: newt
+  name: newt-credentials
+  namespace: newt-system
+spec:
+  data:
+  - remoteRef:
+      key: rhodes.akn/pangolin/newt/site
+      property: endpoint
+    secretKey: endpoint
+  - remoteRef:
+      key: rhodes.akn/pangolin/newt/site
+      property: token_id
+    secretKey: token_id
+  - remoteRef:
+      key: rhodes.akn/pangolin/newt/site
+      property: token_secret
+    secretKey: token_secret
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  target:
+    name: newt-credentials
+    template:
+      data:
+        NEWT_ID: '{{ .token_id }}'
+        NEWT_SECRET: '{{ .token_secret }}'
+        PANGOLIN_ENDPOINT: '{{ .endpoint }}'
+      engineVersion: v2

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/externaldns.k8s.io.v1alpha1.DNSEndpoint.pangolin-chezmoi-sh.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/newt/externaldns.k8s.io.v1alpha1.DNSEndpoint.pangolin-chezmoi-sh.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  labels:
+    app.kubernetes.io/name: newt
+  name: pangolin-chezmoi-sh
+  namespace: newt-system
+spec:
+  endpoints:
+  - dnsName: pangolin.chezmoi.sh
+    recordTTL: 300
+    recordType: A
+    targets:
+    - 145.241.173.236

--- a/projects/rhodes.akn/src/apps/pocket-id/security/kustomization.yaml
+++ b/projects/rhodes.akn/src/apps/pocket-id/security/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - network-policy.allow-intra-namespace.yaml
   - network-policy.allow-from-ingress-gateway.yaml
+  - network-policy.allow-pocket-id-from-newt.yaml
   - network-policy.allow-to-analytics.yaml
   - network-policy.allow-to-internet.yaml
   - network-policy.allow-postgres-to-s3-backup.yaml

--- a/projects/rhodes.akn/src/apps/pocket-id/security/network-policy.allow-pocket-id-from-newt.yaml
+++ b/projects/rhodes.akn/src/apps/pocket-id/security/network-policy.allow-pocket-id-from-newt.yaml
@@ -1,0 +1,20 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows Newt to route traffic to the Pocket ID application.
+  name: allow-pocket-id-from-newt
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: pocket-id
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: newt-system
+            app.kubernetes.io/name: newt
+      toPorts:
+        - ports:
+            - port: "1411"
+              protocol: TCP

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/newt/kustomization.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/newt/kustomization.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: newt-system
+
+resources:
+  - newt.externalsecret.yaml
+
+  # Include security policies
+  - security/
+
+helmCharts:
+  - repo: https://charts.fossorial.io
+    name: newt
+    version: 1.5.0
+
+    releaseName: newt
+    namespace: newt-system
+
+    valuesInline:
+      newtInstances:
+        - name: "main-tunnel"
+          auth:
+            existingSecretName: "newt-credentials"
+            keys:
+              endpointKey: "PANGOLIN_ENDPOINT"
+              idKey: "NEWT_ID"
+              secretKey: "NEWT_SECRET"
+          enabled: true
+
+# kustomize's namespace transformer does not post-process helmCharts resources.
+# The newt Deployment template does not call {{ .Release.Namespace }}, so the
+# namespace field is absent in the rendered output. This patch injects it.
+patches:
+  - patch: |
+      - op: add
+        path: /metadata/namespace
+        value: newt-system
+    target:
+      kind: Deployment
+      name: newt-newt-main-tunnel
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: newt
+    includeTemplates: true
+    includeSelectors: true
+
+images:
+  # renovate: datasource=docker depName=docker.io/fosrl/newt
+  - name: docker.io/fosrl/newt
+    newName: oci.chezmoi.sh/docker.io/fosrl/newt
+    newTag: 1.12.5@sha256:3c009663332145cae39b940b07857469038d5e9d71aacb1497e78795ba4e3b9b

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/newt/kustomization.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/newt/kustomization.yaml
@@ -51,4 +51,4 @@ images:
   # renovate: datasource=docker depName=docker.io/fosrl/newt
   - name: docker.io/fosrl/newt
     newName: oci.chezmoi.sh/docker.io/fosrl/newt
-    newTag: 1.12.5@sha256:3c009663332145cae39b940b07857469038d5e9d71aacb1497e78795ba4e3b9b
+    newTag: 1.15.0@sha256:d69d047c816ca7721eae90d5f3cd3be53b615b3d498678be21488d666538ee5c

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/newt/kustomization.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/newt/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: newt-system
 
 resources:
   - newt.externalsecret.yaml
+  - newt.dnsendpoint.yaml
 
   # Include security policies
   - security/

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/newt/kustomization.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/newt/kustomization.yaml
@@ -48,7 +48,5 @@ labels:
     includeSelectors: true
 
 images:
-  # renovate: datasource=docker depName=docker.io/fosrl/newt
   - name: docker.io/fosrl/newt
     newName: oci.chezmoi.sh/docker.io/fosrl/newt
-    newTag: 1.15.0@sha256:d69d047c816ca7721eae90d5f3cd3be53b615b3d498678be21488d666538ee5c

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/newt/newt.dnsendpoint.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/newt/newt.dnsendpoint.yaml
@@ -1,0 +1,18 @@
+# talosnet-dns (BIND) is authoritative for chezmoi.sh and does not recurse
+# out to public DNS, so pangolin.chezmoi.sh -- a public-only record living in
+# Cloudflare's zone, resolved by Pangolin's kazimierz.akn VPS -- comes back
+# NXDOMAIN from inside this cluster. This DNSEndpoint adds that one record to
+# the internal zone so Newt can resolve it. Target matches the same
+# instance.publicIp Cloudflare A record content set in
+# projects/kazimierz.akn/src/infrastructure/pulumi/stack/oci/dns.ts.
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: pangolin-chezmoi-sh
+spec:
+  endpoints:
+    - dnsName: pangolin.chezmoi.sh
+      recordType: A
+      recordTTL: 300
+      targets:
+        - "145.241.173.236"

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/newt/newt.externalsecret.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/newt/newt.externalsecret.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: newt-credentials
+spec:
+  refreshInterval: 1h
+  data:
+    - secretKey: endpoint
+      remoteRef:
+        key: rhodes.akn/pangolin/newt/site
+        property: endpoint
+    - secretKey: token_id
+      remoteRef:
+        key: rhodes.akn/pangolin/newt/site
+        property: token_id
+    - secretKey: token_secret
+      remoteRef:
+        key: rhodes.akn/pangolin/newt/site
+        property: token_secret
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  target:
+    name: newt-credentials
+    template:
+      engineVersion: v2
+      data:
+        PANGOLIN_ENDPOINT: "{{ .endpoint }}"
+        NEWT_ID: "{{ .token_id }}"
+        NEWT_SECRET: "{{ .token_secret }}"

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/newt/security/kustomization.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/newt/security/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: newt-system
+
+resources:
+  - network-policy.allow-intra-namespace.yaml
+  - network-policy.allow-newt-to-pangolin.yaml
+  - network-policy.allow-newt-to-pocket-id.yaml

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/newt/security/network-policy.allow-intra-namespace.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/newt/security/network-policy.allow-intra-namespace.yaml
@@ -1,0 +1,20 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Permits intra-namespace communication in the newt-system namespace.
+      DNS is not repeated here -- the cluster-wide allow-dns
+      CiliumClusterwideNetworkPolicy already covers every namespaced pod.
+  name: allow-intra-namespace
+  namespace: newt-system
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: newt-system
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: newt-system

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/newt/security/network-policy.allow-newt-to-pangolin.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/newt/security/network-policy.allow-newt-to-pangolin.yaml
@@ -1,0 +1,22 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows Newt to connect to the Pangolin API and tunnel endpoint.
+  name: allow-newt-to-pangolin
+  namespace: newt-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: newt
+  egress:
+    - toFQDNs:
+        - matchName: "pangolin.chezmoi.sh"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+        - ports:
+            - port: "51820"
+              protocol: UDP

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/newt/security/network-policy.allow-newt-to-pocket-id.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/newt/security/network-policy.allow-newt-to-pocket-id.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows Newt to access the Pocket ID application.
+  name: allow-newt-to-pocket-id
+  namespace: newt-system
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: newt
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: pocket-id
+            app.kubernetes.io/name: pocket-id
+      toPorts:
+        - ports:
+            - port: "1411"
+              protocol: TCP


### PR DESCRIPTION
## Summary

Follow-up to #1179: installs the Newt tunnel client on rhodes.akn so it can
register with the Pangolin site provisioned there, and fixes lungmen.akn's
Newt ExternalSecret which was still pointing at the pre-move Vault path.
Also adds the internal DNS record Newt needs to resolve Pangolin from inside
the rhodes.akn cluster.

## Changes Made

### lungmen.akn — fix stale Vault secret path

- **[`newt.externalsecret.yaml`](projects/lungmen.akn/src/infrastructure/kubernetes/newt/newt.externalsecret.yaml)** — points `remoteRef.key` at `lungmen.akn/pangolin/newt/site` (the project-mount path) instead of the old `shared/third-parties/pangolin/newt/lungmen.akn`

### rhodes.akn — install Newt, scoped to Pocket-Id only

- **[`newt/kustomization.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/newt/kustomization.yaml)** — deploys the `fossorial/newt` chart (mirrors lungmen.akn's setup)
- **[`newt.externalsecret.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/newt/newt.externalsecret.yaml)** — Newt credentials from `rhodes.akn/pangolin/newt/site`
- **[`security/network-policy.allow-newt-to-pocket-id.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/newt/security/network-policy.allow-newt-to-pocket-id.yaml)** / **[`network-policy.default-hardened.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/newt/security/network-policy.default-hardened.yaml)** / **[`network-policy.allow-newt-to-pangolin.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/newt/security/network-policy.allow-newt-to-pangolin.yaml)** — deny-by-default egress, Newt can only reach Pocket-Id (port 1411) and the Pangolin endpoint
- **[`apps/pocket-id/security/network-policy.allow-pocket-id-from-newt.yaml`](projects/rhodes.akn/src/apps/pocket-id/security/network-policy.allow-pocket-id-from-newt.yaml)** — matching ingress allow on the Pocket-Id side

### rhodes.akn — internal DNS record for Pangolin

- **[`newt.dnsendpoint.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/newt/newt.dnsendpoint.yaml)** — talosnet-dns (BIND) is authoritative for `chezmoi.sh` and doesn't recurse to public DNS, so `pangolin.chezmoi.sh` (a public-only Cloudflare record, resolved by kazimierz.akn) came back NXDOMAIN from inside rhodes.akn. This `DNSEndpoint` adds that one record via ExternalDNS's CRD source.

## Technical Impact

### Infrastructure Components

Newt (`fosrl/newt:1.12.5`, latest published release) runs as a single-tunnel
Deployment in a new `newt-system` namespace on rhodes.akn, identical in
shape to the existing lungmen.akn instance.

### Security Implementation

Deny-by-default `newt-system` namespace; Newt's egress is limited to DNS,
the Pangolin endpoint, and Pocket-Id on port 1411 — nothing else. Pocket-Id's
own namespace gets a matching narrow ingress allow from Newt specifically
(not a broad `newt-system` allow). Credentials come from OpenBao via
ExternalSecrets, same pattern as every other app in this repo.

### External Access Points

No new public hostname — Pocket-Id was already exposed via Pangolin
(`auth.chezmoi.sh`) in #1179; this PR makes the actual tunnel work.

### Integration Points

Newt connects to the existing kazimierz.akn Pangolin site over the tunnel
ports already opened in that VPS's NSG. The DNS record integrates with
rhodes.akn's existing ExternalDNS/BIND (`rfc2136`) setup — no new provider.

## Testing Validation

- [x] `dist:render` succeeds for both projects, no manual dist edits
- [x] lungmen.akn: ExternalSecret `newt-credentials` reports `SecretSynced`, pod reconnected cleanly after restart
- [x] rhodes.akn: ExternalSecret `newt-credentials` reports `SecretSynced`, Newt pod logs show `Tunnel connection to server established successfully!` and `Started tcp proxy to pocket-id.pocket-id.svc.cluster.local:80`
- [x] `pangolin.chezmoi.sh` resolves correctly from inside rhodes.akn after the DNSEndpoint synced (verified via a throwaway debug pod)
- [x] `https://auth.chezmoi.sh/` returns `200` end-to-end through the new tunnel
- [x] Vault secrets moved to their project-mount paths via `pulumi up --target` scoped to just the `*-newt-vault-secret` resource on both `lungmen.akn` and `rhodes.akn` pangolin stacks (no unrelated drift touched)

## Related Issues

Related to #1179

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
