### PR TITLE
Fix inverted Pocket-Id OIDC client logo light/dark URLs

### DIFF
--- a/projects/kazimierz.akn/src/infrastructure/pulumi/stack/pocket-id/pangolin.ts
+++ b/projects/kazimierz.akn/src/infrastructure/pulumi/stack/pocket-id/pangolin.ts
@@ -20,9 +20,9 @@ export const pangolinOidcClient = new pocketid.oidc.OidcClients(
 		name: "Pangolin",
 		description: "Tunnel / reverse-proxy d'accès public",
 		logoUrl:
-			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/pangolin-light.svg",
-		darkLogoUrl:
 			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/pangolin-dark.svg",
+		darkLogoUrl:
+			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/pangolin-light.svg",
 		launchURL: "https://pangolin.chezmoi.sh/",
 		callbackURLs: ["https://pangolin.chezmoi.sh/auth/idp/2/oidc/callback"], // TODO: use idp callback value to configure it
 		isGroupRestricted: true,

--- a/projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/actual-budget.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/actual-budget.ts
@@ -20,9 +20,9 @@ export const actualBudgetOidcClient = new pocketid.oidc.OidcClients(
 		name: "Gestion du budget",
 		description: "Suivi du budget",
 		logoUrl:
-			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/actual-budget-light.svg",
-		darkLogoUrl:
 			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/actual-budget-dark.svg",
+		darkLogoUrl:
+			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/actual-budget-light.svg",
 		launchURL: "https://budget.chezmoi.sh",
 		callbackURLs: ["https://budget.chezmoi.sh/openid/callback"],
 		isGroupRestricted: true,

--- a/projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/forgejo.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/forgejo.ts
@@ -17,9 +17,9 @@ export const forgejoOidcClient = new pocketid.oidc.OidcClients(
 		name: "Forgejo",
 		description: "Hébergement Git",
 		logoUrl:
-			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/forgejo-light.svg",
-		darkLogoUrl:
 			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/forgejo-dark.svg",
+		darkLogoUrl:
+			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/forgejo-light.svg",
 		launchURL: "https://git.chezmoi.sh",
 		callbackURLs: [
 			"https://git.chezmoi.sh/user/oauth2/auth.chezmoi.sh/callback",

--- a/projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/immich.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/immich.ts
@@ -17,9 +17,9 @@ export const immichOidcClient = new pocketid.oidc.OidcClients(
 		name: "Photos",
 		description: "Sauvegarde et partage de photos/vidéos",
 		logoUrl:
-			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/immich-light.svg",
-		darkLogoUrl:
 			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/immich-dark.svg",
+		darkLogoUrl:
+			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/immich-light.svg",
 		launchURL: "https://photos.chezmoi.sh",
 		callbackURLs: [
 			"app.immich:///oauth-callback",

--- a/projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/jellyfin.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/jellyfin.ts
@@ -13,9 +13,9 @@ export const jellyfinOidcClient = new pocketid.oidc.OidcClients(
 		name: "Streaming",
 		description: "Films, séries et musique",
 		logoUrl:
-			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/jellyfin-light.svg",
-		darkLogoUrl:
 			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/jellyfin-dark.svg",
+		darkLogoUrl:
+			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/jellyfin-light.svg",
 		launchURL: "https://streaming.chezmoi.sh/sso/OID/start/pocket-id",
 		callbackURLs: ["https://streaming.chezmoi.sh/sso/OID/redirect/pocket-id"],
 		isGroupRestricted: true,

--- a/projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/linkding.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/linkding.ts
@@ -20,9 +20,9 @@ export const linkdingOidcClient = new pocketid.oidc.OidcClients(
 		name: "Bookmarks",
 		description: "Gestionnaire de favoris",
 		logoUrl:
-			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/linkding-light.svg",
-		darkLogoUrl:
 			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/linkding-dark.svg",
+		darkLogoUrl:
+			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/linkding-light.svg",
 		launchURL: "https://bookmarks.chezmoi.sh",
 		callbackURLs: ["https://bookmarks.chezmoi.sh/oidc/callback/"],
 		isGroupRestricted: true,

--- a/projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/paperless-ngx.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/paperless-ngx.ts
@@ -20,9 +20,9 @@ export const paperlessNgxOidcClient = new pocketid.oidc.OidcClients(
 		name: "Archives",
 		description: "Archivage et gestion de documents",
 		logoUrl:
-			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/paperless-ngx-light.svg",
-		darkLogoUrl:
 			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/paperless-ngx-dark.svg",
+		darkLogoUrl:
+			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/paperless-ngx-light.svg",
 		launchURL: "https://paperless.chezmoi.sh",
 		callbackURLs: [
 			"https://paperless.chezmoi.sh/accounts/oidc/pocket-id/login/callback/",

--- a/projects/rhodes.akn/src/infrastructure/pulumi/stack/pocket-id/argocd-cli.ts
+++ b/projects/rhodes.akn/src/infrastructure/pulumi/stack/pocket-id/argocd-cli.ts
@@ -13,9 +13,9 @@ export const argocdCliOidcClient = new pocketid.oidc.OidcClients(
 		name: "ArgoCD (CLI)",
 		description: "Déploiement continu (GitOps) — CLI",
 		logoUrl:
-			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/argo-cd-light.svg",
-		darkLogoUrl:
 			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/argo-cd-dark.svg",
+		darkLogoUrl:
+			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/argo-cd-light.svg",
 		callbackURLs: ["http://localhost:8085/auth/callback"],
 		isGroupRestricted: true,
 		isPublic: true,

--- a/projects/rhodes.akn/src/infrastructure/pulumi/stack/pocket-id/argocd.ts
+++ b/projects/rhodes.akn/src/infrastructure/pulumi/stack/pocket-id/argocd.ts
@@ -21,9 +21,9 @@ export const argocdOidcClient = new pocketid.oidc.OidcClients(
 		name: "ArgoCD",
 		description: "Déploiement continu (GitOps)",
 		logoUrl:
-			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/argo-cd-light.svg",
-		darkLogoUrl:
 			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/argo-cd-dark.svg",
+		darkLogoUrl:
+			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/argo-cd-light.svg",
 		launchURL: "https://argocd.akn.chezmoi.sh/",
 		callbackURLs: ["https://argocd.akn.chezmoi.sh/auth/callback"],
 		isGroupRestricted: true,

--- a/projects/rhodes.akn/src/infrastructure/pulumi/stack/pocket-id/vault.ts
+++ b/projects/rhodes.akn/src/infrastructure/pulumi/stack/pocket-id/vault.ts
@@ -14,9 +14,9 @@ export const vaultOidcClient = new pocketid.oidc.OidcClients(
 		// "Vault" for protocol/UI-compat reasons, so use OpenBao's icon, not a
 		// nonexistent "vault" one.
 		logoUrl:
-			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/openbao-light.svg",
-		darkLogoUrl:
 			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/openbao-dark.svg",
+		darkLogoUrl:
+			"https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/openbao-light.svg",
 		launchURL: "https://vault.chezmoi.sh/ui/vault/auth?with=pocket-id%2F",
 		callbackURLs: [
 			"https://vault.chezmoi.sh/ui/vault/auth/pocket-id/oidc/callback",


### PR DESCRIPTION
## Summary

Every Pocket-Id OIDC client definition in this repo had `logoUrl`/`darkLogoUrl` swapped: selfhst's `-light.svg` icon
variant (white-filled, meant for **dark** backgrounds) was assigned to `logoUrl` (Pocket-Id's light-mode slot), and
the black `-dark.svg` variant was assigned to `darkLogoUrl` (dark-mode slot) — the opposite of what the filename
suffix suggests at a glance. This made the icons invisible (white-on-white) or barely visible in the Pocket-Id
login/app-picker in both themes.

**Related Issue:** #1178

## Root Cause

Confirmed against the actual selfhst assets: `jellyfin-light.svg` has `style="fill:#fff"` (white icon, needs a dark
background to be visible), while `jellyfin-dark.svg` has no fill override (default black, needs a light background).
Every one of the 10 OIDC client definitions in this repo assigned these backwards.

## Fix

Swapped `logoUrl` → `*-dark.svg` (black, for light backgrounds) and `darkLogoUrl` → `*-light.svg` (white, for dark
backgrounds) in all 10 affected files:

- [`projects/kazimierz.akn/.../pocket-id/pangolin.ts`](projects/kazimierz.akn/src/infrastructure/pulumi/stack/pocket-id/pangolin.ts)
- [`projects/lungmen.akn/.../pocket-id/jellyfin.ts`](projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/jellyfin.ts)
- [`projects/lungmen.akn/.../pocket-id/immich.ts`](projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/immich.ts)
- [`projects/lungmen.akn/.../pocket-id/linkding.ts`](projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/linkding.ts)
- [`projects/lungmen.akn/.../pocket-id/paperless-ngx.ts`](projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/paperless-ngx.ts)
- [`projects/lungmen.akn/.../pocket-id/actual-budget.ts`](projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/actual-budget.ts)
- [`projects/lungmen.akn/.../pocket-id/forgejo.ts`](projects/lungmen.akn/src/infrastructure/pulumi/stack/pocket-id/forgejo.ts)
- [`projects/rhodes.akn/.../pocket-id/argocd.ts`](projects/rhodes.akn/src/infrastructure/pulumi/stack/pocket-id/argocd.ts)
- [`projects/rhodes.akn/.../pocket-id/argocd-cli.ts`](projects/rhodes.akn/src/infrastructure/pulumi/stack/pocket-id/argocd-cli.ts)
- [`projects/rhodes.akn/.../pocket-id/vault.ts`](projects/rhodes.akn/src/infrastructure/pulumi/stack/pocket-id/vault.ts)

### Decision on the colored "standard" icon variant

The issue also raised whether `logoUrl` should switch to selfhst's unsuffixed colored icon (e.g. `jellyfin.svg`)
instead of the flat black `-dark.svg`. **Decision: keep the monochrome variant.** All 10 clients stay visually
consistent with each other in the light-mode login page; introducing colored icons would make some tiles stand out
arbitrarily depending on whether a "standard" variant happens to exist for that app. This can be revisited later as
a separate, deliberate design change if wanted.

## Technical Impact

### Behavioural Changes

Pocket-Id will render the correct icon for the active browser theme instead of an invisible or barely-visible one.
No functional/auth behavior changes — this only touches display metadata (`logoUrl`/`darkLogoUrl`), both fields are
already in `ignoreChanges` so Pulumi will still need `pulumi up` (or manual sync) to apply since remote drift is
ignored by design.

### Regression Risk

Low — this is a metadata-only swap of two URL strings per client, verified 1:1 against the pre-existing content via
diff. No resource replacement, no schema change.

### Observability

Visual only: verify in a browser against `auth.chezmoi.sh` in both light and dark theme once deployed.

## Testing Validation

- [ ] `pulumi up` applied (or `ignoreChanges` manually overridden) on kazimierz.akn, lungmen.akn, and rhodes.akn
      pocket-id stacks
- [ ] Pocket-Id login/app-picker icons render correctly in light browser theme
- [ ] Pocket-Id login/app-picker icons render correctly in dark browser theme

**Not verified from this session** (no cluster/Pocket-Id access available) — flagging as a manual follow-up for
@xunleii before merge or right after deploy.

## Related Issues

Closes #1178

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>

