### PR TITLE
Make Omni cluster templates fail loudly on missing/out-of-range CIDRs

### DIFF
--- a/.github/workflows/push,pull_request.omni-template-lint.yaml
+++ b/.github/workflows/push,pull_request.omni-template-lint.yaml
@@ -1,0 +1,42 @@
+---
+name: 🧪 Omni Cluster Template CIDR Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/push,pull_request.omni-template-lint.yaml"
+      - "scripts/omni:template:lint"
+      - "projects/*/src/infrastructure/omni/**"
+
+  pull_request:
+    paths:
+      - ".github/workflows/push,pull_request.omni-template-lint.yaml"
+      - "scripts/omni:template:lint"
+      - "projects/*/src/infrastructure/omni/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: 🔍 Check ADR-014 CIDR compliance
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: 🛠️ Set up mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install: false
+
+      - name: ⬇️ Install yq
+        run: mise install yq
+
+      - name: 🔍 Lint Omni cluster templates
+        run: scripts/omni:template:lint

--- a/catalog/omni/clustertemplates/base.yaml
+++ b/catalog/omni/clustertemplates/base.yaml
@@ -50,11 +50,17 @@
 # 3. Document overrides in the cluster template header (see lungmen as example).
 # 4. Validate offline (no Omni connectivity):
 #      omnictl cluster template validate -f <file>
+#    NOTE: this base file itself is NOT expected to pass validate — the
+#    podSubnets sentinel below is deliberately not a valid CIDR. Validate only
+#    the cloned, overridden copy.
 # 5. Apply (requires OMNICONFIG from `mise run bao:login:admin` in chezmoi.sh):
 #      omnictl cluster template sync -f <file>
 #    Re-applying is idempotent. `omnictl apply -f` does NOT work here — it's the generic COSI resource
 #    command (metadata/spec YAML), not the kind:Cluster/ControlPlane/Workers template DSL, and fails with
 #    "yaml: construct errors: ... expected 4 elements node, got N".
+# 6. `scripts/omni:template:lint` checks every per-cluster template's
+#    podSubnets/serviceSubnets/clusterDNS fall within ADR-014's 172.16.0.0/12
+#    range; it runs in CI on any change under projects/*/src/infrastructure/omni/.
 #
 # SHA PINNING
 # -----------
@@ -65,6 +71,7 @@
 #   ADR-014                    docs/decisions/014-network-topology.md
 #   VLAN / SDN layout          docs/network/ipam.md
 #   Machine class definitions  catalog/omni/machineclasses/
+#   CIDR lint script           scripts/omni:template:lint
 # =============================================================================
 ---
 kind: Cluster
@@ -127,10 +134,14 @@ patches:
               - https://raw.githubusercontent.com/chezmoidotsh/arcane/9a58e751d48be11bc7e67f3f2a6bf676973ea440/catalog/talos/manifests/cilium/1.20.0-native.yaml
           podSubnets:
             # MANDATORY OVERRIDE — unique per cluster (ClusterMesh hard prerequisite).
-            # Uncomment ONE line and set it to the cluster's allocated /19 from ipam.md.
-            # A forgotten override makes Talos fall back to its built-in CIDR (NOT in our
-            # 172.30.0.0/16 range) — this is intentional: fail-safe, not silent collision.
-            # - 172.30.0.0/19   # rhodes-akn   (cluster.id 1)
+            # Replace the sentinel below with ONE of the /19s from ipam.md. The
+            # sentinel is not a valid CIDR on purpose: a forgotten override fails
+            # `omnictl cluster template validate` loudly instead of silently
+            # falling back to Talos's built-in CIDR (NOT in our 172.16.0.0/12
+            # range — ADR-014). `scripts/omni:template:lint` also enforces this
+            # field (and serviceSubnets/clusterDNS) on every per-cluster template.
+            - MUST-OVERRIDE-SEE-IPAM.MD # not a CIDR — validate fails until replaced
+            # - 172.30.0.0/19   # rhodes-akn   (cluster.id 1) — ALREADY IN USE
             # - 172.30.32.0/19  # lungmen-akn  (cluster.id 2) — ALREADY IN USE
             # - 172.30.64.0/19  # cluster 3    (cluster.id 3)
             # - 172.30.96.0/19  # cluster 4    (cluster.id 4)

--- a/scripts/omni:template:lint
+++ b/scripts/omni:template:lint
@@ -30,39 +30,54 @@ fi
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 FAILURES=0
 
-# True when every octet is a valid 0-255 decimal (no leading-zero games,
-# rejects things like "999" or "172.16.0.0.1").
+# Octet/prefix pattern: "0" or a non-zero-leading 1-3 digit run. Rejects
+# leading zeros ("016") so no value here ever reaches bash arithmetic in a
+# form it would misparse as octal.
+readonly _OCTET_RE='(0|[1-9][0-9]{0,2})'
+
+# True when every octet is a valid 0-255 decimal, no leading zeros.
 valid_ipv4() {
   local ip="$1" o1 o2 o3 o4
-  [[ ${ip} =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]] || return 1
+  [[ ${ip} =~ ^${_OCTET_RE}\.${_OCTET_RE}\.${_OCTET_RE}\.${_OCTET_RE}$ ]] || return 1
   o1=${BASH_REMATCH[1]} o2=${BASH_REMATCH[2]} o3=${BASH_REMATCH[3]} o4=${BASH_REMATCH[4]}
-  ((o1 <= 255 && o2 <= 255 && o3 <= 255 && o4 <= 255))
+  ((10#${o1} <= 255 && 10#${o2} <= 255 && 10#${o3} <= 255 && 10#${o4} <= 255))
 }
 
 # ADR-014: every Talos/Omni CIDR must live inside 172.16.0.0/12. Validates
 # the full IPv4 (all four octets) and, if a CIDR prefix is present, that it
-# is 0-32 — not just the two octets the range check itself inspects.
+# is a non-empty 0-32 value — not just the two octets the range check
+# itself inspects, and not a bare trailing "/" with nothing after it.
 in_adr014_range() {
   local value="$1" ip="${1%%/*}" prefix=""
-  [[ ${value} == *"/"* ]] && prefix="${value#*/}"
 
   valid_ipv4 "${ip}" || return 1
-  if [[ -n ${prefix} ]]; then
-    [[ ${prefix} =~ ^[0-9]{1,2}$ ]] || return 1
-    ((prefix <= 32)) || return 1
+  if [[ ${value} == *"/"* ]]; then
+    prefix="${value#*/}"
+    [[ ${prefix} =~ ^${_OCTET_RE}$ ]] || return 1
+    ((10#${prefix} <= 32)) || return 1
   fi
 
   local o1 rest o2
   o1=${ip%%.*}
   rest=${ip#*.}
   o2=${rest%%.*}
-  [[ ${o1} == "172" ]] && ((o2 >= 16 && o2 <= 31))
+  [[ ${o1} == "172" ]] && ((10#${o2} >= 16 && 10#${o2} <= 31))
 }
 
 check_field() {
   local file="$1" label="$2" query="$3"
-  local values
-  values="$(yq eval-all "${query}" "${file}" 2>/dev/null)"
+  local values yq_error yq_status
+  yq_error="$(mktemp)"
+  values="$(yq eval-all "${query}" "${file}" 2>"${yq_error}")"
+  yq_status=$?
+
+  if ((yq_status != 0)); then
+    echo "ERROR ${file}: ${label} query failed: $(<"${yq_error}")"
+    FAILURES=$((FAILURES + 1))
+    rm -f "${yq_error}"
+    return
+  fi
+  rm -f "${yq_error}"
 
   if [[ -z ${values} ]]; then
     echo "FAIL ${file}: ${label} is missing or empty"

--- a/scripts/omni:template:lint
+++ b/scripts/omni:template:lint
@@ -48,8 +48,12 @@ valid_ipv4() {
 
 # ADR-014: every Talos/Omni CIDR must live inside 172.16.0.0/12. Validates
 # the full IPv4 (all four octets) and, if a CIDR prefix is present, that it
-# is a non-empty 0-32 value — not just the two octets the range check
-# itself inspects, and not a bare trailing "/" with nothing after it.
+# is a non-empty 12-32 value — not just the two octets the range check
+# itself inspects, and not a bare trailing "/" with nothing after it. A
+# prefix shorter than /12 must be rejected even if the base address happens
+# to fall in range: the base address landing in 172.16.0.0/12 only proves a
+# single point is in range, not that the whole (wider) block is contained
+# within it — e.g. 172.16.0.0/1 covers half the entire IPv4 space.
 in_adr014_range() {
   local value="$1" ip="${1%%/*}" prefix=""
 
@@ -57,7 +61,7 @@ in_adr014_range() {
   if [[ ${value} == *"/"* ]]; then
     prefix="${value#*/}"
     [[ ${prefix} =~ ^${_OCTET_RE}$ ]] || return 1
-    ((10#${prefix} <= 32)) || return 1
+    ((10#${prefix} >= 12 && 10#${prefix} <= 32)) || return 1
   fi
 
   local o1 rest o2

--- a/scripts/omni:template:lint
+++ b/scripts/omni:template:lint
@@ -30,11 +30,32 @@ fi
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 FAILURES=0
 
-# ADR-014: every Talos/Omni CIDR must live inside 172.16.0.0/12.
+# True when every octet is a valid 0-255 decimal (no leading-zero games,
+# rejects things like "999" or "172.16.0.0.1").
+valid_ipv4() {
+  local ip="$1" o1 o2 o3 o4
+  [[ ${ip} =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]] || return 1
+  o1=${BASH_REMATCH[1]} o2=${BASH_REMATCH[2]} o3=${BASH_REMATCH[3]} o4=${BASH_REMATCH[4]}
+  ((o1 <= 255 && o2 <= 255 && o3 <= 255 && o4 <= 255))
+}
+
+# ADR-014: every Talos/Omni CIDR must live inside 172.16.0.0/12. Validates
+# the full IPv4 (all four octets) and, if a CIDR prefix is present, that it
+# is 0-32 — not just the two octets the range check itself inspects.
 in_adr014_range() {
-  local ip="${1%%/*}"
-  [[ ${ip} =~ ^([0-9]{1,3})\.([0-9]{1,3})\.[0-9]{1,3}\.[0-9]{1,3}$ ]] || return 1
-  local o1=${BASH_REMATCH[1]} o2=${BASH_REMATCH[2]}
+  local value="$1" ip="${1%%/*}" prefix=""
+  [[ ${value} == *"/"* ]] && prefix="${value#*/}"
+
+  valid_ipv4 "${ip}" || return 1
+  if [[ -n ${prefix} ]]; then
+    [[ ${prefix} =~ ^[0-9]{1,2}$ ]] || return 1
+    ((prefix <= 32)) || return 1
+  fi
+
+  local o1 rest o2
+  o1=${ip%%.*}
+  rest=${ip#*.}
+  o2=${rest%%.*}
   [[ ${o1} == "172" ]] && ((o2 >= 16 && o2 <= 31))
 }
 

--- a/scripts/omni:template:lint
+++ b/scripts/omni:template:lint
@@ -27,7 +27,10 @@ if ! command -v yq >/dev/null 2>&1; then
   exit 1
 fi
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+if ! REPO_ROOT="$(git rev-parse --show-toplevel)"; then
+  echo >&2 "Error: not inside a git checkout (git rev-parse --show-toplevel failed)."
+  exit 1
+fi
 FAILURES=0
 
 # Octet/prefix pattern: "0" or a non-zero-leading 1-3 digit run. Rejects
@@ -65,7 +68,9 @@ in_adr014_range() {
 }
 
 check_field() {
-  local file="$1" label="$2" query="$3"
+  # kind: "cidr" (podSubnets/serviceSubnets — must carry a /prefix) or
+  # "ip" (clusterDNS — a bare address, no /prefix).
+  local file="$1" label="$2" query="$3" kind="$4"
   local values yq_error yq_status
   yq_error="$(mktemp)"
   values="$(yq eval-all "${query}" "${file}" 2>"${yq_error}")"
@@ -88,6 +93,18 @@ check_field() {
   local value
   while IFS= read -r value; do
     [[ -z ${value} ]] && continue
+
+    if [[ ${kind} == "cidr" && ${value} != *"/"* ]]; then
+      echo "FAIL ${file}: ${label} value '${value}' is missing a /prefix (must be CIDR notation)"
+      FAILURES=$((FAILURES + 1))
+      continue
+    fi
+    if [[ ${kind} == "ip" && ${value} == *"/"* ]]; then
+      echo "FAIL ${file}: ${label} value '${value}' must be a bare IP, not a CIDR"
+      FAILURES=$((FAILURES + 1))
+      continue
+    fi
+
     if ! in_adr014_range "${value}"; then
       echo "FAIL ${file}: ${label} value '${value}' is outside ADR-014's 172.16.0.0/12 range"
       FAILURES=$((FAILURES + 1))
@@ -97,11 +114,14 @@ check_field() {
 
 while IFS= read -r -d '' file; do
   check_field "${file}" "cluster.network.podSubnets" \
-    'select(.kind == "Cluster") | .patches[] | select(.name == "cluster-common") | .inline.cluster.network.podSubnets[]'
+    'select(.kind == "Cluster") | .patches[] | select(.name == "cluster-common") | .inline.cluster.network.podSubnets[]' \
+    "cidr"
   check_field "${file}" "cluster.network.serviceSubnets" \
-    'select(.kind == "Cluster") | .patches[] | select(.name == "cluster-common") | .inline.cluster.network.serviceSubnets[]'
+    'select(.kind == "Cluster") | .patches[] | select(.name == "cluster-common") | .inline.cluster.network.serviceSubnets[]' \
+    "cidr"
   check_field "${file}" "machine.kubelet.clusterDNS" \
-    'select(.kind == "Cluster") | .patches[] | select(.name == "machine-common") | .inline.machine.kubelet.clusterDNS[]'
+    'select(.kind == "Cluster") | .patches[] | select(.name == "machine-common") | .inline.machine.kubelet.clusterDNS[]' \
+    "ip"
 done < <(find "${REPO_ROOT}/projects" -path "*/src/infrastructure/omni/*.clustertemplate.yaml" -print0 || true)
 
 if ((FAILURES > 0)); then

--- a/scripts/omni:template:lint
+++ b/scripts/omni:template:lint
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Alexandre Nicolaie (xunleii@users.noreply.github.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+# mise alias="omni:template:lint"
+# mise description="Check that Omni cluster templates use ADR-014-compliant CIDRs."
+#
+# The reference base (catalog/omni/clustertemplates/base.yaml) is intentionally
+# excluded — it is never applied directly and ships a sentinel podSubnets value
+# on purpose. Only cloned per-cluster templates are checked.
+set -o nounset
+set -o pipefail
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo >&2 "Error: yq is required (mise install)."
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+FAILURES=0
+
+# ADR-014: every Talos/Omni CIDR must live inside 172.16.0.0/12.
+in_adr014_range() {
+  local ip="${1%%/*}"
+  [[ ${ip} =~ ^([0-9]{1,3})\.([0-9]{1,3})\.[0-9]{1,3}\.[0-9]{1,3}$ ]] || return 1
+  local o1=${BASH_REMATCH[1]} o2=${BASH_REMATCH[2]}
+  [[ ${o1} == "172" ]] && ((o2 >= 16 && o2 <= 31))
+}
+
+check_field() {
+  local file="$1" label="$2" query="$3"
+  local values
+  values="$(yq eval-all "${query}" "${file}" 2>/dev/null)"
+
+  if [[ -z ${values} ]]; then
+    echo "FAIL ${file}: ${label} is missing or empty"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  local value
+  while IFS= read -r value; do
+    [[ -z ${value} ]] && continue
+    if ! in_adr014_range "${value}"; then
+      echo "FAIL ${file}: ${label} value '${value}' is outside ADR-014's 172.16.0.0/12 range"
+      FAILURES=$((FAILURES + 1))
+    fi
+  done <<<"${values}"
+}
+
+while IFS= read -r -d '' file; do
+  check_field "${file}" "cluster.network.podSubnets" \
+    'select(.kind == "Cluster") | .patches[] | select(.name == "cluster-common") | .inline.cluster.network.podSubnets[]'
+  check_field "${file}" "cluster.network.serviceSubnets" \
+    'select(.kind == "Cluster") | .patches[] | select(.name == "cluster-common") | .inline.cluster.network.serviceSubnets[]'
+  check_field "${file}" "machine.kubelet.clusterDNS" \
+    'select(.kind == "Cluster") | .patches[] | select(.name == "machine-common") | .inline.machine.kubelet.clusterDNS[]'
+done < <(find "${REPO_ROOT}/projects" -path "*/src/infrastructure/omni/*.clustertemplate.yaml" -print0 || true)
+
+if ((FAILURES > 0)); then
+  echo >&2 "${FAILURES} ADR-014 CIDR violation(s) found in Omni cluster templates."
+  exit 1
+fi
+
+echo "All Omni cluster templates comply with ADR-014's 172.16.0.0/12 CIDR range."


### PR DESCRIPTION
## Summary

`catalog/omni/clustertemplates/base.yaml` (the reusable Talos-on-Proxmox-VE reference template) deliberately omits
`cluster.network.podSubnets` because it's per-cluster — but the omission was silent: a copyist who forgot to override
it got Talos's built-in pod CIDR (`10.244.0.0/16`), which directly violates ADR-014's `172.16.0.0/12`-only allocation
rule, and `omnictl cluster template validate` passed either way.

**Related Issue:** #1086

## Root Cause

The base's `podSubnets` field was a key with only commented-out example values underneath it — i.e. an empty/null
list, not a missing key. Omni's template schema treats an empty `podSubnets` as "not set" and falls through to
Talos's machine-config default rather than rejecting the template, so `omnictl cluster template validate` gave no
signal that anything was wrong. The two existing per-cluster templates (`lungmen-akn`, `rhodes-akn`) both already
override `podSubnets` correctly, so this was a latent gap rather than a live defect — flagged during the #1038 code
review (Parse-Don't-Validate / Fail-Fast).

## Fix

Two changes, one per commit:

1. **[`catalog/omni/clustertemplates/base.yaml`](catalog/omni/clustertemplates/base.yaml)** — replaced the empty
   `podSubnets` field with a sentinel value (`MUST-OVERRIDE-SEE-IPAM.MD`) that is not a valid CIDR. A forgotten
   override now fails `omnictl cluster template validate` loudly on the cloned template instead of silently falling
   back to a Talos default. The header now documents that the base itself is not expected to pass `validate`
   (it never was applied directly, per its own "REFERENCE template — NOT applied directly" note).
2. **[`scripts/omni:template:lint`](scripts/omni:template:lint)** + **[`.github/workflows/push,pull_request.omni-template-lint.yaml`](.github/workflows/push,pull_request.omni-template-lint.yaml)**
   — the sentinel only catches a *completely forgotten* override. It doesn't catch a template that overrides
   `podSubnets`/`serviceSubnets`/`clusterDNS` with a value that's syntactically valid but still outside ADR-014's
   `172.16.0.0/12` range. The new script checks all three fields on every
   `projects/*/src/infrastructure/omni/*.clustertemplate.yaml` against that range (the reference base is excluded by
   path — it's never applied directly), and a new CI workflow runs it on any change under
   `projects/*/src/infrastructure/omni/`.

### Why not conftest/OPA

`catalog/opa/` policies are wired through `conftest --combine` against rendered `dist/` directories
(`.github/workflows/merge_group.compliance-full.yaml` / `push,pull_request.compliance-partial.yaml`), keyed on a
per-namespace directory matrix. Omni cluster templates are Talos DSL, not Kubernetes manifests, have no `dist/`
equivalent, and are single standalone files — forcing them through that dist-shaped matrix would be a much larger,
disproportionate change for what this issue needs. A small standalone script + dedicated workflow (same pattern as
`push,pull_request.vector-config-test.yaml`) is the proportionate fit.

## Technical Impact

### Behavioural Changes

- Cloning the base and forgetting to set `podSubnets` now fails `omnictl cluster template validate` instead of
  silently applying Talos's default CIDR.
- Any per-cluster template PR touching `projects/*/src/infrastructure/omni/` now runs an automatic ADR-014 CIDR
  check in CI.
- No change to the two existing per-cluster templates (`lungmen-akn`, `rhodes-akn`) — both already comply and pass
  the new lint (verified locally).

### Regression Risk

Low. `catalog/omni/clustertemplates/base.yaml` is a reference-only file, never applied directly — changing its
sentinel value cannot affect a live cluster. The new script and workflow are additive and were tested locally
against both real templates (pass) and a deliberately broken CIDR (correctly fails).

### Observability

`scripts/omni:template:lint` prints one `FAIL <file>: <field> ...` line per violation and a summary count; CI
surfaces the same output as a failed check.

## Testing Validation

- [x] `scripts/omni:template:lint` passes against the current `lungmen-akn` and `rhodes-akn` templates
- [x] `scripts/omni:template:lint` correctly fails against a deliberately-injected `10.244.0.0/16` podSubnets value
- [x] `trunk check --filter=-conftest` reports no issues on all changed files
- [ ] CI workflow run (will execute automatically once this PR is opened)

## Related Issues

Closes #1086

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
