### PR TITLE
Add a monthly OpenBao secret hygiene audit tool

### DIFF
--- a/.agents/skills/bao-secret-audit/SKILL.md
+++ b/.agents/skills/bao-secret-audit/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: bao-secret-audit
+description:
+  Runs a repeatable OpenBao secret hygiene audit — naming convention drift against ADR-003, dangling references (dist/
+  ExternalSecrets or Pulumi vault.kv.* calls pointing at a path that doesn't exist), and orphaned secrets (live paths
+  nothing in the repo references). Use monthly, or whenever asked to "audit OpenBao", "check secret hygiene", "find
+  orphaned vault secrets", or "check for dangling ExternalSecret references". Metadata/path-only — never reads a secret
+  value.
+compatibility:
+  Requires `bao` on PATH (installed via `mise`) and an authenticated session (`mise run bao:login` or `mise run
+  bao:login:admin` — list permissions on every KV mount are enough, no read-value permission needed). Requires `uv`
+  (already a repo dependency) to run the script itself.
+---
+
+# OpenBao secret hygiene audit
+
+Wraps `scripts/bao:secret:audit`. Read that script before relying on this skill for anything beyond the well-known
+false-positive shapes documented below — it's the source of truth for what each check actually does.
+
+## When to use this skill
+
+- Monthly maintenance sweep (via `/loop` or a scheduled routine), or when asked directly.
+- After a bulk secret migration/rename, to confirm nothing was left dangling or orphaned.
+- Before deleting a live OpenBao secret, to double check nothing still expects the old path.
+
+## When NOT to use this skill
+
+- To read or dump secret _values_ — this tool and this skill are path/metadata-only by design. Don't extend it to call
+  `bao kv get` on individual secrets.
+- To validate Terraform-, Ansible-, or Crossplane-ProviderConfig-consumed secrets — the reference scanner only covers
+  `dist/` ExternalSecrets and Pulumi `vault.kv.SecretV2`/`getSecretV2` call sites. A secret consumed exclusively through
+  one of those other paths will show up as a false "orphaned" finding — see Known limitations below.
+
+## Workflow
+
+1. **Confirm auth.** Run `bao token lookup`. If it fails or the token lacks list access on a mount, tell the user to run
+   `mise run bao:login` (or `bao:login:admin` for full coverage) before continuing — don't attempt to log in on their
+   behalf.
+2. **Run the script**: `scripts/bao:secret:audit`. It prints per-mount secret counts to stderr as it goes (useful
+   progress signal — the recursive KV walk can take a few seconds per mount) and the Markdown report to stdout. Exit
+   code is `1` if any finding exists, `0` if clean.
+3. **Read every section**, don't just report the finding count:
+   - **Naming convention drift** — cross-check against `docs/decisions/003-openbao-path-naming-conventions.md` before
+     treating a flag as real; the checker is deliberately conservative (character set, category enum for `shared/`,
+     minimum path depth for per-cluster mounts) and can't validate everything ADR-003 describes.
+   - **Dangling references** — these are the highest-confidence findings. A `dist/` ExternalSecret or Pulumi call
+     pointing at a path with no live secret means a sync is currently broken (`SecretSyncedError`) or a `pulumi up` will
+     fail. If the fix is an obvious typo (compare against a working sibling reference to the same mount/category), fix
+     it directly in `src/`, re-render with `scripts/dist:render <path>`, and say so in the summary. If it's not
+     obviously a typo, surface it and ask before touching anything — the live secret might be intentionally pending
+     creation.
+   - **Orphaned secrets** — the _lowest_-confidence findings. Never propose deleting one without checking, per entry:
+     whether the owning app exists yet under `projects/<cluster>/src/apps/` (pre-provisioned secrets for a
+     not-yet-deployed app are expected, not a bug), and whether it's consumed via Terraform/Ansible/Crossplane (out of
+     this tool's scan scope, see Known limitations).
+4. **Triage, don't bulk-act.** Per `AGENTS.md`'s scope-management rules: fix an evidenced, in-scope bug inline (like the
+   dangling-reference typo case above) if the fix is small and clearly safe; for anything requiring judgment calls about
+   staleness or intent, summarize and let the user decide — don't auto-file an issue per orphaned secret, and don't
+   auto-delete anything. If the user wants tracking issues for specific findings, use the `create-issue` skill.
+5. **Report back** in a short summary: counts per section, anything fixed inline, and what still needs a human call.
+
+## Known limitations
+
+- **Pulumi reference extraction is regex-based, not an AST parse.** A `vault.kv.SecretV2`/`getSecretV2` call whose
+  `mount`/`name` uses a template literal with an interpolated variable (`` `${foo}` ``) can't be resolved and is
+  silently skipped — if a report entry looks wrong, grep the Pulumi source directly before trusting the finding.
+- **Only two reference sources are scanned**: `dist/**/*.ExternalSecret.*.yaml` (filtered to ExternalSecrets whose
+  `secretStoreRef` resolves to a vault-backed `SecretStore`/`ClusterSecretStore` — OpenBao's own bootstrap secrets use a
+  Kubernetes-native `SecretStore` and are correctly excluded) and Pulumi `vault.kv.*` call sites. Terraform state,
+  Ansible vars, and Crossplane `ProviderConfig.spec.credentials` are not scanned — a secret consumed only through one of
+  those will show as a false "orphaned" finding.
+- **`personal/` mount is excluded from the orphan check entirely** — those secrets are self-managed per user and were
+  never expected to be referenced by ExternalSecrets or Pulumi.
+
+## Example run
+
+```console
+$ scripts/bao:secret:audit
+Mounts: amiya.akn, kazimierz.akn, lungmen.akn, personal, rhodes.akn, shared
+  amiya.akn: 17 secrets
+  ...
+# OpenBao secret hygiene audit
+
+Live secrets scanned: 89 across 6 mounts.
+References scanned: 36 (dist/ ExternalSecrets + Pulumi vault.kv.* calls).
+
+## Naming convention drift (ADR-003)
+
+None found.
+...
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ Components in `catalog/fluxcd/` exist for the legacy `maison` cluster, which is 
 ### Secrets
 
 - Source of truth: **OpenBao** at `https://vault.chezmoi.sh`.
-- KV mounts follow `projects-<cluster>/` and `shared/`.
+- KV mounts follow `<cluster>/` (e.g. `amiya.akn/`), plus `shared/` and `personal/`.
 - **External Secrets Operator** syncs OpenBao → Kubernetes `Secret` objects.
 - **SOPS + age** encrypts secrets that must live in Git; key path is `SOPS_AGE_KEY_FILE`.
 - Never commit plaintext secrets. Network policies are mandatory for any app touching secrets.

--- a/projects/amiya.akn/dist/infrastructure/kubernetes/cloudflare-operator/external-secrets.io.v1.ExternalSecret.cloudflare-credentials.yaml
+++ b/projects/amiya.akn/dist/infrastructure/kubernetes/cloudflare-operator/external-secrets.io.v1.ExternalSecret.cloudflare-credentials.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   data:
   - remoteRef:
-      key: shared/data/third-parties/cloudflare/iam/amiya.akn/cloudflare-operator
+      key: shared/third-parties/cloudflare/iam/amiya.akn/cloudflare-operator
       property: api_token
     secretKey: CLOUDFLARE_API_TOKEN
   refreshInterval: 1h

--- a/projects/amiya.akn/dist/infrastructure/kubernetes/tailscale/external-secrets.io.v1.ExternalSecret.operator-oauth.yaml
+++ b/projects/amiya.akn/dist/infrastructure/kubernetes/tailscale/external-secrets.io.v1.ExternalSecret.operator-oauth.yaml
@@ -9,14 +9,14 @@ spec:
   - remoteRef:
       conversionStrategy: Default
       decodingStrategy: None
-      key: shared/data/third-parties/tailscale/oauth/amiya.akn
+      key: shared/third-parties/tailscale/oauth/amiya.akn
       metadataPolicy: None
       property: client_id
     secretKey: client_id
   - remoteRef:
       conversionStrategy: Default
       decodingStrategy: None
-      key: shared/data/third-parties/tailscale/oauth/amiya.akn
+      key: shared/third-parties/tailscale/oauth/amiya.akn
       metadataPolicy: None
       property: client_secret
     secretKey: client_secret

--- a/projects/amiya.akn/src/infrastructure/kubernetes/cloudflare-operator/cloudflare-credentials.externalsecret.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/cloudflare-operator/cloudflare-credentials.externalsecret.yaml
@@ -14,5 +14,5 @@ spec:
   data:
     - secretKey: CLOUDFLARE_API_TOKEN
       remoteRef:
-        key: shared/data/third-parties/cloudflare/iam/amiya.akn/cloudflare-operator
+        key: shared/third-parties/cloudflare/iam/amiya.akn/cloudflare-operator
         property: api_token

--- a/projects/amiya.akn/src/infrastructure/kubernetes/tailscale/operator-oauth.externalsecret.yaml
+++ b/projects/amiya.akn/src/infrastructure/kubernetes/tailscale/operator-oauth.externalsecret.yaml
@@ -13,14 +13,14 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
-        key: shared/data/third-parties/tailscale/oauth/amiya.akn
+        key: shared/third-parties/tailscale/oauth/amiya.akn
         metadataPolicy: None
         property: client_id
       secretKey: client_id
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
-        key: shared/data/third-parties/tailscale/oauth/amiya.akn
+        key: shared/third-parties/tailscale/oauth/amiya.akn
         metadataPolicy: None
         property: client_secret
       secretKey: client_secret

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/tailscale/external-secrets.io.v1.ExternalSecret.operator-oauth.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/tailscale/external-secrets.io.v1.ExternalSecret.operator-oauth.yaml
@@ -9,14 +9,14 @@ spec:
   - remoteRef:
       conversionStrategy: Default
       decodingStrategy: None
-      key: shared/data/third-parties/tailscale/oauth/lungmen.akn
+      key: shared/third-parties/tailscale/oauth/lungmen.akn
       metadataPolicy: None
       property: client_id
     secretKey: client_id
   - remoteRef:
       conversionStrategy: Default
       decodingStrategy: None
-      key: shared/data/third-parties/tailscale/oauth/lungmen.akn
+      key: shared/third-parties/tailscale/oauth/lungmen.akn
       metadataPolicy: None
       property: client_secret
     secretKey: client_secret

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/tailscale/operator-oauth.externalsecret.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/tailscale/operator-oauth.externalsecret.yaml
@@ -13,14 +13,14 @@ spec:
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
-        key: shared/data/third-parties/tailscale/oauth/lungmen.akn
+        key: shared/third-parties/tailscale/oauth/lungmen.akn
         metadataPolicy: None
         property: client_id
       secretKey: client_id
     - remoteRef:
         conversionStrategy: Default
         decodingStrategy: None
-        key: shared/data/third-parties/tailscale/oauth/lungmen.akn
+        key: shared/third-parties/tailscale/oauth/lungmen.akn
         metadataPolicy: None
         property: client_secret
       secretKey: client_secret

--- a/scripts/bao:secret:audit
+++ b/scripts/bao:secret:audit
@@ -1,0 +1,309 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "pyyaml>=6",
+# ]
+# ///
+"""OpenBao secret hygiene audit — see .agents/skills/bao-secret-audit/SKILL.md.
+
+Three checks, all metadata/path-only (no secret values are ever read):
+
+  1. Naming convention drift — live paths that don't follow ADR-003
+     (docs/decisions/003-openbao-path-naming-conventions.md).
+  2. Dangling references — an ExternalSecret (dist/) or Pulumi vault.kv.*
+     call (src/infrastructure/pulumi/) points at a path that doesn't exist.
+  3. Orphaned secrets — a live path nothing in the repo references.
+
+Requires `bao` on PATH and an authenticated session (`mise run bao:login` or
+`mise run bao:login:admin`) — the KV list calls need at least read+list on
+every mount.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(
+    subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+)
+
+# Mounts intentionally excluded from the orphan check: personal/ is
+# self-managed by each user, never referenced by ExternalSecrets or Pulumi.
+ORPHAN_CHECK_EXCLUDED_MOUNTS = {"personal"}
+
+SHARED_CATEGORIES = {"sso", "certificates", "third-parties"}
+VALID_PATH_CHARS = re.compile(r"^[A-Za-z0-9._-]+$")
+
+VAULT_CALL_RE = re.compile(r"vault\.kv\.(?:SecretV2|getSecretV2)\(")
+
+
+def run_bao(*args: str) -> str:
+    result = subprocess.run(["bao", *args], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ERROR: bao {' '.join(args)} failed: {result.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+    return result.stdout
+
+
+def list_kv_mounts() -> list[str]:
+    data = json.loads(run_bao("secrets", "list", "-format=json"))
+    return [
+        path.rstrip("/")
+        for path, info in data.items()
+        if info.get("type") == "kv" and info.get("options", {}).get("version") == "2"
+    ]
+
+
+def list_kv_paths(mount: str, subpath: str = "") -> list[str]:
+    """Recursively list every leaf secret path under a mount."""
+    result = subprocess.run(
+        ["bao", "kv", "list", f"-mount={mount}", "-format=json", subpath],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        # No entries at this path (404) — not an error, just an empty branch.
+        return []
+
+    entries = json.loads(result.stdout)
+    leaves: list[str] = []
+    for entry in entries:
+        child = f"{subpath}{entry}" if subpath else entry
+        if entry.endswith("/"):
+            leaves.extend(list_kv_paths(mount, child))
+        else:
+            leaves.append(f"{mount}/{child}")
+    return leaves
+
+
+@dataclass
+class Finding:
+    check: str
+    path: str
+    detail: str
+
+
+@dataclass
+class AuditResult:
+    live_paths: set[str] = field(default_factory=set)
+    referenced_paths: set[str] = field(default_factory=set)
+    findings: list[Finding] = field(default_factory=list)
+
+
+def check_naming_conventions(live_paths: set[str]) -> list[Finding]:
+    findings = []
+    for full_path in sorted(live_paths):
+        mount, _, rest = full_path.partition("/")
+        segments = rest.split("/")
+
+        # The personal mount's first segment is a user email by design
+        # (ADR-003: /personal/{user-email}/...) — "@" is expected there even
+        # though it's outside the mount's own "allowed characters" rule.
+        char_check_segments = segments[1:] if mount == "personal" else segments
+        for segment in char_check_segments:
+            if not VALID_PATH_CHARS.match(segment):
+                findings.append(
+                    Finding(
+                        "naming",
+                        full_path,
+                        f"segment '{segment}' uses characters outside [A-Za-z0-9._-]",
+                    )
+                )
+
+        if mount == "shared":
+            category = segments[0]
+            if category not in SHARED_CATEGORIES:
+                findings.append(
+                    Finding(
+                        "naming",
+                        full_path,
+                        f"category '{category}' is not one of {sorted(SHARED_CATEGORIES)} (ADR-003)",
+                    )
+                )
+            elif category == "sso":
+                findings.append(
+                    Finding("naming", full_path, "'sso' shared category is deprecated (ADR-003)")
+                )
+        elif mount == "personal":
+            if "@" not in segments[0]:
+                findings.append(
+                    Finding("naming", full_path, f"first segment '{segments[0]}' isn't an email")
+                )
+        else:
+            # Per-cluster mount: Application-First Organization requires at
+            # least {app}/{category-or-secret}.
+            if len(segments) < 2:
+                findings.append(
+                    Finding(
+                        "naming",
+                        full_path,
+                        "no app/category grouping — expected {app}/{category}/{secret} (ADR-003)",
+                    )
+                )
+    return findings
+
+
+def _find_vault_backed_stores() -> set[tuple[str, str, str | None]]:
+    """(kind, name, namespace) for every SecretStore/ClusterSecretStore backed
+    by the vault provider. Not every store is — e.g. OpenBao's own bootstrap
+    secrets (softhsm token, its own DB password) come from a Kubernetes-native
+    SecretStore since Vault can't fetch its own unseal material from itself.
+    ClusterSecretStore is cluster-scoped, so namespace is stored as None.
+    """
+    stores: set[tuple[str, str, str | None]] = set()
+    for pattern in ("*.SecretStore.*.yaml", "*.ClusterSecretStore.*.yaml"):
+        for path in REPO_ROOT.glob(f"projects/*/dist/**/{pattern}"):
+            doc = yaml.safe_load(path.read_text())
+            if not doc or "vault" not in doc.get("spec", {}).get("provider", {}):
+                continue
+            kind = doc["kind"]
+            name = doc["metadata"]["name"]
+            namespace = None if kind == "ClusterSecretStore" else doc["metadata"].get("namespace")
+            stores.add((kind, name, namespace))
+    return stores
+
+
+def scan_dist_external_secrets() -> set[str]:
+    vault_stores = _find_vault_backed_stores()
+    referenced = set()
+    for path in REPO_ROOT.glob("projects/*/dist/**/*.ExternalSecret.*.yaml"):
+        docs = yaml.safe_load_all(path.read_text())
+        for doc in docs:
+            if not doc:
+                continue
+            spec = doc.get("spec", {})
+            store_ref = spec.get("secretStoreRef", {})
+            store_kind = store_ref.get("kind", "SecretStore")
+            store_name = store_ref.get("name")
+            store_namespace = None if store_kind == "ClusterSecretStore" else doc["metadata"].get("namespace")
+            if (store_kind, store_name, store_namespace) not in vault_stores:
+                continue
+
+            for item in spec.get("data", []) or []:
+                key = item.get("remoteRef", {}).get("key")
+                if key:
+                    referenced.add(key)
+            for item in spec.get("dataFrom", []) or []:
+                key = item.get("extract", {}).get("key")
+                if key:
+                    referenced.add(key)
+    return referenced
+
+
+def scan_pulumi_vault_calls() -> set[str]:
+    """Regex-extract mount/name from vault.kv.SecretV2 / getSecretV2 calls.
+
+    Approximate on purpose: a full TypeScript AST parse is out of scope for
+    a lint script. Call sites using a template literal with an interpolated
+    variable (`${...}`) can't be resolved and are skipped — grep the file
+    manually if a report entry looks suspicious.
+    """
+    referenced = set()
+    ts_files = list(REPO_ROOT.glob("projects/*/src/infrastructure/pulumi/**/*.ts"))
+    ts_files += list(REPO_ROOT.glob("catalog/pulumi/**/*.ts"))
+
+    for path in ts_files:
+        text = path.read_text()
+        for match in VAULT_CALL_RE.finditer(text):
+            # Grab the next ~40 lines as the call's argument window and cut
+            # it off at the matching top-level close paren so we don't bleed
+            # into the next resource declaration.
+            window = text[match.end() : match.end() + 2000]
+            depth = 1
+            end = len(window)
+            for i, ch in enumerate(window):
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+                    if depth == 0:
+                        end = i
+                        break
+            block = window[:end]
+
+            mount_match = re.search(r"mount:\s*[\"']([^\"'$]+)[\"']", block)
+            name_match = re.search(r"name:\s*[\"']([^\"'$]+)[\"']", block)
+            if mount_match and name_match:
+                referenced.add(f"{mount_match.group(1)}/{name_match.group(1)}")
+    return referenced
+
+
+def run_audit() -> AuditResult:
+    result = AuditResult()
+
+    mounts = list_kv_mounts()
+    print(f"Mounts: {', '.join(mounts)}", file=sys.stderr)
+    for mount in mounts:
+        paths = list_kv_paths(mount)
+        print(f"  {mount}: {len(paths)} secrets", file=sys.stderr)
+        result.live_paths.update(paths)
+
+    result.referenced_paths |= scan_dist_external_secrets()
+    result.referenced_paths |= scan_pulumi_vault_calls()
+
+    result.findings.extend(check_naming_conventions(result.live_paths))
+
+    for ref in sorted(result.referenced_paths):
+        if ref not in result.live_paths:
+            result.findings.append(Finding("dangling", ref, "referenced but no live secret exists"))
+
+    for live in sorted(result.live_paths):
+        mount = live.split("/", 1)[0]
+        if mount in ORPHAN_CHECK_EXCLUDED_MOUNTS:
+            continue
+        if live not in result.referenced_paths:
+            result.findings.append(
+                Finding("orphaned", live, "no ExternalSecret or Pulumi vault.kv.* reference found")
+            )
+
+    return result
+
+
+def render_report(result: AuditResult) -> str:
+    by_check: dict[str, list[Finding]] = {"naming": [], "dangling": [], "orphaned": []}
+    for f in result.findings:
+        by_check[f.check].append(f)
+
+    lines = [
+        "# OpenBao secret hygiene audit",
+        "",
+        f"Live secrets scanned: {len(result.live_paths)} across "
+        f"{len({p.split('/', 1)[0] for p in result.live_paths})} mounts.",
+        f"References scanned: {len(result.referenced_paths)} "
+        "(dist/ ExternalSecrets + Pulumi vault.kv.* calls).",
+        "",
+    ]
+
+    sections = [
+        ("naming", "## Naming convention drift (ADR-003)"),
+        ("dangling", "## Dangling references (referenced, not live)"),
+        ("orphaned", "## Orphaned secrets (live, never referenced)"),
+    ]
+    for key, header in sections:
+        findings = by_check[key]
+        lines.append(header)
+        lines.append("")
+        if not findings:
+            lines.append("None found.")
+        else:
+            for f in findings:
+                lines.append(f"- `{f.path}` — {f.detail}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    audit = run_audit()
+    print(render_report(audit))
+    sys.exit(1 if audit.findings else 0)

--- a/scripts/bao:secret:audit
+++ b/scripts/bao:secret:audit
@@ -66,11 +66,10 @@ def list_kv_mounts() -> list[str]:
 
 def list_kv_paths(mount: str, subpath: str = "") -> list[str]:
     """Recursively list every leaf secret path under a mount."""
-    result = subprocess.run(
-        ["bao", "kv", "list", f"-mount={mount}", "-format=json", subpath],
-        capture_output=True,
-        text=True,
-    )
+    args = ["bao", "kv", "list", f"-mount={mount}", "-format=json"]
+    if subpath:
+        args.append(subpath)
+    result = subprocess.run(args, capture_output=True, text=True)
     if result.returncode != 0:
         # No entries at this path (404) — not an error, just an empty branch.
         return []

--- a/scripts/bao:secret:audit
+++ b/scripts/bao:secret:audit
@@ -71,8 +71,15 @@ def list_kv_paths(mount: str, subpath: str = "") -> list[str]:
         args.append(subpath)
     result = subprocess.run(args, capture_output=True, text=True)
     if result.returncode != 0:
-        # No entries at this path (404) — not an error, just an empty branch.
-        return []
+        # "No value found at ..." is bao's message for an empty branch (the
+        # KV-list equivalent of a 404) — not an error. Anything else (auth
+        # failure, permission denied, transient API error) must not be
+        # swallowed: silently treating it as empty would undercount secrets
+        # without any signal that the scan was incomplete.
+        if "No value found at" in result.stderr:
+            return []
+        print(f"ERROR: bao kv list -mount={mount} {subpath!r} failed: {result.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
 
     entries = json.loads(result.stdout)
     leaves: list[str] = []
@@ -139,14 +146,14 @@ def check_naming_conventions(live_paths: set[str]) -> list[Finding]:
                     Finding("naming", full_path, f"first segment '{segments[0]}' isn't an email")
                 )
         else:
-            # Per-cluster mount: Application-First Organization requires at
-            # least {app}/{category-or-secret}.
-            if len(segments) < 2:
+            # Per-cluster mount: ADR-003's Application-First Organization is
+            # {app}/{category}/{secret} — three segments after the mount.
+            if len(segments) < 3:
                 findings.append(
                     Finding(
                         "naming",
                         full_path,
-                        "no app/category grouping — expected {app}/{category}/{secret} (ADR-003)",
+                        "no category grouping — expected {app}/{category}/{secret} (ADR-003)",
                     )
                 )
     return findings


### PR DESCRIPTION
## Summary

Every OpenBao secret hygiene sweep so far has been manual and one-off. This adds `scripts/bao:secret:audit`, a
repeatable tool that checks live OpenBao KV paths against ADR-003's naming conventions, cross-references every
`dist/` `ExternalSecret` and Pulumi `vault.kv.*` call against live paths in both directions, and reports orphaned
secrets — all metadata/path-only, no secret value is ever read. A companion skill
(`.agents/skills/bao-secret-audit/SKILL.md`) wraps it for a monthly agent-driven run.

**Related Issue:** #1151

## Changes Made

### Audit tool + skill

- **[`scripts/bao:secret:audit`](scripts/bao:secret:audit)** — walks every KV v2 mount via `bao secrets list` /
  `bao kv list`, extracts references from `dist/**/*.ExternalSecret.*.yaml` (filtered to ExternalSecrets whose
  `secretStoreRef` resolves to a vault-backed store — OpenBao's own bootstrap secrets use a Kubernetes-native
  `SecretStore` and are correctly excluded) and from Pulumi `vault.kv.SecretV2`/`getSecretV2` call sites, then
  reports naming drift, dangling references, and orphaned secrets as Markdown.
- **[`.agents/skills/bao-secret-audit/SKILL.md`](.agents/skills/bao-secret-audit/SKILL.md)** — when to run it, how
  to triage each section by confidence level (dangling references are high-confidence and safe to fix inline if
  obviously a typo; orphaned secrets are low-confidence and need per-entry judgment before proposing anything), and
  documents the tool's known scope limits (regex-based Pulumi extraction, no Terraform/Ansible/Crossplane
  ProviderConfig coverage, `personal/` mount excluded from orphan checks).

### Fixes found by the first live run

Running the tool against the production OpenBao instance (`https://vault.chezmoi.sh`) surfaced two real, in-scope
issues, fixed inline per the skill's own triage guidance:

- **[`AGENTS.md`](AGENTS.md)** — documented KV mount naming as `projects-<cluster>/`, but the live mounts (and the
  `cluster-vault` Pulumi component that provisions them) use the bare cluster name (`amiya.akn/`, `lungmen.akn/`,
  ...) plus `shared/` and `personal/`. Corrected the stale line.
- **Three `ExternalSecret`s had a dangling Vault key** — `cloudflare-credentials` (`amiya.akn`) and
  `operator-oauth` (`amiya.akn` and `lungmen.akn`, Tailscale) all referenced
  `shared/data/third-parties/.../...` instead of `shared/third-parties/.../...`. ESO's Vault v2 provider already
  inserts the `data/` segment internally for KV v2 mounts, so the literal `data/` in these three keys pointed at a
  path that doesn't exist — confirmed by comparing against every other working `ExternalSecret` in the repo (e.g.
  `amiya.akn/argocd/auth/oidc-client`, no `data/`) and by listing the real live paths directly
  (`shared/third-parties/cloudflare/iam/amiya.akn/cloudflare-operator`,
  `shared/third-parties/tailscale/oauth/{amiya,lungmen}.akn`). These three secrets were silently failing to sync
  (`SecretSyncedError`), leaving `cloudflare-operator` and the Tailscale operator without their credentials
  refreshed from the correct source. Fixed in `src/`, `dist/` re-rendered via `scripts/dist:render`.

## Technical Impact

### Infrastructure Components

No new services — a local script + a Claude Code skill. Requires `bao` (already an `mise` tool) and an
authenticated session (`mise run bao:login` / `bao:login:admin`) with list access on every KV mount; never requires
read-value access since no secret content is ever fetched.

### Security Implementation

Strictly metadata/path-only by design — the tool and skill both call this out explicitly (`bao secrets list`,
`bao kv list`, never `bao kv get`). The three-secret dangling-reference fix restores correct sync for
production credentials (`amiya.akn` cloudflare-operator, Tailscale operator OAuth on `amiya.akn` and `lungmen.akn`).

### Integration Points

Reads `dist/**/*.ExternalSecret.*.yaml` and `projects/*/src/infrastructure/pulumi/**/*.ts` /
`catalog/pulumi/**/*.ts` as its two reference sources; writes nothing except the Markdown report to stdout.

## Testing Validation

- [x] `scripts/bao:secret:audit` run against the live production OpenBao instance: 89 secrets across 6 mounts, 36
      references scanned
- [x] Verified the tool correctly excludes OpenBao's own Kubernetes-native bootstrap `SecretStore` (initially a
      false-positive source — fixed and re-verified)
- [x] Verified the `personal/` mount's email-containing first segment doesn't trip the character-set check (initially
      a false positive — fixed and re-verified)
- [x] Confirmed the 3 dangling-reference findings against real `bao kv list` output before fixing (not just trusting
      the tool's own conclusion)
- [x] Re-ran the full audit after both fixes: naming drift and dangling references both clean; remaining findings
      are legitimate orphans (some pre-provisioned for apps not yet under `src/apps/`, e.g. `mealie`, `litellm`,
      `open-webui`, `librechat` — none of these apps exist in `src/apps/` yet)
- [x] `trunk check --filter=-conftest` reports no issues on all changed files
- [ ] Monthly scheduled run (via `/loop` or a routine) — left to the user to wire up if wanted; the skill documents
      how

## Future Enhancements

- Terraform/Ansible/Crossplane `ProviderConfig` reference scanning (currently out of scope — see the skill's Known
  limitations section)
- The ~46 remaining orphaned-secret findings (mostly pre-provisioned secrets for not-yet-deployed lungmen.akn apps)
  are intentionally left for the user to triage per the skill's guidance rather than bulk-actioned here

## Related Issues

Closes #1151

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
