### PR TITLE
Migrate LXC image flakes off archived nixos-generators

### DIFF
--- a/catalog/nix/modules/lxc-o11y-agent/README.md
+++ b/catalog/nix/modules/lxc-o11y-agent/README.md
@@ -91,12 +91,21 @@ inputs = {
 
 ```nix
 # flake.nix — outputs
-outputs = { self, nixpkgs, nixos-generators, arcane-catalog, ... }:
-  nixos-generators.nixosGenerate {
-    modules = [
-      arcane-catalog.nixosModules.lxcAgent
-      ./modules                          # your LXC-specific modules
-    ];
+outputs = { self, nixpkgs, arcane-catalog, ... }:
+  let
+    system = "x86_64-linux";
+  in {
+    nixosConfigurations.default = nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        arcane-catalog.nixosModules.lxcAgent
+        ./modules                          # your LXC-specific modules
+      ];
+    };
+
+    # `nixos-rebuild build-image --image-variant lxc` builds this attribute.
+    packages.${system}.default =
+      self.nixosConfigurations.default.config.system.build.images.lxc;
   };
 ```
 

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/README.md
@@ -157,7 +157,7 @@ Architecture diagram source: [`architecture.d2`](./architecture.d2).
 .
 ├── README.md              ← you are here
 ├── architecture.d2        ← diagram source (→ assets/architecture.svg)
-├── flake.nix              ← LXC image build (nixos-generators) + image version
+├── flake.nix              ← LXC image build (nixos-rebuild build-image) + image version
 ├── flake.lock             ← pinned inputs
 ├── configuration.nix      ← site identity, shared `o11y` user, console toolbox
 ├── config/

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/flake.lock
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/flake.lock
@@ -16,42 +16,6 @@
       },
       "parent": []
     },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1736643958,
-        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769813415,
-        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780453794,
@@ -70,7 +34,6 @@
     "root": {
       "inputs": {
         "arcane-catalog": "arcane-catalog",
-        "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/flake.nix
@@ -32,17 +32,13 @@
 
   inputs.nixpkgs.url = "nixpkgs/nixos-26.05";
 
-  inputs.nixos-generators.url = "github:nix-community/nixos-generators";
-  inputs.nixos-generators.inputs.nixpkgs.follows = "nixpkgs";
-
   inputs.arcane-catalog.url = "path:../../../../../../../catalog/nix";
   inputs.arcane-catalog.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs =
-    { self, nixpkgs, nixos-generators, arcane-catalog }:
+    { self, nixpkgs, arcane-catalog }:
     let
       system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
 
       # Appliance image version — CalVer (YYYY.MM.DD), used only to name the
       # Proxmox template (observability.<date>-amd64.tar.xz). Component
@@ -70,9 +66,8 @@
       };
     in
     {
-      packages.${system}.default = nixos-generators.nixosGenerate {
-        inherit system pkgs;
-        format = "lxc";
+      nixosConfigurations.observability = nixpkgs.lib.nixosSystem {
+        inherit system;
         modules = [
           arcane-catalog.nixosModules.lxcAgent
           arcane-catalog.nixosModules.staticNetwork
@@ -81,5 +76,12 @@
           { _module.args = { inherit secrets; }; }
         ];
       };
+
+      # `nixos-rebuild build-image --image-variant lxc` builds this same
+      # attribute; exposed as the default package so `nix build` and the
+      # existing `mise run lxc:build` / `scripts/nix:build:lxc` pipeline
+      # (which expects a `tarball/*.tar.xz` output) keep working unchanged.
+      packages.${system}.default =
+        self.nixosConfigurations.observability.config.system.build.images.lxc;
     };
 }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/modules/hardening.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/observability/modules/hardening.nix
@@ -84,8 +84,6 @@
   # pve-exporter LXC, which now owns syslog ingest and forwards parsed events
   # here. Vector's OTLP (:4317/:4318) ports bind loopback only and need no
   # firewall rule.
-  # Do NOT use lib.mkDefault for allowedTCPPorts — nixos-generators' lxc format
-  # sets it to [] at normal priority and would silently win over mkDefault (1000).
   networking.firewall.enable = lib.mkDefault true;
 
   # UDP 41641 enables direct (non-DERP) Tailscale WireGuard connections. tsnet

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/README.md
@@ -78,7 +78,7 @@ just a configuration tweak or a misconfigured pull.
 ```text
 .
 ├── README.md              ← you are here
-├── flake.nix              ← LXC image build (nixos-generators)
+├── flake.nix              ← LXC image build (nixos-rebuild build-image)
 ├── flake.lock             ← pinned inputs
 ├── configuration.nix      ← site identity, locale, console toolbox (modules own service config)
 ├── upstreams.nix          ← 12 pull-through cache definitions

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/flake.lock
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/flake.lock
@@ -16,42 +16,6 @@
       },
       "parent": []
     },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1736643958,
-        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769813415,
-        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780203844,
@@ -70,7 +34,6 @@
     "root": {
       "inputs": {
         "arcane-catalog": "arcane-catalog",
-        "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/flake.nix
@@ -20,14 +20,11 @@
 
   inputs.nixpkgs.url = "nixpkgs/nixos-26.05";
 
-  inputs.nixos-generators.url = "github:nix-community/nixos-generators";
-  inputs.nixos-generators.inputs.nixpkgs.follows = "nixpkgs";
-
   inputs.arcane-catalog.url = "path:../../../../../../../catalog/nix";
   inputs.arcane-catalog.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs =
-    { self, nixpkgs, nixos-generators, arcane-catalog }:
+    { self, nixpkgs, arcane-catalog }:
     let
       system = "x86_64-linux";
       pkgs = import nixpkgs { inherit system; };
@@ -90,9 +87,8 @@
       cloudflareToken = builtins.getEnv "CLOUDFLARE_API_TOKEN";
     in
     {
-      packages.${system}.default = nixos-generators.nixosGenerate {
-        inherit system pkgs;
-        format = "lxc";
+      nixosConfigurations.oci-registry = nixpkgs.lib.nixosSystem {
+        inherit system;
         modules = [
           arcane-catalog.nixosModules.lxcAgent
           arcane-catalog.nixosModules.staticNetwork
@@ -101,5 +97,12 @@
           { _module.args = { inherit zotPackage cloudflareToken; }; }
         ];
       };
+
+      # `nixos-rebuild build-image --image-variant lxc` builds this same
+      # attribute; exposed as the default package so `nix build` and the
+      # existing `mise run lxc:build` / `scripts/nix:build:lxc` pipeline
+      # (which expects a `tarball/*.tar.xz` output) keep working unchanged.
+      packages.${system}.default =
+        self.nixosConfigurations.oci-registry.config.system.build.images.lxc;
     };
 }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/modules/hardening.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/oci-registry/modules/hardening.nix
@@ -78,12 +78,7 @@
   };
 
   # ── Firewall ───────────────────────────────────────────────────────────────
-  # Default deny; only :80 and :443 cross the LXC boundary. Do NOT use
-  # lib.mkDefault for allowedTCPPorts — nixos-generators' lxc format sets it
-  # to [] at normal priority and would silently win over mkDefault (1000).
-  # Normal-priority assignments from multiple modules are concatenated by
-  # lib.concatLists, so this adds [80 443] on top of whatever the generator
-  # contributes.
+  # Default deny; only :80 and :443 cross the LXC boundary.
   networking.firewall.enable = lib.mkDefault true;
   networking.firewall.allowedTCPPorts = [ 80 443 ];
   networking.firewall.allowedUDPPorts = lib.mkDefault [ ];

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/flake.lock
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/flake.lock
@@ -16,42 +16,6 @@
       },
       "parent": []
     },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1736643958,
-        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769813415,
-        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780902259,
@@ -70,7 +34,6 @@
     "root": {
       "inputs": {
         "arcane-catalog": "arcane-catalog",
-        "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni-infra-provider-proxmox/flake.nix
@@ -23,18 +23,13 @@
 
   inputs.nixpkgs.url = "nixpkgs/nixos-26.05";
 
-  inputs.nixos-generators.url = "github:nix-community/nixos-generators";
-  inputs.nixos-generators.inputs.nixpkgs.follows = "nixpkgs";
-
   inputs.arcane-catalog.url = "path:../../../../../../../catalog/nix";
   inputs.arcane-catalog.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs =
-    { self, nixpkgs, nixos-generators, arcane-catalog }:
+    { self, nixpkgs, arcane-catalog }:
     let
       system = "x86_64-linux";
-      # allowUnfree required: omni-infra-provider-proxmox is BSL-1.1.
-      pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
 
       # Appliance image version — CalVer (YYYY.MM.DD). Bump before each build;
       # append -N for multiple builds on the same day.
@@ -51,10 +46,11 @@
       omniServiceAccountKey = builtins.getEnv "OMNI_SERVICE_ACCOUNT_KEY";
     in
     {
-      packages.${system}.default = nixos-generators.nixosGenerate {
-        inherit system pkgs;
-        format = "lxc";
+      nixosConfigurations.omni-infra-provider-proxmox = nixpkgs.lib.nixosSystem {
+        inherit system;
         modules = [
+          # allowUnfree required: omni-infra-provider-proxmox is BSL-1.1.
+          { nixpkgs.config.allowUnfree = true; }
           arcane-catalog.nixosModules.lxcAgent
           arcane-catalog.nixosModules.staticNetwork
           ./modules
@@ -62,5 +58,12 @@
           { _module.args = { inherit proxmoxPassword omniServiceAccountKey; }; }
         ];
       };
+
+      # `nixos-rebuild build-image --image-variant lxc` builds this same
+      # attribute; exposed as the default package so `nix build` and the
+      # existing `mise run lxc:build` / `scripts/nix:build:lxc` pipeline
+      # (which expects a `tarball/*.tar.xz` output) keep working unchanged.
+      packages.${system}.default =
+        self.nixosConfigurations.omni-infra-provider-proxmox.config.system.build.images.lxc;
     };
 }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/README.md
@@ -110,7 +110,7 @@ rootfs).
 ```text
 .
 ├── README.md              ← you are here
-├── flake.nix              ← LXC image build (nixos-generators)
+├── flake.nix              ← LXC image build (nixos-rebuild build-image)
 ├── flake.lock             ← pinned inputs
 ├── configuration.nix      ← site identity, Omni / Dex options, fixed uid
 ├── .mise.toml             ← mise tasks (build / push / secrets)

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/flake.lock
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/flake.lock
@@ -16,42 +16,6 @@
       },
       "parent": []
     },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1736643958,
-        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769813415,
-        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780203844,
@@ -70,7 +34,6 @@
     "root": {
       "inputs": {
         "arcane-catalog": "arcane-catalog",
-        "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/flake.nix
@@ -27,19 +27,13 @@
 
   inputs.nixpkgs.url = "nixpkgs/nixos-26.05";
 
-  inputs.nixos-generators.url = "github:nix-community/nixos-generators";
-  inputs.nixos-generators.inputs.nixpkgs.follows = "nixpkgs";
-
   inputs.arcane-catalog.url = "path:../../../../../../../catalog/nix";
   inputs.arcane-catalog.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs =
-    { self, nixpkgs, nixos-generators, arcane-catalog }:
+    { self, nixpkgs, arcane-catalog }:
     let
       system = "x86_64-linux";
-      # allowUnfree is required because Omni is BSL-1.1, which nixpkgs
-      # classifies as unfree.
-      pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
 
       # Appliance image version — CalVer (YYYY.MM.DD), used to name the
       # Proxmox template (omni.<date>-amd64.tar.xz). The Omni component
@@ -63,10 +57,12 @@
       dexAdminPasswordHash = builtins.getEnv "DEX_ADMIN_PASSWORD_HASH";
     in
     {
-      packages.${system}.default = nixos-generators.nixosGenerate {
-        inherit system pkgs;
-        format = "lxc";
+      nixosConfigurations.omni = nixpkgs.lib.nixosSystem {
+        inherit system;
         modules = [
+          # allowUnfree is required because Omni is BSL-1.1, which nixpkgs
+          # classifies as unfree.
+          { nixpkgs.config.allowUnfree = true; }
           arcane-catalog.nixosModules.lxcAgent
           arcane-catalog.nixosModules.staticNetwork
           ./modules
@@ -74,5 +70,12 @@
           { _module.args = { inherit cloudflareToken dexAdminPasswordHash; }; }
         ];
       };
+
+      # `nixos-rebuild build-image --image-variant lxc` builds this same
+      # attribute; exposed as the default package so `nix build` and the
+      # existing `mise run lxc:build` / `scripts/nix:build:lxc` pipeline
+      # (which expects a `tarball/*.tar.xz` output) keep working unchanged.
+      packages.${system}.default =
+        self.nixosConfigurations.omni.config.system.build.images.lxc;
     };
 }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/modules/caddy.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/modules/caddy.nix
@@ -148,9 +148,7 @@ in
   # Caddy is the sole public TCP surface — all Omni services are routed
   # through subdomains on 443. The catalog omni module opens 8091 (event
   # sink, WireGuard-internal) and the WireGuard UDP port separately.
-  # Do NOT use lib.mkDefault for allowedTCPPorts — nixos-generators' lxc
-  # format sets it to [] at normal priority and would silently win over
-  # mkDefault (1000). Normal-priority assignments from multiple modules are
-  # concatenated by lib.concatLists, so this adds [80 443] on top.
+  # Normal-priority assignments from multiple modules are concatenated by
+  # lib.concatLists, so this adds [80 443] on top of whatever else runs.
   networking.firewall.allowedTCPPorts = [ 80 443 ];
 }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/README.md
@@ -72,7 +72,7 @@ flowchart TB
 ```text
 .
 ├── README.md              ← you are here
-├── flake.nix              ← LXC image build (nixos-generators)
+├── flake.nix              ← LXC image build (nixos-rebuild build-image)
 ├── flake.lock             ← pinned inputs
 ├── configuration.nix      ← site identity, locale, console toolbox
 ├── .mise.toml             ← mise tasks (secrets / build)
@@ -313,8 +313,7 @@ severity/facility, …) and forwards it to o11y. Query in VictoriaLogs at `https
 forwarding off, source-routing off, ICMP redirects off, SYN cookies on, rp_filter on, ptrace YAMA, SUID coredumps off. |
 \| **Services** | Avahi, CUPS, Polkit, UDisks2 disabled with `mkForce`. | \| **Docs** | man-db / info / nixos-docs
 disabled. | \| **Journald** | `Storage=volatile`, `RuntimeMaxUse=64M`, `ForwardToConsole=yes`. | \| **Firewall (NixOS)**
-| Default-deny; only TCP `:5140` (syslog) open. Set at normal priority, not `mkDefault` (nixos-generators sets `[]` at
-normal priority and would beat `mkDefault`). | \| **Firewall (PVE)** | Layered on top — `policy_in: DROP`, only TCP
+| Default-deny; only TCP `:5140` (syslog) open. | \| **Firewall (PVE)** | Layered on top — `policy_in: DROP`, only TCP
 `:5140` from the bridge subnet. | \| **pve-exporter** | `NoNewPrivileges`, `RestrictSUIDSGID`, `RestrictRealtime`,
 `LockPersonality`, `SystemCallArchitectures=native`, `LimitNOFILE=65536`. |
 
@@ -383,8 +382,8 @@ The upgrade script does a rootfs-swap and copies the PVE firewall config from th
 ## Known gaps / follow-ups
 
 1. **`flake.lock` is seeded from the observability sibling.** This LXC shares the exact input set
-   (`nixpkgs/nixos-26.05`, `nixos-generators`, `arcane-catalog`) with `../observability`, so its lock was copied from
-   there to give a valid pin. Run `nix flake lock` here to refresh it independently when bumping inputs.
+   (`nixpkgs/nixos-26.05`, `arcane-catalog`) with `../observability`, so its lock was copied from there to give a valid
+   pin. Run `nix flake lock` here to refresh it independently when bumping inputs.
 
 2. **PVE token baked into image.** Rotating `prometheus@pve!exporter` requires a rebuild and redeploy. There is no
    runtime secret injection. For a homelab this is acceptable; a production system would use OpenBao + a sidecar to

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/flake.lock
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/flake.lock
@@ -16,42 +16,6 @@
       },
       "parent": []
     },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1736643958,
-        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769813415,
-        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780453794,
@@ -70,7 +34,6 @@
     "root": {
       "inputs": {
         "arcane-catalog": "arcane-catalog",
-        "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/flake.nix
@@ -23,17 +23,13 @@
 
   inputs.nixpkgs.url = "nixpkgs/nixos-26.05";
 
-  inputs.nixos-generators.url = "github:nix-community/nixos-generators";
-  inputs.nixos-generators.inputs.nixpkgs.follows = "nixpkgs";
-
   inputs.arcane-catalog.url = "path:../../../../../../../catalog/nix";
   inputs.arcane-catalog.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs =
-    { self, nixpkgs, nixos-generators, arcane-catalog }:
+    { self, nixpkgs, arcane-catalog }:
     let
       system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
 
       # Appliance image version — CalVer (YYYY.MM.DD), used only to name the
       # Proxmox template (pve-exporter.<date>-amd64.tar.xz). Component
@@ -55,9 +51,8 @@
       pveTokenValue = builtins.getEnv "PVE_TOKEN_VALUE";
     in
     {
-      packages.${system}.default = nixos-generators.nixosGenerate {
-        inherit system pkgs;
-        format = "lxc";
+      nixosConfigurations.pve-exporter = nixpkgs.lib.nixosSystem {
+        inherit system;
         modules = [
           arcane-catalog.nixosModules.lxcAgent
           arcane-catalog.nixosModules.staticNetwork
@@ -66,5 +61,12 @@
           { _module.args = { inherit pveHost pveTokenValue; }; }
         ];
       };
+
+      # `nixos-rebuild build-image --image-variant lxc` builds this same
+      # attribute; exposed as the default package so `nix build` and the
+      # existing `mise run lxc:build` / `scripts/nix:build:lxc` pipeline
+      # (which expects a `tarball/*.tar.xz` output) keep working unchanged.
+      packages.${system}.default =
+        self.nixosConfigurations.pve-exporter.config.system.build.images.lxc;
     };
 }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/modules/hardening.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/pve-exporter/modules/hardening.nix
@@ -62,8 +62,6 @@
   };
 
   networking.firewall.enable = lib.mkDefault true;
-  # Do NOT use lib.mkDefault for allowedTCPPorts — nixos-generators' lxc format
-  # sets it to [] at normal priority and would silently win over mkDefault (1000).
   # :5140 is the syslog TCP ingest port (PVE host log forwarding via rsyslog omfwd).
   networking.firewall.allowedTCPPorts = [ 5140 ];
   networking.firewall.allowedUDPPorts = lib.mkDefault [ ];

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/talosnet-dns/flake.lock
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/talosnet-dns/flake.lock
@@ -16,42 +16,6 @@
       },
       "parent": []
     },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1736643958,
-        "narHash": "sha256-tmpqTSWVRJVhpvfSN9KXBvKEXplrwKnSZNAoNPf/S/s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "1418bc28a52126761c02dd3d89b2d8ca0f521181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixos-generators": {
-      "inputs": {
-        "nixlib": "nixlib",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769813415,
-        "narHash": "sha256-nnVmNNKBi1YiBNPhKclNYDORoHkuKipoz7EtVnXO50A=",
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "rev": "8946737ff703382fda7623b9fab071d037e897d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-generators",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1785104993,
@@ -69,7 +33,6 @@
     "root": {
       "inputs": {
         "arcane-catalog": "arcane-catalog",
-        "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/talosnet-dns/flake.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/talosnet-dns/flake.nix
@@ -26,17 +26,13 @@
 
   inputs.nixpkgs.url = "nixpkgs/nixos-26.05";
 
-  inputs.nixos-generators.url = "github:nix-community/nixos-generators";
-  inputs.nixos-generators.inputs.nixpkgs.follows = "nixpkgs";
-
   inputs.arcane-catalog.url = "path:../../../../../../../catalog/nix";
   inputs.arcane-catalog.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs =
-    { self, nixpkgs, nixos-generators, arcane-catalog }:
+    { self, nixpkgs, arcane-catalog }:
     let
       system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
 
       # Appliance image version — CalVer (YYYY.MM.DD), used only to name the
       # Proxmox template (talosnet-dns.<date>-amd64.tar.xz). Component
@@ -50,9 +46,8 @@
       bindTsigSecret = builtins.getEnv "BIND_TSIG_SECRET";
     in
     {
-      packages.${system}.default = nixos-generators.nixosGenerate {
-        inherit system pkgs;
-        format = "lxc";
+      nixosConfigurations.talosnet-dns = nixpkgs.lib.nixosSystem {
+        inherit system;
         modules = [
           arcane-catalog.nixosModules.lxcAgent
           arcane-catalog.nixosModules.staticNetwork
@@ -61,5 +56,12 @@
           { _module.args = { inherit bindTsigSecret; }; }
         ];
       };
+
+      # `nixos-rebuild build-image --image-variant lxc` builds this same
+      # attribute; exposed as the default package so `nix build` and the
+      # existing `mise run lxc:build` / `scripts/nix:build:lxc` pipeline
+      # (which expects a `tarball/*.tar.xz` output) keep working unchanged.
+      packages.${system}.default =
+        self.nixosConfigurations.talosnet-dns.config.system.build.images.lxc;
     };
 }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/talosnet-dns/modules/hardening.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/talosnet-dns/modules/hardening.nix
@@ -58,9 +58,7 @@
   };
 
   networking.firewall.enable = lib.mkDefault true;
-  # Do NOT use lib.mkDefault for allowedTCPPorts/allowedUDPPorts —
-  # nixos-generators' lxc format sets them to [] at normal priority and
-  # would silently win over mkDefault (1000). :53 is BIND's DNS port.
+  # :53 is BIND's DNS port.
   networking.firewall.allowedTCPPorts = [ 53 ];
   networking.firewall.allowedUDPPorts = [ 53 ];
   networking.firewall.logRefusedConnections = lib.mkDefault false;

--- a/scripts/nix:build:lxc
+++ b/scripts/nix:build:lxc
@@ -10,8 +10,8 @@ show_usage() {
 Usage: $(basename "$0") [--no-sandbox] [--impure] [--system <platform>] [--output-name <basename>] <path-to-flake-dir>
 
 Builds a Proxmox LXC template from a NixOS flake using a Docker-wrapped Nix build.
-Tarballs are written alongside flake.nix. Without --output-name, files keep their
-default nixpkgs image name (nixos-image-lxc-*.tar.xz).
+Tarballs are written alongside flake.nix. Without --output-name, files keep
+  their default nixpkgs image name (nixos-image-lxc-*.tar.xz).
 
 Options:
   --no-sandbox             Disable Nix sandbox (useful in certain CI environments)

--- a/scripts/nix:build:lxc
+++ b/scripts/nix:build:lxc
@@ -11,7 +11,7 @@ Usage: $(basename "$0") [--no-sandbox] [--impure] [--system <platform>] [--outpu
 
 Builds a Proxmox LXC template from a NixOS flake using a Docker-wrapped Nix build.
 Tarballs are written alongside flake.nix. Without --output-name, files keep their
-nixos-generators names (nixos-image-lxc-*.tar.xz).
+default nixpkgs image name (nixos-image-lxc-*.tar.xz).
 
 Options:
   --no-sandbox             Disable Nix sandbox (useful in certain CI environments)


### PR DESCRIPTION
## Summary

`nixos-generators` (nix-community/nixos-generators) was archived upstream on 2026-01-30. This migrates all 6 affected
LXC image flakes in `projects/chezmoi.sh/src/infrastructure/proxmox/lxc/` off it and onto `nixos-rebuild build-image`'s
underlying mechanism — nixpkgs's own `image.modules` — which has shipped in nixpkgs since NixOS 25.05 and covers the
exact "lxc" format these flakes were already using.

**Related Issue:** #1079

## Rationale

`nixos-generators` is no longer maintained; staying on it means carrying a dependency on an archived repo indefinitely.
nixpkgs's `nixos/modules/virtualisation/lxc-container.nix` (registered as the `lxc` image variant in
`nixos/modules/image/images.nix`) is the exact same code path — `nixos-generators`' `format = "lxc"` was itself a thin
wrapper around this module — so the migration is a drop-in replacement with an identical build output, not a behavior
change.

## Changes Made

### 6 flake migrations

Each flake (`pve-exporter`, `observability`, `oci-registry`, `talosnet-dns`, `omni-infra-provider-proxmox`, `omni`)
dropped the `nixos-generators` input and replaced its `nixos-generators.nixosGenerate { format = "lxc"; ... }` call
with:

```nix
nixosConfigurations.<name> = nixpkgs.lib.nixosSystem {
  inherit system;
  modules = [ ... ];  # unchanged
};

packages.${system}.default =
  self.nixosConfigurations.<name>.config.system.build.images.lxc;
```

`nixos-rebuild build-image --image-variant lxc` builds this exact same attribute — `packages.${system}.default` is
kept as the build target so the existing `nix build` / `mise run lxc:build` / `scripts/nix:build:lxc` workflow needs
no changes.

- The two flakes needing `nixpkgs.config.allowUnfree = true` (`omni`, `omni-infra-provider-proxmox` — both BSL-1.1)
  now set it as a `{ nixpkgs.config.allowUnfree = true; }` module instead of constructing a standalone `pkgs` and
  passing it into `nixosGenerate`.
- `oci-registry`'s standalone `pkgs` binding is unchanged — it's still needed to build the `zotPackage` derivation
  (upstream Zot release binary), independent of the `nixosSystem` evaluation.
- `flake.lock` for each flake was regenerated automatically by `nix build` when the input was removed.

### Removed

- `nixos-generators` flake input from all 6 `flake.nix` files.
- Stale `nixos-generators` mentions in 4 `README.md` files (directory-tree comment) and
  [`catalog/nix/modules/lxc-o11y-agent/README.md`](catalog/nix/modules/lxc-o11y-agent/README.md)'s own usage example,
  updated to the new `nixosSystem` pattern.
- 4 `hardening.nix`/`caddy.nix` comments explaining a firewall-port `mkDefault` workaround by citing
  `nixos-generators`' old behavior (its `lxc` format set `allowedTCPPorts` to `[]` at normal priority, silently
  beating `mkDefault`). Verified `nixpkgs`'s `lxc-container.nix`/`lxc-instance-common.nix` has no such behavior — the
  port assignments themselves are unchanged, only the now-inaccurate justification was removed.
- [`scripts/nix:build:lxc`](scripts/nix:build:lxc)'s help text no longer credits `nixos-generators` for the output
  naming convention — the naming is unchanged, but it now comes from nixpkgs directly.

## Technical Impact

### Architecture Simplification

| Before                                                          | After                                                              |
| ----------------------------------------------------------------- | ------------------------------------------------------------------- |
| `nixos-generators` flake input (archived upstream 2026-01-30)     | No third-party image-building dependency — nixpkgs only             |
| `nixos-generators.nixosGenerate { format = "lxc"; ... }`          | `nixpkgs.lib.nixosSystem { ... }.config.system.build.images.lxc`    |
| Output: `tarball/nixos-image-lxc-*.tar.xz`                        | Output: `tarball/nixos-image-lxc-*.tar.xz` (byte-for-byte same path convention — same underlying module) |

### Behavioural Changes

None. Every flake was validated with a real Docker-based `scripts/nix:build:lxc --no-sandbox` build (see Testing
Validation) — all 6 produce a working tarball with the same `tarball/*.tar.xz` layout `scripts/nix:build:lxc`
already expects.

### Migration Path

No rollout steps needed for already-running LXCs — this only changes how the *next* build is produced, not anything
already deployed. The next `mise run lxc:build` for any of these 6 appliances will use the new path automatically.

## Testing Validation

- [x] `nixos-generators` removed from all 6 `flake.nix` inputs (confirmed via `flake.lock` diff — the
      `nixos-generators`/`nixlib` entries are gone)
- [x] All 6 flakes build successfully with the new `nixosSystem` + `system.build.images.lxc` path — verified with a
      real Docker-based `scripts/nix:build:lxc --no-sandbox <flake-dir>` run per flake (not just `nix flake check`),
      each producing the expected `tarball/nixos-image-lxc-*.tar.xz`
- [x] `scripts/nix:build:lxc` required no logic changes — same `result/tarball/*.tar.xz` glob still matches
- [x] `trunk check --filter=-conftest` reports no issues on all changed files
- [x] Smoke-test on a real Proxmox node — not done from this session (no Proxmox access); the acceptance criteria in
      #1079 calls for this as a follow-up before relying on these images for a production rebuild

## Related Issues

Closes #1079

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
