### PR TITLE
Fix linkding startup crash-loop on lungmen.akn with a startupProbe

### DIFF
--- a/projects/lungmen.akn/dist/apps/linkding/apps.v1.Deployment.linkding.yaml
+++ b/projects/lungmen.akn/dist/apps/linkding/apps.v1.Deployment.linkding.yaml
@@ -97,6 +97,12 @@ spec:
           runAsGroup: 23281
           runAsNonRoot: true
           runAsUser: 23281
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds: 5
         volumeMounts:
         - mountPath: /etc/linkding/data
           name: linkding-data

--- a/projects/lungmen.akn/src/apps/linkding/linkding.deployment.yaml
+++ b/projects/lungmen.akn/src/apps/linkding/linkding.deployment.yaml
@@ -94,6 +94,12 @@ spec:
             httpGet:
               path: /health
               port: http
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 30
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
## Summary

linkding on `lungmen.akn` crash-loops because kubelet's `livenessProbe` kills
it mid-bootstrap during a legitimate ~60-90s CPU-heavy startup phase (Django
migrations, OIDC/JWKS setup on first boot). Adding a `startupProbe` gives it
room to finish before the existing `livenessProbe`/`readinessProbe` start
judging the pod.

**Related Issue:** #1113

## Root Cause

- Right after start, the container legitimately saturates close to one full
  CPU core for ~60-90s, during which it can't answer the existing
  `livenessProbe` (`GET /`) / `readinessProbe` (`GET /health`) in time.
- There is no `startupProbe`, so `livenessProbe` starts judging the pod
  immediately (`initialDelaySeconds` unset). Three consecutive failures
  trigger a kill before bootstrap finishes, and the cycle repeats forever
  (`exit 137` roughly every 59s, kubelet event "Container linkding failed
  liveness probe, will be restarted").
- Confirmed by removing both probes entirely: the pod ran without a single
  restart for 3+ minutes, and CPU usage settled from ~560m down to
  single-digit `m` on its own — a real but transient startup cost, not an
  infinite loop or a hang.
- Confirmed the fix live via `kubectl patch`: restoring
  `livenessProbe`/`readinessProbe` and adding a `startupProbe` (`GET
  /health`, `periodSeconds: 5`, `failureThreshold: 30` → 150s grace) kept
  `restartCount` at 0 and the pod `Ready` for 4+ minutes.
- Probe timeout tuning, uWSGI worker count/harakiri, DB/network
  connectivity, `LD_ENABLE_OIDC`/`LD_FAVICON_PROVIDER`, and memory were all
  ruled out during investigation (see issue #1113 for detail).

## Fix

- **[`linkding.deployment.yaml`](projects/lungmen.akn/src/apps/linkding/linkding.deployment.yaml)** — adds a `startupProbe` (`GET /health`, `periodSeconds: 5`, `failureThreshold: 30`) alongside the existing `livenessProbe`/`readinessProbe`.
- `dist/apps/linkding/apps.v1.Deployment.linkding.yaml` regenerated via `dist:render`.

## Technical Impact

### Behavioural Changes

None outside of the crash-loop being fixed: the pod now gets up to 150s to
finish bootstrap before `livenessProbe`/`readinessProbe` start evaluating
it. Steady-state probe behavior is unchanged.

### Regression Risk

Low — this only adds a `startupProbe`, it doesn't change the existing
`livenessProbe`/`readinessProbe` configuration. Already live-tested via
`kubectl patch` on the running cluster before being committed.

### Observability

`kubectl get pods -n linkding` should show `restartCount: 0` and `Ready`
through a full rollout (bootstrap + steady state); no more recurring `exit
137` / "failed liveness probe" events.

## Testing Validation

- [x] `startupProbe` added to `linkding.deployment.yaml`
- [x] `dist:render` run and `dist/` regenerated for the change
- [ ] Deployed pod stays `Ready` with `restartCount: 0` through at least one full rollout (bootstrap + steady state)

## Related Issues

Closes #1113

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
