### PR TITLE
Abort lxc_upgrade smoke-test on failed systemd units

### DIFF
--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh
@@ -563,10 +563,21 @@ lxc_upgrade() {
   fi
   _ok "NixOS activation passed"
 
-  _lxc_ssh "${pve_host}" "pct exec ${smoke_id} -- /run/current-system/sw/bin/bash -lc '
-    systemctl is-system-running
+  local systemd_check
+  systemd_check=$(_lxc_ssh "${pve_host}" "pct exec ${smoke_id} -- /run/current-system/sw/bin/bash -lc '
+    systemctl is-system-running || true
     systemctl --failed --no-legend
-  '" >&2 || true
+  '" || true)
+  echo "${systemd_check}" >&2
+
+  local failed_units
+  failed_units=$(tail -n +2 <<< "${systemd_check}")
+  if [[ -n ${failed_units} ]]; then
+    _fail "Smoke test failed — systemd unit(s) not running: $(tr '\n' ',' <<< "${failed_units}" | sed 's/,$//')"
+    _lxc_ssh "${pve_host}" "pct stop ${smoke_id}" 2>/dev/null || true
+    _lxc_ssh "${pve_host}" "pct destroy ${smoke_id}" 2>/dev/null || true
+    return 1
+  fi
 
   _lxc_ssh "${pve_host}" "pct stop ${smoke_id}; pct destroy ${smoke_id}"
   _ok "Smoke test passed — temporary CT ${smoke_id} destroyed"


### PR DESCRIPTION
## Summary

`lxc_upgrade`'s temporary-CT smoke-test prints failed systemd units but never
gates on them — it proceeded to replace the running production container's
rootfs regardless of what the smoke-test found.

**Related Issue:** #1149

## Root Cause

`lxc_upgrade` (`projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh`)
builds a temporary CT from the new template and smoke-tests it before
touching the real container. The smoke-test only gated on one thing — NixOS
activation. Right after that it also ran a systemd health check, but only
for its printed side effect:

```sh
_lxc_ssh "${pve_host}" "pct exec ${smoke_id} -- /run/current-system/sw/bin/bash -lc '
  systemctl is-system-running
  systemctl --failed --no-legend
'" >&2 || true
```

`|| true` swallowed the exit code of `systemctl is-system-running` (non-zero
whenever any unit failed), and the `--failed` output was never inspected —
the function unconditionally logged "Smoke test passed" and returned.

This caused a real ~8-minute production outage on talosnet-dns during PR
#1147: the smoke-test output clearly showed `bind.service loaded failed
failed`, but the upgrade proceeded past step 2 into step 4 (stop CT) and
step 5 (replace rootfs), taking the live BIND server down. Fixed forward in
PR #1148, but the tooling gap that let a known-bad build reach production
was still open until this PR.

## Fix

- **[`lxc.sh`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh)** — captures the `systemctl is-system-running` / `systemctl --failed --no-legend` output into `systemd_check`, parses the failed-units list out of it (same capture-then-gate pattern already used by the NixOS activation check right above it), and on a non-empty list calls `_fail` naming the specific unit(s), tears down the temporary CT, and `return 1` — before step 3 (snapshot) ever runs.

## Technical Impact

### Behavioural Changes

`lxc_upgrade` now hard-aborts at step 2 (before snapshot/stop/rootfs-replace)
whenever the smoke CT has any failed systemd unit, instead of only logging
it and continuing. A clean template's behavior is unchanged — it still
passes through step 2 and the rest of the upgrade flow untouched.

### Regression Risk

Low — this only tightens an existing check that was already computed and
printed; no new remote calls are introduced, and the false-failure surface
is the same `systemctl --failed` output previous runs already produced (and
ignored). Verified locally against both a clean-unit sample and the
`bind.service loaded failed failed` sample from the talosnet-dns incident.

### Observability

The abort message now names the specific failed unit(s) instead of a
generic "smoke test passed"/no signal at all, so a bad build shows up in the
`lxc_upgrade` output itself rather than only in follow-up cluster
monitoring.

## Testing Validation

- [x] Parsing/gating logic verified locally against a clean `systemctl
      --failed` sample (passes) and the actual talosnet-dns failure sample
      `bind.service loaded failed failed` (aborts, names the unit)
- [ ] A template with a service configured to fail at boot causes
      `lxc_upgrade` to abort at step 2, before step 3 (snapshot) runs — on a
      live PVE host
- [ ] A clean template still passes through step 2 unchanged — on a live PVE
      host

## Related Issues

Closes #1149

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
