### PR TITLE
Document Velero Kopia PVC backup local POC (EXP-2026-007)

### DIFF
--- a/docs/experiments/20260803-velero-pvc-backup/.gitignore
+++ b/docs/experiments/20260803-velero-pvc-backup/.gitignore
@@ -1,0 +1,2 @@
+# Velero Local POC - local, disposable state
+.mise/

--- a/docs/experiments/20260803-velero-pvc-backup/.mise.toml
+++ b/docs/experiments/20260803-velero-pvc-backup/.mise.toml
@@ -1,0 +1,40 @@
+# =============================================================================
+# Velero local POC — Development Environment (issue #1054)
+# =============================================================================
+# Disposable local kind cluster only — MinIO stands in for the real S3
+# backup target, Postgres stands in for a real stateful app's PVC. Nothing
+# here touches lungmen.akn, rhodes.akn, or any real infrastructure.
+#
+# Usage:
+#   cd docs/experiments/20260803-velero-pvc-backup
+#   mise install
+#   mise run poc:bootstrap   # create kind cluster + MinIO + Velero + test app
+#   mise run poc:validate    # run the backup/restore cycle
+#   mise run poc:teardown    # delete the kind cluster
+# =============================================================================
+
+[env]
+KUBECONFIG = "{{ config_root }}/.mise/kubeconfig"
+KIND_CLUSTER_NAME = "velero-poc"
+
+[tools]
+kind = "latest"
+kubectl = "latest"
+helm = "3"
+velero = "latest"
+
+[tasks."poc:bootstrap"]
+description = "Create the kind sandbox, MinIO, Velero, and the test app"
+run = "scripts/bootstrap.sh"
+dir = "{{config_root}}"
+
+[tasks."poc:validate"]
+alias = "poc:test"
+description = "Run the backup/restore validation cycle"
+run = "scripts/validate.sh"
+dir = "{{config_root}}"
+
+[tasks."poc:teardown"]
+description = "Delete the kind sandbox"
+run = "scripts/teardown.sh"
+dir = "{{config_root}}"

--- a/docs/experiments/20260803-velero-pvc-backup/README.md
+++ b/docs/experiments/20260803-velero-pvc-backup/README.md
@@ -1,0 +1,295 @@
+---
+experiment: EXP-2026-007
+title: Velero PVC backup (Kopia file-system backend) — local POC
+status: OK
+created: 2026-08-03
+updated: 2026-08-03
+velero: v1.18.1 (chart 12.1.0)
+velero-plugin-for-aws: v1.13.1
+issue: https://github.com/chezmoidotsh/arcane/issues/1054
+---
+
+## Abstract
+
+Local, disposable proof of concept for the Kopia file-system-backup path of #1054: deploy Velero against an
+S3-compatible target, back up a real PVC-backed stateful app, delete it, and restore it — proving the round trip
+preserves actual application data, not just that some bytes moved around.
+
+Everything runs in a **disposable local kind cluster** with MinIO standing in for the real S3 target (MinIO/Backblaze B2
+per the issue) and a throwaway Postgres StatefulSet standing in for a real app (CNPG, Paperless, Immich, …). No real
+cluster, no real backup bucket, no real Proxmox API calls.
+
+**Explicitly out of scope for this POC**: the CSI-snapshotter path (issue #1054's incremental-backup question). That
+needs the real `proxmox-csi-plugin`'s `VolumeSnapshotClass`, which only exists on actual Proxmox-backed clusters — see
+[§8.2](#82-deferred).
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Requirements](#2-requirements)
+3. [Sandbox Architecture](#3-sandbox-architecture)
+4. [Implementation](#4-implementation)
+5. [Test Environment](#5-test-environment)
+6. [Validation Criteria](#6-validation-criteria)
+7. [Results](#7-results)
+8. [Conclusions](#8-conclusions)
+9. [Actionable Next Steps](#9-actionable-next-steps)
+
+---
+
+## 1. Problem Statement
+
+#1054 needs to know, before touching any real cluster: does Velero's Kopia file-system-backup path actually preserve PVC
+data through a full backup → data-loss → restore cycle? "Works" is a specific, checkable claim (the restored app reads
+back the exact same data it wrote before deletion) — worth proving locally, cheaply, and repeatably before spending time
+on `lungmen.akn`.
+
+## 2. Requirements
+
+- Disposable and reproducible from a clean checkout with one command (`mise run poc:bootstrap`).
+- S3-compatible backup target, matching the real candidates (MinIO or Backblaze B2) closely enough that the
+  `backupStorageLocation` config is representative.
+- A real PVC-backed stateful app, not a synthetic file — the check must prove an _application_ reads its data back after
+  restore, matching what a real CNPG/Paperless PVC needs to guarantee.
+- Never touch `lungmen.akn`, `rhodes.akn`, or any real OpenBao/Cloudflare/S3 credentials.
+
+**Out of scope**: CSI-snapshot backups (needs real Proxmox CSI), Backblaze B2 specifically (MinIO's S3 API is sufficient
+to validate the Velero↔S3 plumbing), multi-cluster packaging (issue AC item 5 — deferred until this POC's approach is
+confirmed).
+
+---
+
+## 3. Sandbox Architecture
+
+```text
+kind cluster "velero-poc"
+├── velero-poc namespace
+│     └── MinIO (single-node, S3 API) — bucket "velero-backups"
+├── velero namespace
+│     ├── Velero deployment (Kopia backend, no CSI VolumeSnapshotLocation)
+│     └── node-agent DaemonSet (runs the actual Kopia backup/restore data path)
+└── velero-poc-app namespace
+      └── test-app StatefulSet (Postgres 17) — PVC "data-test-app-0"
+            bound to a static `local` PV (see §4.2 for why not kind's default SC)
+```
+
+MinIO is used instead of Garage (the S3-compatible store the
+[Pulumi/Crossplane POC](../20260702-pulumi-crossplane-evaluation/) uses) specifically because the real target for #1054
+is "existing MinIO or Backblaze B2" — matching the production backend keeps the `s3ForcePathStyle`/region config
+representative of what actually gets deployed.
+
+### 3.1 Kopia only backs up volumes you opt in
+
+`configuration.defaultVolumesToFsBackup: true` (Velero's global opt-out flag) was tried first — Velero accepted it
+without error, but the `data` PVC volume was silently never backed up (only the pod's two `emptyDir` volumes were). Not
+investigated to a root cause (would need tracing `volumeHelperImpl.ShouldPerformFSBackup` in Velero's source, several
+layers past what a quick POC warrants) — switched instead to the explicit, documented mechanism:
+
+```yaml
+metadata:
+  annotations:
+    backup.velero.io/backup-volumes: data
+```
+
+This is the officially documented way to select PVC volumes for fs-backup per-pod (`manifests/test-app.yaml`) and worked
+correctly. `configuration.defaultVolumesToFsBackup` is left unset in `manifests/velero-helmvalues.yaml`.
+
+### 3.2 kind's default StorageClass is incompatible with fs-backup
+
+kind's bundled `standard` StorageClass (`rancher.io/local-path`) provisions PVs of type `hostPath`. Velero's fs-backup
+explicitly refuses these:
+
+```text
+level=warning msg="Volume data in pod velero-poc-app/test-app-0 is a hostPath volume which is not supported for
+pod volume backup, skipping" logSource="pkg/podvolume/backupper.go:347"
+```
+
+This is a real, documented Velero limitation — not a config mistake. Velero's own e2e suite works around it by deploying
+the community `csi-driver-host-path` CSI driver, which produces properly CSI-typed PVs backed by the same underlying
+node storage. That driver is a full sidecar-heavy install (external-provisioner, external-attacher, external-resizer,
+node-driver-registrar, the plugin itself); a static `local`-type PV inside a `manual` StorageClass gets the same result
+— kubelet mounts the volume into the pod the identical way, and `local` isn't `hostPath` from Velero's check's point of
+view — for a fraction of the setup:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: velero-poc-data
+spec:
+  local:
+    path: /mnt/velero-poc-data # pre-created on the kind node, see scripts/bootstrap.sh
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions: [{ key: kubernetes.io/hostname, operator: In, values: [velero-poc-control-plane] }]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+```
+
+`manual` has `provisioner: kubernetes.io/no-provisioner` — no dynamic provisioning, so `Retain` (not `Delete`) is
+mandatory: nothing would ever execute the delete. After the simulated data-loss step deletes the PVC, the PV is left
+`Released` with a stale `claimRef`; `scripts/validate.sh` clears it
+(`kubectl patch pv ... --type json -p '[{"op": "remove", "path": "/spec/claimRef"}]'`) so the restored PVC (same name,
+new UID) binds to it normally.
+
+**On real infra this whole workaround doesn't apply.** `proxmox-csi-plugin`-provisioned PVs are genuinely CSI-typed
+(confirmed in [the CSI/CCM experiment](../20260617-proxmox-csi-ccm/)), so the hostPath exclusion never triggers there —
+this is purely a kind sandbox artifact.
+
+### 3.3 Postgres needs real ownership, not just group access
+
+`fsGroup` alone (group-writable via kubelet's recursive chown-to-group on mount) isn't enough for Postgres's entrypoint
+— it calls `chmod` on `PGDATA`, and `chmod` requires actual file _ownership_ (or `CAP_FOWNER`), which group membership
+doesn't grant. A root `initContainer` that `chown -R 70:70`s the PVC and the `run` emptyDir before the non-root Postgres
+container starts fixes it — but that init container must **not** inherit the main container's
+`capabilities.drop: [ALL]`, or even `uid 0` can't `chown` a path it doesn't already own (`CAP_CHOWN`/`CAP_FOWNER` are
+what actually grant that, not the UID).
+
+---
+
+## 4. Implementation
+
+### 4.1 Bootstrap
+
+```sh
+mise run poc:bootstrap
+```
+
+Idempotent — creates the kind cluster if missing (and the `/mnt/velero-poc-data` directory the static PV needs on the
+node), reuses it otherwise. Deploys, in order: MinIO + bucket-creation Job (`manifests/minio.yaml`), Velero via the
+official Helm chart (`manifests/velero-helmvalues.yaml`, Kopia backend, no VolumeSnapshotLocation), and the Postgres
+test app (`manifests/test-app.yaml`).
+
+```sh
+mise run poc:teardown   # deletes the kind cluster and everything in it
+```
+
+### 4.2 Validation
+
+```sh
+mise run poc:validate
+```
+
+Writes a timestamped marker row into Postgres, takes a Kopia backup (`velero backup create --wait`), deletes the whole
+`velero-poc-app` namespace (simulated data loss), clears the static PV's stale `claimRef`, restores from the backup
+(`velero restore create --wait`), and checks the marker row is back — see §3.2/§3.3 for why the sandbox needs the extra
+steps a real CSI-backed cluster wouldn't.
+
+### 4.3 Manifests
+
+| File                                               | Purpose                                                           |
+| -------------------------------------------------- | ----------------------------------------------------------------- |
+| `manifests/minio.yaml`                             | Single-node MinIO + bucket-creation Job (S3 backup target)        |
+| `manifests/velero-helmvalues.yaml`                 | Velero Helm values — Kopia backend, MinIO `backupStorageLocation` |
+| `manifests/test-app.yaml`                          | `manual` StorageClass + static `local` PV + Postgres StatefulSet  |
+| `scripts/bootstrap.sh`/`validate.sh`/`teardown.sh` | Sandbox lifecycle, wired into `mise run poc:*`                    |
+
+---
+
+## 5. Test Environment
+
+| Component  | Value                                       |
+| ---------- | ------------------------------------------- |
+| kind       | v0.32.0, node image `kindest/node:v1.36.1`  |
+| Velero     | chart 12.1.0, app v1.18.1, Kopia uploader   |
+| AWS plugin | `velero/velero-plugin-for-aws:v1.13.1`      |
+| MinIO      | `minio/minio:RELEASE.2025-09-07T16-13-09Z`  |
+| Test app   | `postgres:17-alpine`, 1Gi static `local` PV |
+
+---
+
+## 6. Validation Criteria
+
+```sh
+mise run poc:validate
+```
+
+| ID    | Criterion                                         |
+| ----- | ------------------------------------------------- |
+| V-001 | Backup phase is `Completed`                       |
+| V-002 | Namespace is gone after deletion                  |
+| V-003 | Restore phase is `Completed`                      |
+| V-004 | Namespace restored                                |
+| V-005 | PVC restored and `Bound`                          |
+| V-006 | Postgres ready after restore                      |
+| V-007 | Marker row survived the backup/restore round trip |
+
+---
+
+## 7. Results
+
+`mise run poc:bootstrap` followed by `mise run poc:validate` passes all 7 checks on a clean run:
+
+```text
+=== Results: 7 passed, 0 failed ===
+```
+
+Two real bugs were found and fixed along the way (both already folded into the manifests/scripts above, not left as open
+issues in this repeatable POC):
+
+- A `((pass++))`-style post-increment in `check()` evaluates to `0` (falsy) the first time `pass` goes from 0 → 1, which
+  trips `set -e` and silently kills the script right after the first `PASS` line. Fixed with `pass=$((pass + 1))`. Worth
+  a quick check if `docs/experiments/20260617-proxmox-csi-ccm/scripts/validate.sh` (same pattern) has ever been re-run
+  since — out of scope to fix here since that experiment is already closed.
+- The `minio-create-bucket` Job originally used `envFrom: secretRef` with secret keys named `root_user`/ `root_password`
+  while the script referenced `$MINIO_ROOT_USER`/`$MINIO_ROOT_PASSWORD` — `envFrom` propagates the secret's own key
+  names as env-var names, not a chosen alias. Fixed with explicit `env: valueFrom: secretKeyRef` entries.
+
+## 8. Conclusions
+
+**The Kopia file-system-backup path works** — a real Postgres PVC's data survives a full delete → restore cycle intact,
+using the exact backup-target shape (S3-compatible, MinIO/B2) and StatefulSet pattern #1054's real workloads (CNPG,
+Paperless, Immich) will use. This directly closes 2 of #1054's acceptance criteria: "Velero is deployed and healthy" and
+"at least one backup completes successfully, restore test passes".
+
+The `defaultVolumesToFsBackup` silent-skip (§3.1) is worth a note for whoever deploys this on a real cluster: use the
+explicit `backup.velero.io/backup-volumes` annotation per workload rather than the global flag, since the global flag
+was observed to silently exclude a PVC volume with zero error or warning — a false sense of "everything's covered"
+otherwise.
+
+Everything in §3.2 (hostPath exclusion, the static local-PV workaround) is a kind-sandbox-only concern.
+`proxmox-csi-plugin` PVs are genuinely CSI-typed, so this doesn't recur on `lungmen.akn`.
+
+### 8.1 Not answered by this POC
+
+- **CSI-snapshot incremental backups** — #1054's other acceptance-criteria item. Needs the real Proxmox CSI driver's
+  `VolumeSnapshotClass`; no local stand-in reproduces it faithfully enough to be worth building. Validate directly on
+  `lungmen.akn` once the baseline (this POC's Kopia path) is deployed there.
+- **Restore into a different cluster/namespace** — this POC restores into the same cluster it backed up from. #1054
+  doesn't require cross-cluster restore, so not tested.
+- **Backup of a real CNPG cluster** (vs. a plain Postgres StatefulSet) — CNPG's own backup/WAL-archiving machinery may
+  interact with a concurrent Kopia snapshot differently (e.g. needing pre/post hooks to fsfreeze). Worth a follow-up
+  check before relying on this for `lungmen.akn`'s actual CNPG clusters.
+
+### 8.2 Deferred
+
+- **Reusable ArgoCD Application packaging** (#1054 AC item 5) — this POC used raw manifests/Helm CLI for speed; an
+  ArgoCD-managed `Application` + per-cluster `velero.helmvalues/` overlay (matching this repo's `<chart>.helmvalues/`
+  convention) is the next step once the approach above is confirmed on real infra.
+- **Real S3 backup target** (MinIO already deployed in the homelab, or Backblaze B2) — this POC's in-cluster MinIO is
+  throwaway; the real deployment needs a persistent, external bucket per #1054's acceptance criteria.
+
+### 8.3 References
+
+- Issue: [#1054](https://github.com/chezmoidotsh/arcane/issues/1054)
+- Related: [#1051](https://github.com/chezmoidotsh/arcane/issues/1051) (EXP-2026-005, Proxmox CSI snapshotter requires
+  `root@pam` — the reason this POC exists), [#1028](https://github.com/chezmoidotsh/arcane/issues/1028)
+  (proxmox-csi-plugin rollout), [#1188](https://github.com/chezmoidotsh/arcane/issues/1188) (lungmen.akn recreation —
+  the eventual real-cluster target for this backup strategy)
+- Velero docs: <https://velero.io/docs/main/file-system-backup/>
+- Velero fs-backup hostPath limitation: `pkg/podvolume/backupper.go` (vmware-tanzu/velero, tag v1.18.1)
+- Proxmox CSI/CCM precedent: `docs/experiments/20260617-proxmox-csi-ccm/`
+
+---
+
+## 9. Actionable Next Steps
+
+- Deploy this same Kopia-backend Velero configuration on `lungmen.akn` against a real S3 target (MinIO or B2), with the
+  `backup.velero.io/backup-volumes` annotation pattern from §3.1, and repeat the backup/restore validation against a
+  real app's PVC.
+- Separately validate the CSI-snapshot path directly on `lungmen.akn` once `proxmox-csi-plugin` is live there — no local
+  stand-in for this, see [§8.1](#81-not-answered-by-this-poc).
+- Package as a reusable ArgoCD Application per #1054 AC item 5, once the above is confirmed.

--- a/docs/experiments/20260803-velero-pvc-backup/README.md
+++ b/docs/experiments/20260803-velero-pvc-backup/README.md
@@ -227,17 +227,6 @@ mise run poc:validate
 === Results: 7 passed, 0 failed ===
 ```
 
-Two real bugs were found and fixed along the way (both already folded into the manifests/scripts above, not left as open
-issues in this repeatable POC):
-
-- A `((pass++))`-style post-increment in `check()` evaluates to `0` (falsy) the first time `pass` goes from 0 → 1, which
-  trips `set -e` and silently kills the script right after the first `PASS` line. Fixed with `pass=$((pass + 1))`. Worth
-  a quick check if `docs/experiments/20260617-proxmox-csi-ccm/scripts/validate.sh` (same pattern) has ever been re-run
-  since — out of scope to fix here since that experiment is already closed.
-- The `minio-create-bucket` Job originally used `envFrom: secretRef` with secret keys named `root_user`/ `root_password`
-  while the script referenced `$MINIO_ROOT_USER`/`$MINIO_ROOT_PASSWORD` — `envFrom` propagates the secret's own key
-  names as env-var names, not a chosen alias. Fixed with explicit `env: valueFrom: secretKeyRef` entries.
-
 ## 8. Conclusions
 
 **The Kopia file-system-backup path works** — a real Postgres PVC's data survives a full delete → restore cycle intact,

--- a/docs/experiments/20260803-velero-pvc-backup/manifests/minio.yaml
+++ b/docs/experiments/20260803-velero-pvc-backup/manifests/minio.yaml
@@ -1,0 +1,158 @@
+# Single-node MinIO used as the S3-compatible backup target for this sandbox.
+# Raw manifests instead of a Helm chart, same reasoning as the Garage manifest
+# in docs/experiments/20260702-pulumi-crossplane-evaluation/manifests/garage.yaml:
+# this is throwaway sandbox infra, not a component under evaluation.
+#
+# MinIO is used here (not Garage) because the real target for #1054 is
+# "existing MinIO or Backblaze B2" — matching the production backend keeps
+# the S3 config (s3ForcePathStyle, region) representative.
+#
+# Storage is emptyDir: this sandbox is torn down and recreated on every run,
+# state resetting on every bootstrap is a feature, not a bug.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero-poc
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+  namespace: velero-poc
+type: Opaque
+stringData:
+  # Dev-only fixed values — this cluster is local, disposable, and never
+  # reachable from outside the pod.
+  root_user: veleropoc
+  root_password: veleropocsecretkey
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: velero-poc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+          args: ["server", "/data", "--console-address", ":9001"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-credentials
+                  key: root_user
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-credentials
+                  key: root_password
+          ports:
+            - name: s3-api
+              containerPort: 9000
+            - name: console
+              containerPort: 9001
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: velero-poc
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: s3-api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001
+---
+# One-shot bucket creation — MinIO doesn't auto-create buckets on boot the
+# way Garage's --default-bucket flag does.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-create-bucket
+  namespace: velero-poc
+spec:
+  backoffLimit: 6
+  template:
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mc
+          image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              mc alias set velero-poc http://minio.velero-poc.svc:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+              mc mb --ignore-existing velero-poc/velero-backups
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-credentials
+                  key: root_user
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-credentials
+                  key: root_password
+          volumeMounts:
+            - name: mc-config
+              mountPath: /.mc
+      volumes:
+        - name: mc-config
+          emptyDir: {}

--- a/docs/experiments/20260803-velero-pvc-backup/manifests/minio.yaml
+++ b/docs/experiments/20260803-velero-pvc-backup/manifests/minio.yaml
@@ -25,7 +25,7 @@ stringData:
   # Dev-only fixed values — this cluster is local, disposable, and never
   # reachable from outside the pod.
   root_user: veleropoc
-  root_password: veleropocsecretkey
+  root_password: veleropocsecretkey # checkov:skip=CKV_SECRET_6: Fake dev-only value, disposable local sandbox.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -42,15 +42,19 @@ spec:
       labels:
         app: minio
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 10001
+        runAsGroup: 10001
         seccompProfile:
           type: RuntimeDefault
       containers:
         - name: minio
           image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+          # imagePullPolicy left at the IfNotPresent default rather than
+          # Always: the tag is a pinned, immutable release, so re-pulling on
+          # every restart would just waste time. checkov:skip=CKV_K8S_15
           args: ["server", "/data", "--console-address", ":9001"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -62,18 +66,15 @@ spec:
               cpu: 50m
               memory: 128Mi
             limits:
+              cpu: 500m
               memory: 512Mi
+          # _FILE variants read the credential from a mounted volume instead
+          # of the pod's env — keeps it out of `kubectl describe pod` output.
           env:
-            - name: MINIO_ROOT_USER
-              valueFrom:
-                secretKeyRef:
-                  name: minio-credentials
-                  key: root_user
-            - name: MINIO_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: minio-credentials
-                  key: root_password
+            - name: MINIO_ROOT_USER_FILE
+              value: /etc/minio-credentials/root_user
+            - name: MINIO_ROOT_PASSWORD_FILE
+              value: /etc/minio-credentials/root_password
           ports:
             - name: s3-api
               containerPort: 9000
@@ -84,11 +85,29 @@ spec:
               mountPath: /data
             - name: tmp
               mountPath: /tmp
+            - name: credentials
+              mountPath: /etc/minio-credentials
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: s3-api
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: s3-api
+            initialDelaySeconds: 5
+            periodSeconds: 10
       volumes:
         - name: data
           emptyDir: {}
         - name: tmp
           emptyDir: {}
+        - name: credentials
+          secret:
+            secretName: minio-credentials
 ---
 apiVersion: v1
 kind: Service
@@ -118,41 +137,48 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 10001
+        runAsGroup: 10001
         seccompProfile:
           type: RuntimeDefault
       containers:
         - name: mc
           image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+          # imagePullPolicy left at IfNotPresent — see the minio container's
+          # comment above. checkov:skip=CKV_K8S_15
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
           command:
             - sh
             - -c
             - |
               set -eu
+              MINIO_ROOT_USER="$(cat /etc/minio-credentials/root_user)"
+              MINIO_ROOT_PASSWORD="$(cat /etc/minio-credentials/root_password)"
               mc alias set velero-poc http://minio.velero-poc.svc:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
               mc mb --ignore-existing velero-poc/velero-backups
-          env:
-            - name: MINIO_ROOT_USER
-              valueFrom:
-                secretKeyRef:
-                  name: minio-credentials
-                  key: root_user
-            - name: MINIO_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: minio-credentials
-                  key: root_password
           volumeMounts:
             - name: mc-config
               mountPath: /.mc
+            - name: credentials
+              mountPath: /etc/minio-credentials
+              readOnly: true
       volumes:
         - name: mc-config
           emptyDir: {}
+        - name: credentials
+          secret:
+            secretName: minio-credentials

--- a/docs/experiments/20260803-velero-pvc-backup/manifests/test-app.yaml
+++ b/docs/experiments/20260803-velero-pvc-backup/manifests/test-app.yaml
@@ -1,0 +1,155 @@
+# Minimal stateful app to prove Kopia file-level backup/restore round-trips
+# real PV data. Postgres + a written marker row (not just raw files) so the
+# restore check proves an application actually reads its data back, not just
+# that bytes survived on disk — closer to what backing up a real CNPG/
+# Paperless PVC needs to guarantee. Pattern reused from
+# docs/experiments/20260617-proxmox-csi-ccm/manifests/test-pvc.yaml.
+#
+# Uses a static `local`-type PV, not kind's default "standard" StorageClass.
+# kind's bundled local-path-provisioner creates PVs of type hostPath, which
+# Velero's fs-backup explicitly refuses ("is a hostPath volume which is not
+# supported for pod volume backup, skipping" — pkg/podvolume/backupper.go).
+# `local` PVs are mounted the same way but aren't hostPath-typed, so Kopia
+# backs them up fine — the same reason Velero's own e2e suite uses the CSI
+# hostpath driver (a heavier stand-in) rather than local-path-provisioner.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero-poc-app
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: manual
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: velero-poc-data
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  # Retain (not Delete): "manual" has no provisioner, so nothing would ever
+  # execute a Delete — a PVC deletion would leave the PV stuck Failed. The
+  # POC's restore step clears spec.claimRef to make it bindable again
+  # instead (see scripts/validate.sh).
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+  local:
+    path: /mnt/velero-poc-data
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - velero-poc-control-plane
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-app
+  namespace: velero-poc-app
+spec:
+  serviceName: test-app
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+      annotations:
+        # Explicit opt-in, the documented, reliable way to select which pod
+        # volumes Kopia backs up. configuration.defaultVolumesToFsBackup
+        # (Velero's global opt-out setting) was tried first and silently
+        # skipped this PVC-backed volume with no error or log line — not
+        # investigated further, this annotation is the supported mechanism
+        # for exactly this per-pod case anyway. See README §3 for details.
+        backup.velero.io/backup-volumes: data
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        # kind's local-path-provisioner hostPath volumes are root-owned.
+        # postgres's entrypoint calls chmod on PGDATA, which needs actual
+        # ownership (not just fsGroup's group-write bit) — chown as root
+        # once before the non-root postgres container starts.
+        - name: fix-permissions
+          image: postgres:17-alpine
+          command: ["sh", "-c", "chown -R 70:70 /var/lib/postgresql/data /var/run/postgresql"]
+          securityContext:
+            # Needs CAP_CHOWN/CAP_FOWNER to chown paths it doesn't already
+            # own — dropping ALL would leave even uid 0 unable to chown.
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: run
+              mountPath: /var/run/postgresql
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 70
+            runAsGroup: 70
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          env:
+            - name: POSTGRES_DB
+              value: testdb
+            - name: POSTGRES_USER
+              value: test
+            - name: POSTGRES_PASSWORD
+              value: test
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: tmp
+              mountPath: /tmp
+            - name: run
+              mountPath: /var/run/postgresql
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "test"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "test"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: manual
+        resources:
+          requests:
+            storage: 1Gi

--- a/docs/experiments/20260803-velero-pvc-backup/manifests/test-app.yaml
+++ b/docs/experiments/20260803-velero-pvc-backup/manifests/test-app.yaml
@@ -75,6 +75,7 @@ spec:
         # for exactly this per-pod case anyway. See README §3 for details.
         backup.velero.io/backup-volumes: data
     spec:
+      automountServiceAccountToken: false
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -90,6 +91,12 @@ spec:
             # Needs CAP_CHOWN/CAP_FOWNER to chown paths it doesn't already
             # own — dropping ALL would leave even uid 0 unable to chown.
             allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data

--- a/docs/experiments/20260803-velero-pvc-backup/manifests/velero-helmvalues.yaml
+++ b/docs/experiments/20260803-velero-pvc-backup/manifests/velero-helmvalues.yaml
@@ -19,6 +19,7 @@ deployNodeAgent: true
 
 credentials:
   useSecret: true
+  # checkov:skip=CKV_SECRET_6: This is a Secret *name* reference, not a credential value.
   existingSecret: cloud-credentials
 
 configuration:

--- a/docs/experiments/20260803-velero-pvc-backup/manifests/velero-helmvalues.yaml
+++ b/docs/experiments/20260803-velero-pvc-backup/manifests/velero-helmvalues.yaml
@@ -1,0 +1,57 @@
+# Velero, Kopia backend only (issue #1054's baseline path). The CSI-snapshot
+# path is NOT configured here — it needs the real Proxmox CSI driver's
+# VolumeSnapshotClass, which doesn't exist in a local kind sandbox. See the
+# experiment README for how that part gets validated separately, on real
+# infra.
+image:
+  repository: docker.io/velero/velero
+  tag: v1.18.1
+
+initContainers:
+  - name: velero-plugin-for-aws
+    image: velero/velero-plugin-for-aws:v1.13.1
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /target
+        name: plugins
+
+deployNodeAgent: true
+
+credentials:
+  useSecret: true
+  existingSecret: cloud-credentials
+
+configuration:
+  # Kopia only backs up a pod's volumes when opted in. Using the explicit
+  # per-pod backup.velero.io/backup-volumes annotation (manifests/test-app.yaml)
+  # instead of this global opt-out flag — see that manifest's comment for why.
+  backupStorageLocation:
+    - name: default
+      provider: aws
+      bucket: velero-backups
+      default: true
+      credential:
+        name: cloud-credentials
+        key: cloud
+      config:
+        region: minio
+        s3Url: http://minio.velero-poc.svc:9000
+        s3ForcePathStyle: "true"
+  # No CSI VolumeSnapshotLocation in this sandbox — that path needs the real
+  # Proxmox CSI driver's VolumeSnapshotClass, which doesn't exist in kind.
+  volumeSnapshotLocation: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 256Mi
+
+nodeAgent:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 256Mi

--- a/docs/experiments/20260803-velero-pvc-backup/scripts/bootstrap.sh
+++ b/docs/experiments/20260803-velero-pvc-backup/scripts/bootstrap.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Bootstrap for the Velero local POC (issue #1054)
+# =============================================================================
+# Creates a disposable kind cluster, deploys MinIO as the S3-compatible
+# backup target, installs Velero (Kopia backend only), and deploys the
+# Postgres test app used for the backup/restore validation.
+#
+# Usage:
+#   mise run poc:bootstrap
+#   ./scripts/bootstrap.sh
+# =============================================================================
+
+set -euo pipefail
+
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-velero-poc}"
+VELERO_CHART_VERSION="12.1.0"
+EXPERIMENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+check_dependencies() {
+  local deps=("kind" "kubectl" "helm" "velero")
+  local missing=()
+  for dep in "${deps[@]}"; do
+    command -v "${dep}" &>/dev/null || missing+=("${dep}")
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    log_error "Missing dependencies: ${missing[*]} — run 'mise install' in this directory."
+    exit 1
+  fi
+}
+
+create_cluster() {
+  mkdir -p "$(dirname "${KUBECONFIG:-${HOME}/.kube/config}")"
+  if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+    log_info "kind cluster ${CLUSTER_NAME} already exists, reusing it"
+  else
+    log_info "Creating kind cluster: ${CLUSTER_NAME}"
+    kind create cluster --name "${CLUSTER_NAME}"
+  fi
+  kubectl config use-context "kind-${CLUSTER_NAME}"
+  # Backing directory for the static `local` PV (manifests/test-app.yaml) —
+  # `local` volumes, unlike hostPath, require the path to pre-exist.
+  docker exec "${CLUSTER_NAME}-control-plane" mkdir -p /mnt/velero-poc-data
+}
+
+deploy_minio() {
+  log_info "Deploying MinIO (S3-compatible backup target)"
+  # Job pod templates are immutable — delete before reapplying so reruns
+  # against an existing cluster (e.g. after fixing the manifest) don't fail.
+  kubectl -n velero-poc delete job minio-create-bucket --ignore-not-found
+  kubectl apply -f "${EXPERIMENT_DIR}/manifests/minio.yaml"
+  kubectl -n velero-poc rollout status deployment/minio --timeout=120s
+  kubectl -n velero-poc wait --for=condition=complete job/minio-create-bucket --timeout=120s
+  log_success "MinIO ready, bucket velero-backups created"
+}
+
+install_velero() {
+  log_info "Installing Velero (chart ${VELERO_CHART_VERSION}, Kopia backend)"
+
+  helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts 2>/dev/null || true
+  helm repo update vmware-tanzu
+
+  kubectl create namespace velero --dry-run=client -o yaml | kubectl apply -f -
+
+  # Velero's AWS plugin expects a static credentials file — MinIO's root
+  # user/password stand in for an IAM access key/secret pair.
+  kubectl -n velero create secret generic cloud-credentials \
+    --from-literal=cloud="[default]
+aws_access_key_id=veleropoc
+aws_secret_access_key=veleropocsecretkey" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  helm upgrade --install velero vmware-tanzu/velero \
+    --version "${VELERO_CHART_VERSION}" \
+    --namespace velero \
+    -f "${EXPERIMENT_DIR}/manifests/velero-helmvalues.yaml" \
+    --wait --timeout 180s
+
+  kubectl -n velero rollout status deployment/velero --timeout=120s
+  kubectl -n velero rollout status daemonset/node-agent --timeout=120s
+
+  log_success "Velero installed"
+}
+
+deploy_test_app() {
+  log_info "Deploying Postgres test app (PVC to back up)"
+  kubectl apply -f "${EXPERIMENT_DIR}/manifests/test-app.yaml"
+  kubectl -n velero-poc-app rollout status statefulset/test-app --timeout=180s
+  log_success "Test app ready"
+}
+
+print_instructions() {
+  log_success "=========================================="
+  log_success "Bootstrap complete"
+  log_success "=========================================="
+  echo ""
+  echo "Next steps:"
+  echo "  mise run poc:validate   # run the backup/restore cycle"
+  echo "  mise run poc:teardown   # delete the kind cluster"
+}
+
+main() {
+  log_info "Bootstrapping Velero local POC (cluster: ${CLUSTER_NAME})"
+  check_dependencies
+  create_cluster
+  deploy_minio
+  install_velero
+  deploy_test_app
+  print_instructions
+}
+
+main "$@"

--- a/docs/experiments/20260803-velero-pvc-backup/scripts/teardown.sh
+++ b/docs/experiments/20260803-velero-pvc-backup/scripts/teardown.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Deletes the local kind cluster for the Velero POC and everything in it.
+set -euo pipefail
+
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-velero-poc}"
+
+if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+  kind delete cluster --name "${CLUSTER_NAME}"
+  echo "[SUCCESS] kind cluster ${CLUSTER_NAME} deleted"
+else
+  echo "[INFO] kind cluster ${CLUSTER_NAME} does not exist, nothing to do"
+fi

--- a/docs/experiments/20260803-velero-pvc-backup/scripts/validate.sh
+++ b/docs/experiments/20260803-velero-pvc-backup/scripts/validate.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Backup/restore validation for the Velero local POC (issue #1054)
+# =============================================================================
+# Writes a marker row into the test app's Postgres DB, takes a Kopia backup,
+# deletes the whole namespace (simulating data loss), restores from the
+# backup, and checks the marker row is back. Proves the round trip preserves
+# real application data, not just that some bytes survived on disk.
+#
+# Usage:
+#   mise run poc:validate
+#   ./scripts/validate.sh
+# =============================================================================
+
+set -euo pipefail
+
+NS="velero-poc-app"
+POD="test-app-0"
+BACKUP_NAME="test-backup-$(date +%s)"
+MARKER="velero-poc-$(date +%s)"
+
+pass=0
+fail=0
+
+check() {
+  local id="$1" desc="$2" cmd="$3"
+  if eval "${cmd}" &>/dev/null; then
+    echo "PASS [${id}] ${desc}"
+    pass=$((pass + 1))
+  else
+    echo "FAIL [${id}] ${desc}"
+    fail=$((fail + 1))
+  fi
+}
+
+psql_exec() {
+  kubectl -n "${NS}" exec "${POD}" -- psql -U test -d testdb -tAc "$1"
+}
+
+echo "=== Velero Local POC — Backup/Restore Validation ==="
+echo ""
+
+echo "--- Writing marker data (${MARKER}) ---"
+psql_exec "CREATE TABLE IF NOT EXISTS velero_poc_marker (value text);"
+psql_exec "INSERT INTO velero_poc_marker (value) VALUES ('${MARKER}');"
+
+echo "--- Creating backup ${BACKUP_NAME} ---"
+velero backup create "${BACKUP_NAME}" --include-namespaces "${NS}" --wait
+
+check "V-001" "Backup phase is Completed" \
+  "velero backup describe ${BACKUP_NAME} --details 2>/dev/null | grep -q 'Phase:.*Completed'"
+
+echo "--- Deleting namespace ${NS} (simulated data loss) ---"
+kubectl delete namespace "${NS}" --wait --timeout=120s
+
+check "V-002" "Namespace is gone after deletion" \
+  "! kubectl get namespace ${NS} &>/dev/null"
+
+# The static local PV (manifests/test-app.yaml) has no dynamic provisioner,
+# so deleting its PVC leaves it "Released" with a stale claimRef instead of
+# being deleted/recreated. Clear the claimRef so it's bindable again — the
+# restored PVC (same name, new UID) then binds to it normally.
+echo "--- Making the local PV bindable again for restore ---"
+kubectl patch pv velero-poc-data --type json -p '[{"op": "remove", "path": "/spec/claimRef"}]' 2>/dev/null || true
+
+echo "--- Restoring from ${BACKUP_NAME} ---"
+RESTORE_NAME="${BACKUP_NAME}-restore"
+velero restore create "${RESTORE_NAME}" --from-backup "${BACKUP_NAME}" --wait
+
+check "V-003" "Restore phase is Completed" \
+  "velero restore describe ${RESTORE_NAME} --details 2>/dev/null | grep -q 'Phase:.*Completed'"
+
+check "V-004" "Namespace restored" \
+  "kubectl get namespace ${NS} &>/dev/null"
+
+echo "--- Waiting for restored StatefulSet to become ready ---"
+kubectl -n "${NS}" rollout status statefulset/test-app --timeout=180s || true
+
+check "V-005" "PVC restored and Bound" \
+  "kubectl -n ${NS} get pvc data-test-app-0 -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Bound"
+
+check "V-006" "Postgres ready after restore" \
+  "kubectl -n ${NS} exec ${POD} -- pg_isready -U test"
+
+check "V-007" "Marker row survived backup/restore round trip" \
+  "[ \"\$(psql_exec \"SELECT value FROM velero_poc_marker WHERE value = '${MARKER}';\")\" = '${MARKER}' ]"
+
+echo ""
+echo "=== Results: ${pass} passed, ${fail} failed ==="
+exit "${fail}"


### PR DESCRIPTION
## Summary

Documents the EXP-2026-007 local proof of concept for the Kopia file-system-backup path of issue 1054 (Velero PVC backup for Proxmox-based Talos clusters). Everything runs in a disposable local kind cluster — MinIO stands in for the real S3 target (MinIO/Backblaze B2), a Postgres StatefulSet stands in for a real stateful app. The POC confirms a real PVC's data survives a full backup → delete → restore cycle intact, closing 2 of issue 1054's acceptance criteria before any real cluster is touched.

**Related Issue:** #1054

## Changes Made

### Experiment: EXP-2026-007

- **[`docs/experiments/20260803-velero-pvc-backup/README.md`](docs/experiments/20260803-velero-pvc-backup/README.md)** — Full write-up: sandbox architecture, 3 findings worth flagging for the real deployment, validation results, conclusions, and next steps
- **[`docs/experiments/20260803-velero-pvc-backup/manifests/minio.yaml`](docs/experiments/20260803-velero-pvc-backup/manifests/minio.yaml)** — Single-node MinIO + bucket-creation Job (S3-compatible backup target)
- **[`docs/experiments/20260803-velero-pvc-backup/manifests/velero-helmvalues.yaml`](docs/experiments/20260803-velero-pvc-backup/manifests/velero-helmvalues.yaml)** — Velero Helm values: Kopia backend, MinIO `backupStorageLocation`, no CSI `VolumeSnapshotLocation`
- **[`docs/experiments/20260803-velero-pvc-backup/manifests/test-app.yaml`](docs/experiments/20260803-velero-pvc-backup/manifests/test-app.yaml)** — `manual` StorageClass + static `local` PV + Postgres StatefulSet used to validate the backup/restore round trip
- **[`scripts/bootstrap.sh`](docs/experiments/20260803-velero-pvc-backup/scripts/bootstrap.sh), [`validate.sh`](docs/experiments/20260803-velero-pvc-backup/scripts/validate.sh), [`teardown.sh`](docs/experiments/20260803-velero-pvc-backup/scripts/teardown.sh)** — Sandbox lifecycle, wired into `mise run poc:*`

## Technical Impact

### Experiment Findings

All 7 validation checks pass on a clean run (backup completes, namespace deletion, restore completes, PVC rebinds, Postgres comes back up, and a marker row written before deletion is present after restore). Three findings worth carrying into the real `lungmen.akn` deployment:

- `configuration.defaultVolumesToFsBackup` (Velero's global opt-out flag) silently skipped the PVC volume with no error — use the explicit `backup.velero.io/backup-volumes` annotation per workload instead.
- kind's default StorageClass provisions `hostPath`-typed PVs, which Velero's fs-backup explicitly refuses. Worked around locally with a static `local`-type PV — `proxmox-csi-plugin` PVs are genuinely CSI-typed, so this doesn't recur on real infra.
- A non-root container needs actual file ownership (not just `fsGroup` group-write) to `chmod` its own data directory — a root init-container with `chown` and no capability drop handles this.

CSI-snapshot incremental backups (the other half of issue 1054) are out of scope for this local POC — that needs the real Proxmox CSI driver's `VolumeSnapshotClass` and can only be validated on an actual cluster.

## Testing Validation

- [x] `mise run poc:bootstrap` stands up MinIO, Velero, and the test app cleanly
- [x] `mise run poc:validate` passes all 7 checks (V-001 through V-007) on a clean run
- [x] README renders correctly on GitHub (ToC anchors, code blocks, relative links)

## Future Enhancements

- Deploy this Kopia-backend configuration on `lungmen.akn` against a real S3 target and repeat the validation against a real app's PVC
- Validate the CSI-snapshot path directly on `lungmen.akn` once `proxmox-csi-plugin` is live there
- Package as a reusable ArgoCD Application per issue 1054's acceptance criteria

## Related Issues

Addresses #1054

---
<sub>AI-assisted with Claude:claude-sonnet-5 under human supervision</sub>
