### PR TITLE
Deploy Velero for PVC backup and restore on lungmen

### DIFF
--- a/projects/lungmen.akn/dist/apps/actual-budget/apps.v1.StatefulSet.actual-budget.yaml
+++ b/projects/lungmen.akn/dist/apps/actual-budget/apps.v1.StatefulSet.actual-budget.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: actual-budget
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes: persistent
       labels:
         app.kubernetes.io/instance: actual-budget
         app.kubernetes.io/name: actual-budget

--- a/projects/lungmen.akn/dist/apps/atuin/apps.v1.Deployment.atuin.yaml
+++ b/projects/lungmen.akn/dist/apps/atuin/apps.v1.Deployment.atuin.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/name: atuin
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes: atuin-data
       labels:
         app.kubernetes.io/instance: atuin
         app.kubernetes.io/name: atuin

--- a/projects/lungmen.akn/dist/apps/jellyfin/apps.v1.StatefulSet.jellyfin.yaml
+++ b/projects/lungmen.akn/dist/apps/jellyfin/apps.v1.StatefulSet.jellyfin.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: jellyfin
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes: persistent
       labels:
         app.kubernetes.io/instance: jellyfin
         app.kubernetes.io/name: jellyfin

--- a/projects/lungmen.akn/dist/apps/paperless-ngx/apps.v1.StatefulSet.paperless-ngx.yaml
+++ b/projects/lungmen.akn/dist/apps/paperless-ngx/apps.v1.StatefulSet.paperless-ngx.yaml
@@ -23,6 +23,8 @@ spec:
   serviceName: paperless-ngx
   template:
     metadata:
+      annotations:
+        backup.velero.io/backup-volumes: persistent-storage
       labels:
         app.kubernetes.io/component: webserver
         app.kubernetes.io/instance: paperless-ngx

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/.application.patch
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/.application.patch
@@ -1,0 +1,32 @@
+apiVersion: arcane.chezmoi.sh/v1alpha1
+kind: ApplicationPatch
+metadata: {}
+spec:
+  info:
+    # -- Application metadata
+    - name: Description
+      value: Backup and restore for Kubernetes cluster resources and persistent volumes
+    - name: Category
+      value: Storage / Backup
+    - name: Version
+      # renovate: datasource=helm depName=velero registryUrl=https://vmware-tanzu.github.io/helm-charts
+      value: "12.1.0"
+    # -- Documentation & Resources
+    - name: Documentation
+      value: https://velero.io/docs/main/
+    - name: GitHub Repository
+      value: https://github.com/vmware-tanzu/velero
+
+  syncPolicy:
+    automated:
+      enabled: false # Backup/restore tooling — avoid automatic updates that could disrupt in-flight backups
+
+    # node-agent's DaemonSet needs privileged/hostPath access (mounting
+    # kubelet's pod volume dir on each node for Kopia's fs-backup data
+    # path) -- the "baseline" Pod Security default rejects that, so
+    # relax enforcement for the namespace ArgoCD creates for this
+    # Application.
+    managedNamespaceMetadata:
+      labels:
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/enforce-version: v1.33

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/apps.v1.DaemonSet.node-agent.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/apps.v1.DaemonSet.node-agent.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/version: 1.18.1
+    helm.sh/chart: velero-12.1.0
+  name: node-agent
+  namespace: velero-system
+spec:
+  selector:
+    matchLabels:
+      name: node-agent
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/instance: velero
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: velero
+        app.kubernetes.io/version: 1.18.1
+        helm.sh/chart: velero-12.1.0
+        name: node-agent
+        role: node-agent
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - node-agent
+        - server
+        command:
+        - /velero
+        env:
+        - name: VELERO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: VELERO_SCRATCH_DIR
+          value: /scratch
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /credentials/cloud
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /credentials/cloud
+        - name: AZURE_CREDENTIALS_FILE
+          value: /credentials/cloud
+        - name: ALIBABA_CLOUD_CREDENTIALS_FILE
+          value: /credentials/cloud
+        image: oci.chezmoi.sh/docker.io/velero/velero:v1.18.1
+        imagePullPolicy: IfNotPresent
+        name: node-agent
+        ports:
+        - containerPort: 8085
+          name: http-monitoring
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext: null
+        volumeMounts:
+        - mountPath: /credentials
+          name: cloud-credentials
+        - mountPath: /host_pods
+          mountPropagation: HostToContainer
+          name: host-pods
+        - mountPath: /host_plugins
+          mountPropagation: HostToContainer
+          name: host-plugins
+        - mountPath: /scratch
+          name: scratch
+      dnsPolicy: ClusterFirst
+      securityContext:
+        runAsUser: 0
+      serviceAccountName: velero-server
+      terminationGracePeriodSeconds: 3600
+      volumes:
+      - name: cloud-credentials
+        secret:
+          secretName: velero-credentials
+      - hostPath:
+          path: /var/lib/kubelet/pods
+        name: host-pods
+      - hostPath:
+          path: /var/lib/kubelet/plugins
+        name: host-plugins
+      - emptyDir: {}
+        name: scratch

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/apps.v1.Deployment.velero.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/apps.v1.Deployment.velero.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/version: 1.18.1
+    component: velero
+    helm.sh/chart: velero-12.1.0
+  name: velero
+  namespace: velero-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: velero
+      app.kubernetes.io/name: velero
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8085"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/instance: velero
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: velero
+        app.kubernetes.io/version: 1.18.1
+        helm.sh/chart: velero-12.1.0
+        name: velero
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - server
+        - --uploader-type=kopia
+        - --repo-maintenance-job-configmap=velero-repo-maintenance
+        command:
+        - /velero
+        env:
+        - name: VELERO_SCRATCH_DIR
+          value: /scratch
+        - name: VELERO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: LD_LIBRARY_PATH
+          value: /plugins
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /credentials/cloud
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /credentials/cloud
+        - name: AZURE_CREDENTIALS_FILE
+          value: /credentials/cloud
+        - name: ALIBABA_CLOUD_CREDENTIALS_FILE
+          value: /credentials/cloud
+        image: oci.chezmoi.sh/docker.io/velero/velero:v1.18.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /metrics
+            port: http-monitoring
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: velero
+        ports:
+        - containerPort: 8085
+          name: http-monitoring
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /metrics
+            port: http-monitoring
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /plugins
+          name: plugins
+        - mountPath: /credentials
+          name: cloud-credentials
+        - mountPath: /scratch
+          name: scratch
+      dnsPolicy: ClusterFirst
+      initContainers:
+      - image: oci.chezmoi.sh/docker.io/velero/velero-plugin-for-aws:v1.13.1
+        imagePullPolicy: IfNotPresent
+        name: velero-plugin-for-aws
+        volumeMounts:
+        - mountPath: /target
+          name: plugins
+      restartPolicy: Always
+      serviceAccountName: velero-server
+      terminationGracePeriodSeconds: 3600
+      volumes:
+      - name: cloud-credentials
+        secret:
+          secretName: velero-credentials
+      - emptyDir: {}
+        name: plugins
+      - emptyDir: {}
+        name: scratch

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/batch.v1.Job.velero-upgrade-crds.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/batch.v1.Job.velero-upgrade-crds.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    helm.sh/hook: pre-install,pre-upgrade,pre-rollback
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "5"
+  labels:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    helm.sh/chart: velero-12.1.0
+  name: velero-upgrade-crds
+  namespace: velero-system
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: velero-upgrade-crds
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - install
+        - --crds-only
+        - --apply
+        command:
+        - /velero
+        image: oci.chezmoi.sh/docker.io/velero/velero:v1.18.1
+        imagePullPolicy: IfNotPresent
+        name: velero
+      restartPolicy: OnFailure
+      serviceAccountName: velero-server-upgrade-crds

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/batch.v1.Job.velero-upgrade-crds.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/batch.v1.Job.velero-upgrade-crds.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   annotations:
     argocd.argoproj.io/hook: PreSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
     helm.sh/hook: pre-install,pre-upgrade,pre-rollback
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "5"

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/cilium.io.v2.CiliumNetworkPolicy.allow-to-kube-apiserver.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/cilium.io.v2.CiliumNetworkPolicy.allow-to-kube-apiserver.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows all velero-system pods (controller + node-agent) to reach the Kubernetes API server.
+      Required for watching/managing Backup, Restore, and PodVolumeBackup custom resources plus PVCs
+      cluster-wide.
+  name: allow-to-kube-apiserver
+  namespace: velero-system
+spec:
+  egress:
+  - toEntities:
+    - kube-apiserver
+  endpointSelector: {}

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/cilium.io.v2.CiliumNetworkPolicy.allow-to-s3-backup.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/cilium.io.v2.CiliumNetworkPolicy.allow-to-s3-backup.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows all velero-system pods to reach the S3-compatible backup endpoint (s3.chezmoi.sh:443)
+      for Kopia backup/restore data transfer.
+  name: allow-to-s3-backup
+  namespace: velero-system
+spec:
+  egress:
+  - toFQDNs:
+    - matchName: s3.chezmoi.sh
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: TCP
+  endpointSelector: {}

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/cilium.io.v2.CiliumNetworkPolicy.default-hardened.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/cilium.io.v2.CiliumNetworkPolicy.default-hardened.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Default hardened network policy for the velero-system namespace that implements a secure
+      baseline by denying all traffic except explicitly allowed connections. Permits intra-namespace
+      communication and DNS resolution to kube-system, while blocking all other traffic by default.
+  name: default-hardened
+  namespace: velero-system
+spec:
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: kube-dns
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      rules:
+        dns:
+        - matchPattern: '*'
+  - toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: velero-system
+  endpointSelector: {}
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: velero-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/core.v1.ConfigMap.velero-repo-maintenance.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/core.v1.ConfigMap.velero-repo-maintenance.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+data:
+  global: |
+    {
+      "keepLatestMaintenanceJobs": 3
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    helm.sh/chart: velero-12.1.0
+  name: velero-repo-maintenance
+  namespace: velero-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/core.v1.Service.velero.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/core.v1.Service.velero.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/version: 1.18.1
+    helm.sh/chart: velero-12.1.0
+  name: velero
+  namespace: velero-system
+spec:
+  ports:
+  - name: http-monitoring
+    port: 8085
+    targetPort: http-monitoring
+  selector:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/name: velero
+    name: velero
+  type: ClusterIP

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/core.v1.ServiceAccount.velero-server-upgrade-crds.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/core.v1.ServiceAccount.velero-server-upgrade-crds.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,pre-rollback
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-4"
+  labels:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    helm.sh/chart: velero-12.1.0
+  name: velero-server-upgrade-crds
+  namespace: velero-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/core.v1.ServiceAccount.velero-server-upgrade-crds.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/core.v1.ServiceAccount.velero-server-upgrade-crds.yaml
@@ -4,6 +4,7 @@ automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   annotations:
+    argocd.argoproj.io/hook: PreSync
     helm.sh/hook: pre-install,pre-upgrade,pre-rollback
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "-4"

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/core.v1.ServiceAccount.velero-server.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/core.v1.ServiceAccount.velero-server.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    helm.sh/chart: velero-12.1.0
+  name: velero-server
+  namespace: velero-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/external-secrets.io.v1.ExternalSecret.velero-credentials.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/external-secrets.io.v1.ExternalSecret.velero-credentials.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: velero-credentials
+  namespace: velero-system
+spec:
+  dataFrom:
+  - extract:
+      key: lungmen.akn/velero/backup/s3.chezmoi.sh
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  target:
+    name: velero-credentials
+    template:
+      data:
+        cloud: |
+          [default]
+          aws_access_key_id={{ .access_key_id }}
+          aws_secret_access_key={{ .secret_access_key }}
+      engineVersion: v2
+      type: Opaque

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.ClusterRole.velero-upgrade-crds.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.ClusterRole.velero-upgrade-crds.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,pre-rollback
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+  labels:
+    app.kubernetes.io/component: upgrade-crds
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    helm.sh/chart: velero-12.1.0
+  name: velero-upgrade-crds
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - patch
+  - update
+  - get
+  - list

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.ClusterRole.velero-upgrade-crds.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.ClusterRole.velero-upgrade-crds.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    argocd.argoproj.io/hook: PreSync
     helm.sh/hook: pre-install,pre-upgrade,pre-rollback
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "-5"

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.ClusterRoleBinding.velero-server.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.ClusterRoleBinding.velero-server.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    helm.sh/chart: velero-12.1.0
+  name: velero-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: velero-server
+  namespace: velero-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.ClusterRoleBinding.velero-upgrade-crds.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.ClusterRoleBinding.velero-upgrade-crds.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
+    argocd.argoproj.io/hook: PreSync
     helm.sh/hook: pre-install,pre-upgrade,pre-rollback
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "-3"

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.ClusterRoleBinding.velero-upgrade-crds.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.ClusterRoleBinding.velero-upgrade-crds.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,pre-rollback
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-3"
+  labels:
+    app.kubernetes.io/component: upgrade-crds
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    helm.sh/chart: velero-12.1.0
+  name: velero-upgrade-crds
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: velero-upgrade-crds
+subjects:
+- kind: ServiceAccount
+  name: velero-server-upgrade-crds
+  namespace: velero-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.Role.velero-server.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.Role.velero-server.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    helm.sh/chart: velero-12.1.0
+  name: velero-server
+  namespace: velero-system
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.RoleBinding.velero-server.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/rbac.authorization.k8s.io.v1.RoleBinding.velero-server.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    helm.sh/chart: velero-12.1.0
+  name: velero-server
+  namespace: velero-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: velero-server
+subjects:
+- kind: ServiceAccount
+  name: velero-server
+  namespace: velero-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/velero.io.v1.BackupStorageLocation.default.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/velero.io.v1.BackupStorageLocation.default.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  labels:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/version: 1.18.1
+    helm.sh/chart: velero-12.1.0
+  name: default
+  namespace: velero-system
+spec:
+  accessMode: ReadWrite
+  config:
+    region: fr-par-1
+    s3ForcePathStyle: "true"
+    s3Url: https://s3.chezmoi.sh
+  credential:
+    key: cloud
+    name: velero-credentials
+  default: true
+  objectStorage:
+    bucket: velero-lungmen-akn
+  provider: aws

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/velero.io.v1.Schedule.actual-budget.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/velero.io.v1.Schedule.actual-budget.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: actual-budget
+  namespace: velero-system
+spec:
+  schedule: 0 */12 * * *
+  template:
+    includedNamespaces:
+    - actual-budget
+    includedResources:
+    - pods
+    - persistentvolumeclaims
+    - persistentvolumes
+    storageLocation: default
+    ttl: 168h0m0s

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/velero.io.v1.Schedule.atuin.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/velero.io.v1.Schedule.atuin.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: atuin
+  namespace: velero-system
+spec:
+  schedule: 0 */12 * * *
+  template:
+    includedNamespaces:
+    - atuin
+    includedResources:
+    - pods
+    - persistentvolumeclaims
+    - persistentvolumes
+    storageLocation: default
+    ttl: 168h0m0s

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/velero.io.v1.Schedule.jellyfin.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/velero.io.v1.Schedule.jellyfin.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: jellyfin
+  namespace: velero-system
+spec:
+  schedule: 0 */12 * * *
+  template:
+    includedNamespaces:
+    - jellyfin
+    includedResources:
+    - pods
+    - persistentvolumeclaims
+    - persistentvolumes
+    storageLocation: default
+    ttl: 168h0m0s

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/velero.io.v1.Schedule.paperless-ngx.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/velero/velero.io.v1.Schedule.paperless-ngx.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: paperless-ngx
+  namespace: velero-system
+spec:
+  schedule: 0 */12 * * *
+  template:
+    includedNamespaces:
+    - paperless-ngx
+    includedResources:
+    - pods
+    - persistentvolumeclaims
+    - persistentvolumes
+    storageLocation: default
+    ttl: 168h0m0s

--- a/projects/lungmen.akn/src/apps/actual-budget/actual-budget.statefulset.yaml
+++ b/projects/lungmen.akn/src/apps/actual-budget/actual-budget.statefulset.yaml
@@ -8,6 +8,9 @@ spec:
   serviceName: actual-budget
   replicas: 1
   template:
+    metadata:
+      annotations:
+        backup.velero.io/backup-volumes: persistent
     spec:
       automountServiceAccountToken: false
       containers:

--- a/projects/lungmen.akn/src/apps/atuin/atuin.deployment.yaml
+++ b/projects/lungmen.akn/src/apps/atuin/atuin.deployment.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         app.kubernetes.io/name: atuin
         app.kubernetes.io/instance: atuin
+      annotations:
+        backup.velero.io/backup-volumes: atuin-data
     spec:
       automountServiceAccountToken: false
       containers:

--- a/projects/lungmen.akn/src/apps/jellyfin/jellyfin.statefulset.yaml
+++ b/projects/lungmen.akn/src/apps/jellyfin/jellyfin.statefulset.yaml
@@ -9,6 +9,9 @@ spec:
   serviceName: jellyfin
   replicas: 1
   template:
+    metadata:
+      annotations:
+        backup.velero.io/backup-volumes: persistent
     spec:
       automountServiceAccountToken: false
       containers:

--- a/projects/lungmen.akn/src/apps/paperless-ngx/paperless-ngx.statefulset.yaml
+++ b/projects/lungmen.akn/src/apps/paperless-ngx/paperless-ngx.statefulset.yaml
@@ -21,6 +21,8 @@ spec:
       labels:
         app.kubernetes.io/component: webserver
         app.kubernetes.io/instance: paperless-ngx-webserver
+      annotations:
+        backup.velero.io/backup-volumes: persistent-storage
     spec:
       automountServiceAccountToken: false
       containers:

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/.application.patch
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/.application.patch
@@ -1,0 +1,32 @@
+apiVersion: arcane.chezmoi.sh/v1alpha1
+kind: ApplicationPatch
+metadata: {}
+spec:
+  info:
+    # -- Application metadata
+    - name: Description
+      value: Backup and restore for Kubernetes cluster resources and persistent volumes
+    - name: Category
+      value: Storage / Backup
+    - name: Version
+      # renovate: datasource=helm depName=velero registryUrl=https://vmware-tanzu.github.io/helm-charts
+      value: "12.1.0"
+    # -- Documentation & Resources
+    - name: Documentation
+      value: https://velero.io/docs/main/
+    - name: GitHub Repository
+      value: https://github.com/vmware-tanzu/velero
+
+  syncPolicy:
+    automated:
+      enabled: false # Backup/restore tooling — avoid automatic updates that could disrupt in-flight backups
+
+    # node-agent's DaemonSet needs privileged/hostPath access (mounting
+    # kubelet's pod volume dir on each node for Kopia's fs-backup data
+    # path) -- the "baseline" Pod Security default rejects that, so
+    # relax enforcement for the namespace ArgoCD creates for this
+    # Application.
+    managedNamespaceMetadata:
+      labels:
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/enforce-version: v1.33

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/actual-budget.pvc-backup.schedule.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/actual-budget.pvc-backup.schedule.yaml
@@ -1,0 +1,20 @@
+---
+# One Schedule per app (rather than one shared Schedule across namespaces) so each
+# app's backups have their own timeline/name prefix — simpler to target for restore
+# (`velero restore create --from-backup actual-budget-<timestamp>`) without needing
+# to filter a multi-app backup down to one namespace.
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: actual-budget
+spec:
+  schedule: "0 */12 * * *"
+  template:
+    includedNamespaces:
+      - actual-budget
+    includedResources:
+      - pods
+      - persistentvolumeclaims
+      - persistentvolumes
+    storageLocation: default
+    ttl: 168h0m0s

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/actual-budget.pvc-backup.schedule.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/actual-budget.pvc-backup.schedule.yaml
@@ -15,6 +15,10 @@ spec:
     includedResources:
       - pods
       - persistentvolumeclaims
+      # PersistentVolume is cluster-scoped but Velero still correlates it to
+      # includedNamespaces via spec.claimRef.namespace — see jellyfin's Schedule
+      # for the full reasoning (verified live, and dropping this was tried and
+      # reverted).
       - persistentvolumes
     storageLocation: default
     ttl: 168h0m0s

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/atuin.pvc-backup.schedule.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/atuin.pvc-backup.schedule.yaml
@@ -1,0 +1,20 @@
+---
+# One Schedule per app (rather than one shared Schedule across namespaces) so each
+# app's backups have their own timeline/name prefix — simpler to target for restore
+# (`velero restore create --from-backup atuin-<timestamp>`) without needing to
+# filter a multi-app backup down to one namespace.
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: atuin
+spec:
+  schedule: "0 */12 * * *"
+  template:
+    includedNamespaces:
+      - atuin
+    includedResources:
+      - pods
+      - persistentvolumeclaims
+      - persistentvolumes
+    storageLocation: default
+    ttl: 168h0m0s

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/atuin.pvc-backup.schedule.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/atuin.pvc-backup.schedule.yaml
@@ -15,6 +15,10 @@ spec:
     includedResources:
       - pods
       - persistentvolumeclaims
+      # PersistentVolume is cluster-scoped but Velero still correlates it to
+      # includedNamespaces via spec.claimRef.namespace — see jellyfin's Schedule
+      # for the full reasoning (verified live, and dropping this was tried and
+      # reverted).
       - persistentvolumes
     storageLocation: default
     ttl: 168h0m0s

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/jellyfin.pvc-backup.schedule.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/jellyfin.pvc-backup.schedule.yaml
@@ -15,6 +15,13 @@ spec:
     includedResources:
       - pods
       - persistentvolumeclaims
+      # PersistentVolume is cluster-scoped, but Velero still correlates it to
+      # includedNamespaces via spec.claimRef.namespace — confirmed live: this
+      # namespace's 5 PVs made it in, not all 32 cluster-wide. Dropping this
+      # was tried and reverted: PVs aren't pulled in as a related item the way
+      # PVCs are from Pods, so omitting it silently drops the PV manifest
+      # entirely (matters for our statically-bound SMB volumes, which have no
+      # provisioner to recreate them on restore without it).
       - persistentvolumes
     storageLocation: default
     ttl: 168h0m0s

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/jellyfin.pvc-backup.schedule.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/jellyfin.pvc-backup.schedule.yaml
@@ -1,0 +1,20 @@
+---
+# One Schedule per app (rather than one shared Schedule across namespaces) so each
+# app's backups have their own timeline/name prefix — simpler to target for restore
+# (`velero restore create --from-backup jellyfin-<timestamp>`) without needing to
+# filter a multi-app backup down to one namespace.
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: jellyfin
+spec:
+  schedule: "0 */12 * * *"
+  template:
+    includedNamespaces:
+      - jellyfin
+    includedResources:
+      - pods
+      - persistentvolumeclaims
+      - persistentvolumes
+    storageLocation: default
+    ttl: 168h0m0s

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/kustomization.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: velero-system
+
+resources:
+  - velero-credentials.externalsecret.yaml
+  - security
+
+helmCharts:
+  - repo: https://vmware-tanzu.github.io/helm-charts
+    name: velero
+    # renovate: datasource=helm depName=velero registryUrl=https://vmware-tanzu.github.io/helm-charts
+    version: 12.1.0
+
+    releaseName: velero
+    namespace: velero-system
+
+    valuesFile: velero.helmvalues/default.yaml
+
+patches:
+  # The Helm chart marks this Job with helm.sh/hook annotations so a real `helm install`
+  # runs it before anything else. Kustomize's helmCharts inflator renders the chart to
+  # plain manifests and drops that hook semantics, so ArgoCD was syncing this Job in the
+  # same wave as the BackupStorageLocation CR it must create the CRD for first — failing
+  # with "could not find velero.io/BackupStorageLocation ... CRD is installed". Translating
+  # to an ArgoCD PreSync hook restores the "CRDs before CRs" ordering Helm would have given.
+  - target:
+      kind: Job
+      name: velero-upgrade-crds
+    patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1hook
+        value: PreSync
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1hook-delete-policy
+        value: HookSucceeded
+
+images:
+  - name: docker.io/velero/velero
+    newName: oci.chezmoi.sh/docker.io/velero/velero
+  - name: velero/velero-plugin-for-aws
+    newName: oci.chezmoi.sh/docker.io/velero/velero-plugin-for-aws

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/kustomization.yaml
@@ -4,6 +4,10 @@ kind: Kustomization
 namespace: velero-system
 
 resources:
+  - actual-budget.pvc-backup.schedule.yaml
+  - atuin.pvc-backup.schedule.yaml
+  - jellyfin.pvc-backup.schedule.yaml
+  - paperless-ngx.pvc-backup.schedule.yaml
   - velero-credentials.externalsecret.yaml
   - security
 

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/kustomization.yaml
@@ -34,6 +34,13 @@ patches:
   # treatment: ArgoCD applies every PreSync hook before any plain Sync-phase resource, so
   # without this the Job would run before its own RBAC exists on a genuinely fresh install
   # (a pod stuck on "ServiceAccount not found" that ArgoCD would then wait on forever).
+  #
+  # hook-delete-policy is BeforeHookCreation,HookSucceeded (matching the chart's own
+  # helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded exactly) rather than
+  # just HookSucceeded: a Job that failed once would otherwise sit there forever — Jobs
+  # are immutable, so ArgoCD can't recreate one under the same name until the old one is
+  # gone. BeforeHookCreation clears out whatever's left (succeeded or failed) right before
+  # the next retry creates a fresh one.
   - target:
       kind: Job
       name: velero-upgrade-crds
@@ -43,7 +50,7 @@ patches:
         value: PreSync
       - op: add
         path: /metadata/annotations/argocd.argoproj.io~1hook-delete-policy
-        value: HookSucceeded
+        value: BeforeHookCreation,HookSucceeded
   - target:
       kind: ServiceAccount
       name: velero-server-upgrade-crds

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
   # same wave as the BackupStorageLocation CR it must create the CRD for first — failing
   # with "could not find velero.io/BackupStorageLocation ... CRD is installed". Translating
   # to an ArgoCD PreSync hook restores the "CRDs before CRs" ordering Helm would have given.
+  #
+  # Its ServiceAccount and ClusterRole/ClusterRoleBinding need the exact same PreSync hook
+  # treatment: ArgoCD applies every PreSync hook before any plain Sync-phase resource, so
+  # without this the Job would run before its own RBAC exists on a genuinely fresh install
+  # (a pod stuck on "ServiceAccount not found" that ArgoCD would then wait on forever).
   - target:
       kind: Job
       name: velero-upgrade-crds
@@ -39,6 +44,27 @@ patches:
       - op: add
         path: /metadata/annotations/argocd.argoproj.io~1hook-delete-policy
         value: HookSucceeded
+  - target:
+      kind: ServiceAccount
+      name: velero-server-upgrade-crds
+    patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1hook
+        value: PreSync
+  - target:
+      kind: ClusterRole
+      name: velero-upgrade-crds
+    patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1hook
+        value: PreSync
+  - target:
+      kind: ClusterRoleBinding
+      name: velero-upgrade-crds
+    patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1hook
+        value: PreSync
 
 images:
   - name: docker.io/velero/velero

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/paperless-ngx.pvc-backup.schedule.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/paperless-ngx.pvc-backup.schedule.yaml
@@ -15,6 +15,10 @@ spec:
     includedResources:
       - pods
       - persistentvolumeclaims
+      # PersistentVolume is cluster-scoped but Velero still correlates it to
+      # includedNamespaces via spec.claimRef.namespace — see jellyfin's Schedule
+      # for the full reasoning (verified live, and dropping this was tried and
+      # reverted).
       - persistentvolumes
     storageLocation: default
     ttl: 168h0m0s

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/paperless-ngx.pvc-backup.schedule.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/paperless-ngx.pvc-backup.schedule.yaml
@@ -1,0 +1,20 @@
+---
+# One Schedule per app (rather than one shared Schedule across namespaces) so each
+# app's backups have their own timeline/name prefix — simpler to target for restore
+# (`velero restore create --from-backup paperless-ngx-<timestamp>`) without needing
+# to filter a multi-app backup down to one namespace.
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: paperless-ngx
+spec:
+  schedule: "0 */12 * * *"
+  template:
+    includedNamespaces:
+      - paperless-ngx
+    includedResources:
+      - pods
+      - persistentvolumeclaims
+      - persistentvolumes
+    storageLocation: default
+    ttl: 168h0m0s

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/security/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/security/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - network-policy.default-hardened.yaml
+  - network-policy.allow-to-kube-apiserver.yaml
+  - network-policy.allow-to-s3-backup.yaml

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/security/network-policy.allow-to-kube-apiserver.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/security/network-policy.allow-to-kube-apiserver.yaml
@@ -1,0 +1,19 @@
+---
+# Velero (the controller Deployment and the node-agent DaemonSet) watches/manages
+# Backup, Restore, and PodVolumeBackup CRs plus PVCs across the whole cluster —
+# it needs Kubernetes API access unconditionally.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows all velero-system pods (controller + node-agent) to reach the Kubernetes API server.
+      Required for watching/managing Backup, Restore, and PodVolumeBackup custom resources plus PVCs
+      cluster-wide.
+  name: allow-to-kube-apiserver
+  namespace: velero-system
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/security/network-policy.allow-to-s3-backup.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/security/network-policy.allow-to-s3-backup.yaml
@@ -1,0 +1,22 @@
+---
+# S3 backup egress for Velero (controller + node-agent DaemonSet Kopia uploader).
+# Allows reaching the S3-compatible backup endpoint (s3.chezmoi.sh:443) that
+# backupStorageLocation "default" points at (velero.helmvalues/default.yaml).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows all velero-system pods to reach the S3-compatible backup endpoint (s3.chezmoi.sh:443)
+      for Kopia backup/restore data transfer.
+  name: allow-to-s3-backup
+  namespace: velero-system
+spec:
+  endpointSelector: {}
+  egress:
+    - toFQDNs:
+        - matchName: s3.chezmoi.sh
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/security/network-policy.default-hardened.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/security/network-policy.default-hardened.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Default hardened network policy for the velero-system namespace that implements a secure
+      baseline by denying all traffic except explicitly allowed connections. Permits intra-namespace
+      communication and DNS resolution to kube-system, while blocking all other traffic by default.
+  name: default-hardened
+  namespace: velero-system
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: velero-system
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+          rules:
+            dns:
+              - matchPattern: "*"
+
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: velero-system

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/velero-credentials.externalsecret.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/velero-credentials.externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# velero-credentials.externalsecret.yaml
+#
+# Renders the Garage S3 credentials (provisioned by Pulumi, stack/velero.ts) into the
+# AWS-style INI file Velero's velero-plugin-for-aws expects at credentials.existingSecret.
+
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: velero-credentials
+spec:
+  dataFrom:
+    - extract:
+        key: lungmen.akn/velero/backup/s3.chezmoi.sh
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  target:
+    name: velero-credentials
+    template:
+      type: Opaque
+      engineVersion: v2
+      data:
+        cloud: |
+          [default]
+          aws_access_key_id={{ .access_key_id }}
+          aws_secret_access_key={{ .secret_access_key }}
+  refreshInterval: 5m

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/velero/velero.helmvalues/default.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/velero/velero.helmvalues/default.yaml
@@ -1,0 +1,54 @@
+---
+# Kopia file-system-backup path only (validated in docs/experiments/20260803-velero-pvc-backup,
+# EXP-2026-007). The CSI-snapshot path (volumeSnapshotLocation) is deliberately left empty and
+# stays that way — Proxmox CSI volume snapshots are not something this project intends to adopt,
+# so Kopia fs-backup is the permanent backup path here.
+initContainers:
+  - name: velero-plugin-for-aws
+    # renovate: datasource=docker depName=velero/velero-plugin-for-aws
+    image: velero/velero-plugin-for-aws:v1.13.1
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /target
+        name: plugins
+
+deployNodeAgent: true
+
+credentials:
+  useSecret: true
+  # checkov:skip=CKV_SECRET_6: This is a Secret *name* reference, not a credential value.
+  existingSecret: velero-credentials
+
+configuration:
+  backupStorageLocation:
+    - name: default
+      provider: aws
+      bucket: velero-lungmen-akn
+      default: true
+      credential:
+        name: velero-credentials
+        key: cloud
+      config:
+        region: fr-par-1
+        s3Url: https://s3.chezmoi.sh
+        s3ForcePathStyle: "true"
+  # Kopia only backs up a pod's volumes when explicitly opted in via the
+  # backup.velero.io/backup-volumes annotation on each workload — the global
+  # defaultVolumesToFsBackup flag was found (in the POC) to silently skip a PVC
+  # with no error. Left unset here on purpose; annotate workloads individually.
+  volumeSnapshotLocation: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 512Mi
+
+nodeAgent:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi

--- a/projects/lungmen.akn/src/infrastructure/pulumi/index.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/index.ts
@@ -4,3 +4,4 @@ export * from "./stack/pangolin";
 export * from "./stack/pocket-id";
 export * from "./stack/tailscale-operator";
 export * from "./stack/vault";
+export * from "./stack/velero";

--- a/projects/lungmen.akn/src/infrastructure/pulumi/stack/velero.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/stack/velero.ts
@@ -1,0 +1,55 @@
+import * as garage from "@axnic/pulumi-garage";
+import { vaultSecretMetadata } from "@chezmoi.sh/pulumi-lib";
+import * as pulumi from "@pulumi/pulumi";
+import * as vault from "@pulumi/vault";
+
+// ---------------------------------------------------------------------------
+// Garage S3 bucket + credentials for Velero backups (lungmen.akn)
+// ---------------------------------------------------------------------------
+// Dedicated bucket/key, separate from the CNPG backup bucket (stack/cloudnative-pg.ts):
+// Velero's PVC-backup scope is cluster-wide and shouldn't share credentials with
+// CNPG's WAL-archiving bucket.
+const bucketName = "velero-lungmen-akn";
+
+const bucket = new garage.Bucket("velero-lungmen-akn-bucket", {
+	globalAlias: bucketName,
+});
+
+const key = new garage.Key("velero-lungmen-akn-key", {
+	name: "velero-backup-lungmen.akn",
+});
+
+new garage.BucketKeyPermission("velero-lungmen-akn-permission", {
+	accessKeyId: key.accessKeyId,
+	bucketId: bucket.id,
+	permissions: {
+		read: true,
+		write: true,
+	},
+});
+
+new vault.kv.SecretV2(
+	"velero-backup-credentials",
+	{
+		mount: "lungmen.akn",
+		name: "velero/backup/s3.chezmoi.sh",
+		dataJson: pulumi.jsonStringify({
+			access_key_id: key.accessKeyId,
+			secret_access_key: key.secretAccessKey,
+			region: "fr-par-1",
+			endpoint_url: "https://s3.chezmoi.sh",
+			bucket: bucketName,
+		}),
+		customMetadata: {
+			data: {
+				description: "Garage S3 credentials for Velero backup object store",
+				application: "velero",
+				...vaultSecretMetadata(key),
+			},
+		},
+	},
+	{ parent: key },
+);
+
+export const veleroBackupBucket = pulumi.output(bucketName);
+export const veleroBackupAccessKeyId = key.accessKeyId;


### PR DESCRIPTION
## Summary

Deploys Velero (Kopia file-system-backup path) on `lungmen.akn` as an ArgoCD-managed
Application, reusing the existing self-hosted Garage S3 endpoint (`s3.chezmoi.sh`) already
used for CNPG backups. This closes the "deploy for real" half of the Kopia backup path
validated locally in EXP-2026-007 (#1190) — `lungmen.akn` is being recreated via Omni (#1188),
so real backup coverage needs to exist before that migration starts.

**Related Issue:** #1193

## Changes Made

### Pulumi: Garage bucket + credentials

- **[`stack/velero.ts`](projects/lungmen.akn/src/infrastructure/pulumi/stack/velero.ts)** — Creates a dedicated `velero-lungmen-akn` Garage bucket and access key (separate from the CNPG backup bucket/key), and pushes the credentials to Vault at `lungmen.akn/velero/backup/s3.chezmoi.sh`.

### ArgoCD Application: Velero

- **[`kustomization.yaml`](projects/lungmen.akn/src/infrastructure/kubernetes/velero/kustomization.yaml)** — Velero Helm chart 12.1.0, images remapped through the `oci.chezmoi.sh` registry mirror per this repo's convention. A JSON Patch turns the CRD-install Job into an ArgoCD PreSync hook (see Technical Impact).
- **[`velero.helmvalues/default.yaml`](projects/lungmen.akn/src/infrastructure/kubernetes/velero/velero.helmvalues/default.yaml)** — Kopia backend only; CSI `VolumeSnapshotLocation` is intentionally never configured (Proxmox CSI volume snapshots aren't something this project plans to adopt). `backupStorageLocation` points at the new `velero-lungmen-akn` bucket. Memory limits bumped to 512Mi (see Technical Impact).
- **[`velero-credentials.externalsecret.yaml`](projects/lungmen.akn/src/infrastructure/kubernetes/velero/velero-credentials.externalsecret.yaml)** — Renders the Garage credentials into the AWS-style INI file `velero-plugin-for-aws` expects.
- **[`security/`](projects/lungmen.akn/src/infrastructure/kubernetes/velero/security/)** — Default-hardened baseline, kube-apiserver egress (Velero watches Backup/Restore/PVC resources cluster-wide), and S3 egress to `s3.chezmoi.sh:443`.
- **[`.application.patch`](projects/lungmen.akn/src/infrastructure/kubernetes/velero/.application.patch)** — Manual sync only (`automated.enabled: false`), matching this repo's convention for storage/backup tooling where auto-updates could disrupt in-flight backups. `managedNamespaceMetadata` relaxes the namespace's Pod Security level to `privileged` (see Technical Impact).

### Per-app 12h backup schedules

- **[`actual-budget.pvc-backup.schedule.yaml`](projects/lungmen.akn/src/infrastructure/kubernetes/velero/actual-budget.pvc-backup.schedule.yaml)**, **[`atuin`](projects/lungmen.akn/src/infrastructure/kubernetes/velero/atuin.pvc-backup.schedule.yaml)**, **[`jellyfin`](projects/lungmen.akn/src/infrastructure/kubernetes/velero/jellyfin.pvc-backup.schedule.yaml)**, **[`paperless-ngx`](projects/lungmen.akn/src/infrastructure/kubernetes/velero/paperless-ngx.pvc-backup.schedule.yaml)** — one `Schedule` per app (every 12h), each scoped to `includedResources: [pods, persistentvolumeclaims, persistentvolumes]` only — no Deployments/Services/Secrets/etc. get backed up, just volume data. One Schedule per app rather than one shared Schedule across namespaces, so each app's backups get their own name prefix/timeline — simpler to target for restore.
- **[`actual-budget.statefulset.yaml`](projects/lungmen.akn/src/apps/actual-budget/actual-budget.statefulset.yaml)**, **[`atuin.deployment.yaml`](projects/lungmen.akn/src/apps/atuin/atuin.deployment.yaml)**, **[`jellyfin.statefulset.yaml`](projects/lungmen.akn/src/apps/jellyfin/jellyfin.statefulset.yaml)**, **[`paperless-ngx.statefulset.yaml`](projects/lungmen.akn/src/apps/paperless-ngx/paperless-ngx.statefulset.yaml)** — each pod template gets a `backup.velero.io/backup-volumes` annotation naming its real data volume (not its Redis/SMB-media/cache volumes). CNPG-backed apps are excluded — they already have their own barman-cloud `ScheduledBackup` and shouldn't get a second, inconsistent fs-level snapshot of a live database.

## Technical Impact

### Infrastructure Components

Velero v1.18.1 (chart 12.1.0) with the Kopia uploader and `velero-plugin-for-aws` init
container, deployed as a controller Deployment + node-agent DaemonSet in the new
`velero-system` namespace.

### Security Implementation

Dedicated Garage bucket/key (not shared with CNPG's backup credentials), synced via
ExternalSecrets Operator from Vault. Cilium network policies scope egress to exactly
kube-apiserver and `s3.chezmoi.sh:443`, on top of a default-deny baseline.

`node-agent`'s DaemonSet needs `hostPath` access to reach kubelet's pod volumes on each
node — the namespace's default "baseline" Pod Security level rejects that outright, so
`managedNamespaceMetadata` relaxes it to `privileged` (same pattern already used for
`rhodes.akn`'s `proxmox` namespace, for the identical reason: a node DaemonSet needing
host-level volume access).

### Integration Points

Reuses the existing `s3.chezmoi.sh` Garage endpoint already backing CNPG's WAL archiving —
no new S3-compatible backend introduced. Kopia only backs up a pod's volumes when explicitly
opted in via the `backup.velero.io/backup-volumes` annotation per workload (the POC found the
global `defaultVolumesToFsBackup` flag silently skips PVCs).

### Two real bugs found and fixed during live validation

- **CRD-install ordering.** The Helm chart's CRD-installer Job runs via a
  `helm.sh/hook: pre-install,pre-upgrade` hook — semantics Kustomize's `helmCharts`
  inflator drops entirely, since it just renders the chart to plain manifests. Without
  translating that to an `argocd.argoproj.io/hook: PreSync` annotation, ArgoCD's task
  builder fails *before syncing anything at all*: it does an upfront API-discovery check
  across every resource (including hooks), and immediately errors out on the
  `BackupStorageLocation` CR because its CRD doesn't exist yet. Even with the PreSync
  hook fixed, **a brand-new install still needs one manual bootstrap** (`kubectl apply`
  the Job + its RBAC directly, outside ArgoCD) the very first time, since PreSync hooks
  are subject to that same upfront discovery check — this will need doing again after
  the Omni-based `lungmen.akn` recreation this PR exists to protect against.
- **OOMKilled under real load.** The 256Mi memory limit (carried over from the POC,
  sized for one tiny disposable Postgres volume in a `kind` sandbox) crashed the
  `velero` pod mid-backup while creating a fresh Kopia repository for a namespace's
  first-ever backup — happened even for a 250Mi PVC (`atuin`). A container crash mid-backup
  also fails the whole `Backup` object outright, since Velero marks anything found
  `InProgress` at server startup as `Failed`. Bumped to 512Mi.

## Operational Notes

Learned while live-testing on `lungmen.akn`, worth keeping in mind for anyone operating
this later:

- **Every pod in an included namespace gets a cheap resource-manifest backup; only
  annotated pods get real data.** `includedNamespaces` scopes by namespace, not by pod —
  confirmed directly in the logs on `paperless-ngx` (2 pods: `paperless-ngx-0`, annotated,
  and `paperless-ngx-redis-0`, not annotated). Both pods' *manifests* get backed up (a few
  KB of YAML each), but only `paperless-ngx-0`'s `persistent-storage` volume actually goes
  through Kopia. No need to exclude unrelated pods from a namespace — they just cost
  nothing if left unannotated.
- **Selective backup/restore of one pod among several uses label selectors, not pod
  names.** Velero has no "by resource name" filter. To back up or restore just one pod's
  volume when a namespace has multiple annotated pods: `--selector <label>=<value>` on
  either `velero backup create` or `velero restore create`. Crucially, **the selector only
  needs to exist at restore time** — Velero captures full resource metadata (including
  labels) in every backup regardless of any selector used at backup time, so one broad
  namespace backup can serve any number of differently-scoped restores later. The label
  just has to already be on the pod *before* the backup runs. Confirmed our existing
  StatefulSet labels (`app.kubernetes.io/component: webserver` vs `tasks-broker` on
  `paperless-ngx`) already work for this — no manifest changes needed.
- **Never `kubectl delete` a `Backup` object directly.** It only removes the Kubernetes
  CR, not the underlying data in the S3 bucket — Velero's `BackupSync` controller
  periodically rediscovers orphaned backup data in the bucket and **recreates** the CR
  from it. Confirmed directly: a `Backup` deleted via `kubectl delete` reappeared with a
  later `creationTimestamp`, and its S3 objects were still present, untouched, well past
  the backup's own TTL/expiration. Proper deletion (CR + S3 data together) needs
  `velero backup delete <name>` or, equivalently, a `DeleteBackupRequest` object. This
  doesn't affect the Schedules themselves — Velero's own TTL-based garbage collection
  (not manual `kubectl delete`) is what actually expires scheduled backups in normal
  operation, and that path does purge both correctly.

## Testing Validation

- [x] `velero-server` Deployment and `node-agent` DaemonSet reach `Running` in `velero-system`
- [x] `velero-credentials` ExternalSecret syncs successfully
- [x] `velero backup-location get` reports the `default` BackupStorageLocation `Available`
- [x] Cilium network policies allow only kube-apiserver + `s3.chezmoi.sh:443` egress
- [x] Real backup/restore-path validation: manual backups against all 4 apps
      (`actual-budget`, `atuin`, `jellyfin`, `paperless-ngx`), both combined and matching
      each final per-app `Schedule` individually — all completed, all confirmed landing in
      S3 by listing the bucket directly (not just trusting Velero's own status), then
      cleaned up via proper `DeleteBackupRequest` deletion

Verified live throughout by syncing this Application directly from this branch (bypassing
merge — see PR discussion) against `lungmen.akn`.

## Future Enhancements

- CSI-snapshot backups — not planned; see Changes Made (Proxmox CSI volume snapshots
  aren't something this project intends to adopt).
- Backup/restore validation against a real CNPG cluster specifically, to check whether
  CNPG's WAL-archiving machinery needs pre/post hooks alongside a concurrent Kopia
  snapshot — not applicable today since CNPG apps are deliberately excluded from these
  schedules (own barman-cloud backup), but worth revisiting if that ever changes.
- Extend per-app schedules to `forgejo`, `jellyseerr`, `mealie`, `silverbullet`, and the
  primary-write SMB volumes on `immich`/`paperless-ngx` (`immich-smb-storage`,
  `paperless-ngx-smb-storage`) — deliberately out of scope for this PR, scoped down to
  the 4 apps explicitly requested.
- An actual **restore** has never been exercised against `lungmen.akn` — only backup.

## Related Issues

Addresses #1193 (deployment and backup validated; restore validation still open)

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
