### PR TITLE
Clarify Feature/Improvement/Task/Docs boundaries in create-issue skill

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -99,6 +99,15 @@ What does the issue ask for?
 | Security hardening, vulnerability, secret management      | `Security`    |
 | Clarification or discussion, no concrete change requested | `Question`    |
 
+`Feature` and `Improvement` both describe things getting better, and `Task` and `Docs` both describe indirect work —
+that's where mistyping happens. Resolve them with the test in each row below, not by how the title reads:
+
+| Ambiguous pair              | Ask                                                                                  | Resolution                                                                                                                                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Feature` vs. `Task`        | Could a user/operator already do this before the change, just via a worse mechanism? | Yes → `Task` (only the implementation changes — e.g. swapping a generated/bridged SDK for a hand-written one). No, this capability didn't exist at all → `Feature`.                             |
+| `Feature` vs. `Improvement` | Does the target system/service run at all today?                                     | No → `Feature`, even if the rollout is framed as "fleet-wide" or "standardization" — that describes the rollout shape, not whether the thing is new. Yes, it's already running → `Improvement`. |
+| `Docs` vs. `Task`           | Does closing the issue change anything besides a document?                           | No, purely descriptive output → `Docs`. Yes, it also commits to fixing/resolving what it investigates → `Task`, even though a document ships alongside it.                                      |
+
 Breaking variants of any change add the `breaking-change` label.
 
 ### Scope-label decision tree


### PR DESCRIPTION
## Summary

Adds a three-row disambiguation table to the `create-issue` skill's "Issue Type decision tree" so agents (and humans)
stop mistyping GitHub Issue Type on three specific, recurring shapes of work.

## Changes Made

### Skill documentation

- **[`.agents/skills/create-issue/SKILL.md`](.agents/skills/create-issue/SKILL.md)** — adds a table right after the
  existing Issue Type decision tree, covering `Feature` vs. `Task`, `Feature` vs. `Improvement`, and `Docs` vs. `Task`,
  each with a concrete yes/no test instead of a vibe-based read of the title.

## Technical Impact

### Documentation only

No code, infrastructure, or runtime change. This only affects how future issues get typed when filed or triaged
through the `create-issue`/`triage-issues` skills.

## Testing Validation

- [ ] `.agents/skills/create-issue/SKILL.md` renders correctly and the new table sits directly under the existing
      decision tree

## Related Issues

None — this codifies a pattern found during a manual backlog triage pass, not a filed issue.

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
