### PR TITLE
Remove duplicate cluster field from application-addition issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/application-addition.yml
+++ b/.github/ISSUE_TEMPLATE/application-addition.yml
@@ -31,18 +31,6 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: cluster
-    attributes:
-      label: Target cluster
-      options:
-        - project:amiya.akn (core platform — auth, secrets, GitOps)
-        - project:lungmen.akn (home applications — media, productivity, personal)
-        - project:kazimierz.akn (public-access gateway)
-        - project:hass (Home Assistant ecosystem)
-    validations:
-      required: true
-
   - type: checkboxes
     id: integration
     attributes:


### PR DESCRIPTION
## Summary

The `application-addition.yml` issue template had a "Target cluster" dropdown
asking reporters to pick a `project:<cluster>` value. Nothing in CI or GitHub
Actions consumed that answer — it just sat in the issue body as text. The
board's `AKN Project` single-select field already tracks the same
classification and is the one `triage-issues` sets from the issue body during
triage, so the dropdown was a second, unused copy of the same information.

**Related Issue:** N/A — cleanup surfaced while reviewing why the same
classification appeared to exist in two places.

## Changes Made

### Issue template

- **[`.github/ISSUE_TEMPLATE/application-addition.yml`](.github/ISSUE_TEMPLATE/application-addition.yml)** — removed the `Target cluster` dropdown (id `cluster`); the target cluster still comes through in the sentence-form title (`Add <application> on <cluster>`) and TL;DR body text.

## Technical Impact

### Integration Points

No workflow or script read the dropdown's `id: cluster` answer, so removing
it doesn't change any automation. The board's `AKN Project` field
(`.agents/skills/triage-issues/SKILL.md`) remains the single place this
classification lives, set during triage from the issue title/body.

## Testing Validation

- [ ] Opening a new "Application Addition" issue no longer shows the "Target cluster" field
- [ ] The remaining form fields (app name, TL;DR, integration/security checkboxes, dependencies, resources, notes, links) still render correctly

## Related Issues

N/A

---

<sub>AI-assisted with claude:claude-sonnet-5 under human supervision</sub>
