### PR TITLE
Extend Dex ID-token/refresh-token TTL for omni.chezmoi.sh

### DIFF
--- a/catalog/nix/siderolabs/omni/dex.nix
+++ b/catalog/nix/siderolabs/omni/dex.nix
@@ -84,6 +84,41 @@ in
         [{ email = "admin@example.com"; username = "admin"; hashEnvVar = "DEX_ADMIN_PASSWORD_HASH"; }]
       '';
     };
+
+    expiry = {
+      idTokens = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "24h";
+        description = ''
+          ID-token lifetime, as a Go duration string. Left unset (null),
+          Dex uses its own compiled-in default.
+        '';
+      };
+
+      refreshTokens = {
+        validIfNotUsedFor = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "168h";
+          description = ''
+            How long an unused refresh token stays valid, as a Go duration
+            string. Left unset (null), Dex uses its own compiled-in default.
+          '';
+        };
+
+        absoluteLifetime = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "168h";
+          description = ''
+            Maximum lifetime of a refresh token regardless of use, as a Go
+            duration string. Left unset (null), Dex uses its own
+            compiled-in default.
+          '';
+        };
+      };
+    };
   };
 
   config =
@@ -128,6 +163,16 @@ in
           hash = mkHashOrEmpty u;
         })
         dex.users;
+
+      # Only emit expiry.* keys the user actually set — an unset option must
+      # fall through to Dex's own compiled-in default, not a guessed value.
+      refreshTokensBlock = lib.filterAttrs (_: v: v != null) {
+        inherit (dex.expiry.refreshTokens) validIfNotUsedFor absoluteLifetime;
+      };
+      expiryBlock = lib.filterAttrs (_: v: v != null && v != { }) {
+        idTokens = dex.expiry.idTokens;
+        refreshTokens = lib.optionalAttrs (refreshTokensBlock != { }) refreshTokensBlock;
+      };
     in
     lib.mkIf (cfg.enable && dex.enable) {
       services.dex = {
@@ -157,7 +202,7 @@ in
           }];
 
           staticPasswords = passwordUsers;
-        };
+        } // lib.optionalAttrs (expiryBlock != { }) { expiry = expiryBlock; };
       };
     };
 }

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/README.md
@@ -68,6 +68,10 @@ flowchart TB
 - **Omni UI/API** binds on `127.0.0.1:8443` (loopback, PKI TLS). **Dex** binds on `127.0.0.1:5557` (loopback, plain
   HTTP). Both are only reachable through Caddy.
 - **No SSH.** Console access goes through `pct enter <vmid>` on the Proxmox host.
+- **Session lifetime** — Dex issues ID tokens valid for **24h**, with refresh tokens valid for **7 days** (both
+  unused-window and absolute lifetime), configured via `services.omni.dex.expiry` in `configuration.nix`. 24h was chosen
+  over the stricter 12h option since this is a single-admin homelab login, not a multi-tenant system; tighten it in
+  `configuration.nix` if that trade-off changes.
 
 ### Host kernel prerequisites — WireGuard + TUN device
 

--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/configuration.nix
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/configuration.nix
@@ -195,6 +195,16 @@
         username = "admin";
         hashEnvVar = "DEX_ADMIN_PASSWORD_HASH";
       }];
+      # Single-admin personal homelab login, not a high-security multi-tenant
+      # system — 24h ID tokens and a 7-day refresh window trade a little
+      # session-hijack exposure for not having to re-authenticate daily.
+      expiry = {
+        idTokens = "24h";
+        refreshTokens = {
+          validIfNotUsedFor = "168h"; # 7 days
+          absoluteLifetime = "168h"; # 7 days
+        };
+      };
       # Set to a nix-store file so dex.nix can read DEX_ADMIN_PASSWORD_HASH
       # at Nix eval time (builtins.readFile only works on build-accessible
       # paths). When dexAdminPasswordHash is empty (pure build), null so


### PR DESCRIPTION
## Summary

The co-located Dex OIDC provider backing `omni.chezmoi.sh` never set an `expiry`
block in its config, so ID-token and refresh-token lifetimes ran entirely on
Dex's undocumented, compiled-in defaults — nothing in this repo stated or
controlled how long an Omni login session actually lasted. This adds a
configurable `expiry` option group to the shared Dex module and sets explicit
TTLs for `omni.chezmoi.sh`.

**Related Issue:** #1177

## Changes Made

### Dex catalog module

- **[`catalog/nix/siderolabs/omni/dex.nix`](catalog/nix/siderolabs/omni/dex.nix)** — adds
  `services.omni.dex.expiry.{idTokens, refreshTokens.validIfNotUsedFor,
  refreshTokens.absoluteLifetime}`, all `nullOr str` defaulting to `null`.
  The emitted Dex `settings.expiry` block is built with `lib.filterAttrs`
  (only non-null keys) and merged in only when non-empty, so leaving the
  option unset keeps Dex's own current default behavior instead of the
  module guessing at a value that could drift across Dex versions.

### `omni.chezmoi.sh` LXC

- **[`projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/configuration.nix`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/configuration.nix)**
  — sets `dex.expiry.idTokens = "24h"` and `dex.expiry.refreshTokens = {
  validIfNotUsedFor = "168h"; absoluteLifetime = "168h"; }` (168h = 7 days).
- **[`projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/README.md`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/omni/README.md)**
  — documents the configured TTL/refresh window in the Architecture section.

## Technical Impact

### Infrastructure Components

No new services. `services.dex` (already deployed) now emits an explicit
`expiry` block instead of relying on Dex's compiled-in defaults.

### Security Implementation

Session lifetime is now explicit and auditable in Git instead of living
implicitly inside a specific Dex binary's defaults. **24h was chosen over the
stricter 12h option from the issue** because this is a single-admin personal
homelab login, not a high-security multi-tenant system — happy to switch to
12h if you'd rather have the tighter window.

### External Access Points

None — no change to routing, only to token lifetime.

### Integration Points

None — Dex's `staticClients`/`issuer` wiring to Omni is unchanged.

## Testing Validation

- [x] `mise run lxc:build` built the omni LXC image for real (Nix eval/build
      succeeded, not just a manual syntax trace)
- [x] Rendered Dex config extracted directly from the built tarball matches
      the issue exactly: `expiry.idTokens: 24h`,
      `expiry.refreshTokens.{validIfNotUsedFor,absoluteLifetime}: 168h`
- [x] Template pushed to `pve-01.pve.chezmoi.sh` successfully
- [x] Live upgrade attempted against production CT 101; it aborted safely at
      the pre-upgrade smoke-test step. Root cause: a pre-existing gap in the
      shared smoke-test helper, unrelated to this change — the disposable
      test container doesn't get the source CT's NICs cloned, so network
      units fail on any omni upgrade, not just this one. `dex.service`
      itself started fine in that smoke test. Production CT 101 was never
      stopped or modified.
- [ ] Pending final cutover — the live swap on CT 101 hasn't happened yet.
      Blocked on an unrelated decision (how to handle the smoke-test gap),
      not on any problem with this change.

## Related Issues

Closes #1177

---

<sub>AI-assisted with claude:claude-sonnet-5 under human supervision</sub>

