### PR TITLE
Fix Prune=confirm silently blocking automated syncs on lungmen.akn apps

### DIFF
--- a/projects/rhodes.akn/src/argocd/shoot.apps/applications.applicationset.yaml
+++ b/projects/rhodes.akn/src/argocd/shoot.apps/applications.applicationset.yaml
@@ -85,7 +85,13 @@ spec:
           - ApplyOutOfSyncOnly=false # Only sync out-of-sync resources, rather than applying every object in the application
           - CreateNamespace=true # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.
           - Delete=confirm # Confirm before deleting resources
-          - Prune=confirm # Confirm before pruning resources
+          # NOT Prune=confirm: automated.enabled + automated.prune above mean sync
+          # runs unattended, and a confirmation can only be supplied via manual
+          # UI/CLI/annotation action. Combined with Prune=confirm, an orphaned
+          # resource stops confirming forever, which silently blocks the whole
+          # Application's sync (not just the pending prune) with no signal in
+          # health.status. See issue #1195.
+          - Prune=true # Prune resources without requiring manual confirmation
           - PruneLast=true # Allow the ability for resource pruning to happen as a final, implicit wave of a sync operation
           - PrunePropagationPolicy=foreground # Supported policies are background, foreground and orphan.
           - Replace=false # Argo CD will use kubectl replace or kubectl create command to apply changes.


### PR DESCRIPTION
## Summary

`Prune=confirm` combined with `syncPolicy.automated.enabled: true` on lungmen.akn's
apps meant an automated sync could never auto-confirm a pending prune — once ArgoCD
wanted to prune a resource no longer declared in git, the whole Application's sync got
stuck forever, not just the prune, with zero signal in `health.status`. This drops
`Prune=confirm` to `Prune=true` on the ApplicationSet template that actually causes it.

**Related Issue:** Refs #1195 (this PR fixes the config; the live-cluster remediation
and cross-cluster verification the issue also asks for are called out below as manual
follow-up — see "Out of scope / manual follow-up").

## Root Cause

Issue #1195 names [`system.applicationset.yaml`](projects/rhodes.akn/src/argocd/shoot.apps/system.applicationset.yaml)
as the offending template. That file is used for lungmen.akn's *infrastructure* apps,
and its `automated.prune` defaults to `false` — none of the infra apps' `.application.patch`
files override it to `true`, so `Prune=confirm` there is currently dead code (no
automated prune is ever attempted, so the confirmation wall is never hit).

The actual offender is [`applications.applicationset.yaml`](projects/rhodes.akn/src/argocd/shoot.apps/applications.applicationset.yaml),
which templates every app under `dist/apps/*` (`actual-budget`, `forgejo`, `immich`,
`linkding`, `jellyseerr`, `mealie`, `n8n`, `silverbullet`, …). It defaults every one of
them to `automated.enabled: true` + `automated.prune: true` + `automated.selfHeal: true`,
*and* `syncOptions: [..., Prune=confirm, ...]`. None of these apps carry an
`.application.patch` that overrides `prune`, so all of them run with this combination.

Per the [ArgoCD sync-options docs](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/),
confirming a pending prune requires an explicit UI/CLI action or manually applying the
`argocd.argoproj.io/deletion-approved` annotation — there is no path for an automated
sync to supply that confirmation itself. So `Prune=confirm` on an
`automated.enabled: true` Application isn't a safety gate, it's an unconditional trap:
the first resource ever removed from that app's git source (of any kind) permanently
wedges the Application's sync, with `health.status` staying `Healthy` throughout.

Evidence this already happened:

- `actual-budget`, `forgejo`, `immich`, `linkding` — their git source only declares
  `allow-<app>-from-cilium-gateway` CiliumNetworkPolicies (checked under
  `projects/lungmen.akn/src/apps/<app>/security/`); the old `allow-<app>-from-envoy-gateway`
  policy is git-orphaned, confirming the live objects are stuck pending prune
  confirmation that will never come.
- `n8n` — same situation: git only declares `allow-n8n-from-cilium-gateway`, no
  `allow-n8n-from-envoy-gateway`. This app wasn't in the issue's "confirmed stuck" list
  but its git source shows the identical orphaned-policy pattern.
- `jellyseerr`, `mealie`, `silverbullet` — their **entire app directories were removed
  from git** (commits `610366415` "Uninstall Mealie and Jellyseerr" and `a178dbd03`
  "Remove silverbullet, deprecated"). If those Applications still exist live, ArgoCD is
  not just stuck on one stale NetworkPolicy for them — it's stuck trying to prune the
  whole app (every Deployment, Secret, PVC, ConfigMap, …), which is a larger blast
  radius than the issue described.

I considered scoping the fix down with a resource-level
`argocd.argoproj.io/sync-options: Prune=true` annotation (which the docs confirm
overrides the app-level `Prune=confirm` per-resource) applied only to
`CiliumNetworkPolicy` manifests, keeping `Prune=confirm` for other kinds. I rejected it:
the `jellyseerr`/`mealie`/`silverbullet` case proves the failure isn't
NetworkPolicy-specific — any resource kind removed from git hits the identical
permanent-hang bug. Scoping to one kind would leave the same landmine live for
Secrets, PVCs, ConfigMaps, etc. Since `Prune=confirm` provides no actual protection
under `automated.enabled: true` (it can never be satisfied), dropping it to
`Prune=true` for the whole template is the fix that actually closes the failure mode,
not just narrows which resource kind triggers it.

## Fix

### ArgoCD ApplicationSet template

- **[`projects/rhodes.akn/src/argocd/shoot.apps/applications.applicationset.yaml`](projects/rhodes.akn/src/argocd/shoot.apps/applications.applicationset.yaml)** —
  changed the `applications` ApplicationSet's default `syncOptions` from `Prune=confirm`
  to `Prune=true`, with a comment recording why (this ApplicationSet's `automated.enabled: true`
  default makes `Prune=confirm` unsatisfiable). `Delete=confirm` is left untouched — it
  only applies when a human explicitly runs `argocd app delete`, so it isn't implicated
  in this failure mode. `system.applicationset.yaml` is left untouched too — its
  `automated.prune: false` default means it isn't currently exposed to this bug; if a
  future infra app patch sets `prune: true` there, it should make the same `Prune=true`
  call at that point.

This is a `src/argocd/` file consumed directly by ArgoCD's seed bootstrap
(`projects/rhodes.akn/src/argocd/seed.apps/shoot.applicationset.yaml`), not rendered
through `dist:render`, so no `dist/` regeneration was needed.

## Technical Impact

### Behavioural Changes

After this merges and the ApplicationSet controller re-templates the Application spec,
every app under `dist/apps/*` on lungmen.akn (and any other cluster using this same
template) will auto-prune orphaned resources on the next automated sync **without a
manual confirmation step**. This is the intended fix — the confirmation step was never
actually being satisfied — but it does mean any resource that's been silently
diverging from git (present live, absent from git) will get deleted on the next sync
once this rolls out, instead of staying wedged. See "Out of scope / manual follow-up"
below for the specific case (`jellyseerr`/`mealie`/`silverbullet`) where that could
delete more than a stray NetworkPolicy if those apps' live resources still hold data
worth keeping.

### Regression Risk

**Medium.** The change makes pruning happen automatically instead of blocking forever,
which is strictly the intended behavior for apps that are supposed to be `automated` +
`selfHeal` in the first place — GitOps assumes git is the source of truth, and letting
"deleted from git" mean "deleted live" is the normal contract. The risk is entirely in
the transition: any currently-diverged live resource under this template (not just the
known CiliumNetworkPolicies) will be pruned on its next automated sync post-merge. I
could not enumerate all such resources without cluster access (see below) — the review
before merge should account for that.

### Observability

No alerting was added for long-running non-terminal `operationState.phase`. This repo
has no existing Application-health alerting stack to hook into (checked — no
Prometheus AlertManager rules or notification controller config referencing
`operationState` under `projects/*/src/`), and building one is a separate, larger piece
of work than this config fix. Worth a follow-up issue if it recurs after this fix.

## Testing Validation

- [ ] `dist:render --changed` run — n/a, this file isn't dist-rendered (confirmed above)
- [ ] `trunk check --filter=-conftest` — passed locally, no issues
- [ ] Manual: after merge, confirm `actual-budget`, `forgejo`, `immich`, `linkding`
      sync cleanly (see exact commands below — requires live cluster access this PR's
      environment doesn't have)

## Out of scope / manual follow-up

This worktree has no kubeconfig/OpenBao credentials, so the following items from
#1195's acceptance criteria could not be done here and need to be run manually
against the `omni-rhodes-akn` / `admin@lungmen.akn` contexts:

1. **Delete the orphaned live CiliumNetworkPolicy objects** for the 4 confirmed-stuck
   namespaces (safe now that git no longer declares them):

   ```sh
   for ns in actual-budget forgejo immich linkding; do
     kubectl --context admin@lungmen.akn -n "$ns" delete ciliumnetworkpolicy "allow-$ns-from-envoy-gateway"
   done
   ```

   `n8n` should get the same treatment — its git source is also orphaned (see Root
   Cause above), even though the issue didn't originally list it as confirmed-stuck:

   ```sh
   kubectl --context admin@lungmen.akn -n n8n delete ciliumnetworkpolicy allow-n8n-from-envoy-gateway
   ```

2. **Confirm whether `jellyseerr`, `mealie`, `silverbullet` Applications still exist
   live**, and if so what state they're in — their entire git source was removed, so if
   they're stuck it's on pruning the whole app, not one policy:

   ```sh
   kubectl --context omni-rhodes-akn -n lungmen-akn get applications.argoproj.io \
     jellyseerr mealie silverbullet -o jsonpath='{.status.operationState.phase} {.status.operationState.message}{"\n"}'
   ```

   If they're stuck, back up anything worth keeping (PVC contents especially — these
   apps were deliberately uninstalled, but check they don't still hold data you want)
   before this fix's `Prune=true` reaches them on the next automated sync.

3. **Check `rhodes.akn` and `amiya.akn` for the same stuck-sync pattern** — this fix
   only covers lungmen.akn's `applications.applicationset.yaml`; if `rhodes.akn` or
   `amiya.akn` template apps through an ApplicationSet with the same
   `automated.enabled: true` + `Prune=confirm` combination, they need the same
   treatment:

   ```sh
   kubectl --context omni-rhodes-akn get applications.argoproj.io -A -o json \
     | jq -r '.items[] | select(.status.operationState.phase=="Running" and (.status.operationState.startedAt | fromdateiso8601) < (now - 3600)) | .metadata.namespace + "/" + .metadata.name + ": " + .status.operationState.message'
   ```

## Related Issues

Refs #1195

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
