### PR TITLE
Document --server-side requirement for manual kubectl apply

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,14 @@ Agents cannot drive interactive tools or scroll through pagers. Always:
 If the user requests an interactive flow, explain the limitation and propose the non-interactive equivalent
 (`git rebase --continue`, `git add file1 file2`, `cat file`, …).
 
+### kubectl apply: always use --server-side
+
+Client-side `kubectl apply` writes the full manifest into the `kubectl.kubernetes.io/last-applied-configuration`
+annotation. Kubernetes caps total `metadata.annotations` size at 262144 bytes per object; large CRDs (CloudNativePG's
+`Cluster`/`Pooler` schemas, for example) can exceed that on their own, and once the annotation is oversized any further
+write to the object — server-side apply included — is rejected until the annotation is removed. Always pass
+`--server-side` for manual `kubectl apply` against this repo's clusters; it never writes that annotation.
+
 ### Destructive and shared-state operations
 
 - Never force-push, `git reset --hard`, drop branches, or rewrite published history without explicit user confirmation


### PR DESCRIPTION
## Summary

A full ArgoCD sync of `cloudnative-pg` on `rhodes.akn` fails because the live
`clusters.postgresql.cnpg.io` / `poolers.postgresql.cnpg.io` CRDs already
carry an oversized `kubectl.kubernetes.io/last-applied-configuration`
annotation from an earlier manual `kubectl apply` without `--server-side`.
Kubernetes rejects **any** further write to an object once its total
`metadata.annotations` exceed 262144 bytes, regardless of apply mode — so a
per-resource `ServerSideApply=true` annotation added on top doesn't unstick
the already-broken objects (see discussion below). That patch has been
dropped from this PR; instead, this documents the actual preventive rule so
the same annotation never grows past the limit on the next manual apply.

**Related Issue:** #1192

## Root Cause

```
one or more synchronization tasks completed unsuccessfully, reason: error when patching "/dev/shm/3878990208": CustomResourceDefinition.apiextensions.k8s.io "poolers.postgresql.cnpg.io" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes,error when patching "/dev/shm/4057517872": CustomResourceDefinition.apiextensions.k8s.io "clusters.postgresql.cnpg.io" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
```

Client-side `kubectl apply` serializes the full manifest into the
`last-applied-configuration` annotation. CloudNativePG's `Cluster` and
`Pooler` CRDs carry large enough OpenAPI schemas that a manual, client-side
`kubectl apply` (most likely during cluster bootstrap) pushed that
annotation past Kubernetes' 262144-byte limit. Once an object is in that
state, the API server rejects any subsequent write to it — server-side
apply included, since server-side apply doesn't remove pre-existing
annotations it doesn't own. `ServerSideApply=true` was already set at the
Application level in
`projects/rhodes.akn/src/argocd/shoot.apps/system.applicationset.yaml`
(confirmed via `git blame`, in place well before this issue), which
prevents the annotation from growing further, but doesn't retroactively
shrink what's already on the live objects.

## Fix

### AGENTS.md

- **[`AGENTS.md`](AGENTS.md)** — new "kubectl apply: always use --server-side" subsection documenting the annotation-size limit and mandating `--server-side` for manual `kubectl apply` against this repo's clusters, so this class of failure doesn't reoccur on the next manual operation (e.g. a cluster bootstrap).

## Technical Impact

### Behavioural Changes

Documentation only — no manifest or runtime change in this PR.

### Regression Risk

None. Docs-only change.

### Observability

N/A.

## Testing Validation

- [ ] N/A — documentation change, no manifests affected

## Related Issues

Addresses #1192 (partial). The live `rhodes.akn` CRDs most likely still
carry the oversized annotation predating this rule; clearing it
(`kubectl annotate crd/clusters.postgresql.cnpg.io
crd/poolers.postgresql.cnpg.io
kubectl.kubernetes.io/last-applied-configuration-`) is a one-time
live-cluster operation outside this PR's scope, per discussion on this
thread — not using "Closes" since that step isn't done here.

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
