### PR TITLE
Fix LXC upgrade smoke test false-positive on network units

### DIFF
--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh
@@ -570,8 +570,21 @@ lxc_upgrade() {
   '" || true)
   echo "${systemd_check}" >&2
 
+  # Known false-positives in the disposable smoke-test CT, not signals of a
+  # broken image:
+  #   - network-addresses-eth{0,1}.service: `pct create` here never clones
+  #     the source CT's net0/net1, so these interfaces don't exist in the
+  #     smoke CT and the unit has nothing to configure. Cloning real bridged
+  #     NICs instead would make the smoke CT bring up the same static IPs as
+  #     the live CT (baked into the image by
+  #     catalog/nix/modules/lxc-static-network and any per-site
+  #     networking.interfaces.<if> config) — a real duplicate-IP conflict on
+  #     the live network, worse than the false-positive it would fix.
+  #   - sys-kernel-debug.mount: debugfs isn't available in every LXC
+  #     profile; harmless and unrelated to image correctness.
   local failed_units
-  failed_units=$(tail -n +2 <<< "${systemd_check}")
+  failed_units=$(tail -n +2 <<< "${systemd_check}" \
+    | grep -vE 'network-addresses-eth[0-9]+\.service|sys-kernel-debug\.mount' || true)
   if [[ -n ${failed_units} ]]; then
     _fail "Smoke test failed — systemd unit(s) not running: $(tr '\n' ',' <<< "${failed_units}" | sed 's/,$//')"
     _lxc_ssh "${pve_host}" "pct stop ${smoke_id}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

The `lxc_upgrade` smoke test in the shared LXC helper always fails for the
omni appliance, aborting every upgrade attempt before it ever reaches the
live container. Root cause: two systemd units the check flags as failures
can structurally never succeed in the disposable smoke-test container, and
one is an unrelated container artifact. This excludes those specific,
known-benign failures from the check.

**Related Issue:** none — found while deploying #1177/#1199 (Dex expiry TTLs
on `omni.chezmoi.sh`).

## Root Cause

`lxc_upgrade` step 2 creates a disposable CT from the new template, cloning
only `rootfs`/`features`/`memory`/`cores` from the source CT — it never
clones `net0`/`net1`. A real smoke-test run against the omni appliance's
`2026.08.04` build produced:

```
● sys-kernel-debug.mount         loaded failed failed Kernel Debug File System
● network-addresses-eth0.service loaded failed failed Address configuration of eth0
● network-addresses-eth1.service loaded failed failed Address configuration of eth1
```

`network-addresses-eth{0,1}.service` are NixOS's own static-IP-assignment
units (`networking.interfaces.<if>.ipv4.addresses`, wired up by
`catalog/nix/modules/lxc-static-network` for `eth0` and directly in
`configuration.nix` for `eth1`). With no `net0`/`net1` cloned, neither
interface exists in the smoke CT, so these units have nothing to configure
and fail immediately — regardless of whether the image itself is correct.
`sys-kernel-debug.mount` fails because debugfs isn't available in every LXC
profile; it's unrelated to image correctness. `dex.service` (the actual
subject of the concurrent change) was healthy and active in that same run —
only these three known-irrelevant units were failing.

Cloning `net0`/`net1` into the smoke CT was considered and rejected: both
`eth0` and `eth1`'s static IPs are baked into the image itself, independent
of whatever `pct` net config is passed at create time, so the smoke CT would
bring up the *same addresses as the live CT* on the same network — a real
duplicate-IP conflict, worse than the false positive it fixes.

## Fix

### Shared LXC upgrade helper

- **[`projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh)**
  — filters `network-addresses-eth[0-9]+.service` and `sys-kernel-debug.mount`
  out of the smoke test's failed-units check, with a comment explaining why
  each is a structural false positive rather than a signal of a broken
  image. Every other failed unit still fails the smoke test as before.

## Technical Impact

### Behavioural Changes

The smoke test in `lxc_upgrade` step 2 no longer aborts on these two known
false-positive patterns. Any other failing unit (including `dex`, `caddy`,
`omni`, etc.) still fails the check exactly as before.

### Regression Risk

Low. The exclusion list is a narrow, explicit regex match on two specific,
well-understood unit names — it can't accidentally swallow an unrelated
failure. Affects all 5 appliances sharing `lxc.sh`, but only appliances
using `catalog.staticNetwork`/static `networking.interfaces` (currently just
omni) were ever hitting this false positive; the others are unaffected
either way.

### Observability

The full `systemctl --failed` output is still printed to the log before
filtering, so the excluded units remain visible for manual review even when
they don't block the upgrade.

## Testing Validation

- [x] Reproduced the false-positive failure on a real smoke-test run against
      the omni `2026.08.04` build before this fix
- [ ] Re-run the smoke test with this fix against the same build and confirm
      it now passes (only genuinely-relevant units block it)

## Related Issues

None — operational fix discovered mid-deployment, not tied to a filed issue.

---

<sub>AI-assisted with claude:claude-sonnet-5 under human supervision</sub>
