### PR TITLE
Provision lungmen-akn on Omni and bring up CCM/CSI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,12 +485,21 @@ importers:
       '@chezmoi.sh/pulumi-lib':
         specifier: workspace:*
         version: link:../../../../../catalog/pulumi/lib
+      '@chezmoi.sh/pulumi-proxmox-cluster-identity':
+        specifier: workspace:*
+        version: link:../../../../../catalog/pulumi/components/proxmox-cluster-identity
+      '@pulumi/kubernetes':
+        specifier: 'catalog:'
+        version: 4.33.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@26.1.0)(typescript@5.9.3))(typescript@5.9.3)
       '@pulumi/pangolin':
         specifier: workspace:*
         version: link:../../../../../catalog/pulumi/sdks/pangolin
       '@pulumi/pocket-id':
         specifier: workspace:*
         version: link:../../../../../catalog/pulumi/sdks/pocket-id
+      '@pulumi/proxmox':
+        specifier: workspace:*
+        version: link:../../../../../catalog/pulumi/sdks/proxmox
       '@pulumi/pulumi':
         specifier: 'catalog:'
         version: 3.250.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@26.1.0)(typescript@5.9.3))(typescript@5.9.3)

--- a/projects/chezmoi.sh/src/infrastructure/pulumi/Pulumi.chezmoi_sh.live.yaml
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/Pulumi.chezmoi_sh.live.yaml
@@ -23,5 +23,6 @@ config:
   proxmox:endpoint: https://pve-01.pve.chezmoi.sh:8006/api2/json
   proxmox:insecure: "true"
   chezmoi-sh-infra:rhodesAknKubernetesContext: omni-rhodes-akn
+  chezmoi-sh-infra:lungmenAknKubernetesContext: omni-lungmen-akn
   pocket-id-api:baseUrl: https://auth.chezmoi.sh
   pocket-id-api:apiKeyHeader: X-API-KEY

--- a/projects/chezmoi.sh/src/infrastructure/pulumi/stack/proxmox/access/index.ts
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/stack/proxmox/access/index.ts
@@ -1,7 +1,9 @@
 import "./pve-exporter";
 import "./rhodes-akn-bootstrap";
+import "./lungmen-akn-bootstrap";
 import "./omni";
 
+export * from "./lungmen-akn-bootstrap";
 export * from "./omni";
 export * from "./pve-exporter";
 export * from "./rhodes-akn-bootstrap";

--- a/projects/chezmoi.sh/src/infrastructure/pulumi/stack/proxmox/access/lungmen-akn-bootstrap.ts
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/stack/proxmox/access/lungmen-akn-bootstrap.ts
@@ -5,9 +5,6 @@ import * as pulumi from "@pulumi/pulumi";
 // -----------------------------------------------------------------------------
 // lungmen-akn-bootstrap@pve -- lets lungmen.akn's own Pulumi program
 // self-provision its PVE identities without consuming a token minted here.
-// Same pattern as rhodes-akn-bootstrap.ts (see that file for the full
-// reasoning) — mirrored here for lungmen.akn's Omni-based recreation
-// (chezmoidotsh/arcane#1188).
 // -----------------------------------------------------------------------------
 export const lungmenAknBootstrapUser = new proxmox.VirtualEnvironmentUser(
 	"pve-user-lungmen-akn-bootstrap",
@@ -31,19 +28,23 @@ export const lungmenAknBootstrapToken = new proxmox.UserToken(
 );
 
 // `lungmenAknBootstrapToken.value` is already the complete, ready-to-use
-// `USER@REALM!TOKENID=SECRET` credential string — see rhodes-akn-bootstrap.ts
-// for why this must be passed through as-is, not rebuilt from id/secret parts.
+// `USER@REALM!TOKENID=SECRET` credential string. Re-concatenating
+// userId!tokenName onto it produces a doubly-prefixed, invalid token that
+// Proxmox rejects with "authentication failure: no such user" — pass it
+// through as-is, don't rebuild it.
 const lungmenAknBootstrapApiToken = lungmenAknBootstrapToken.value;
 
 // Delivered as a direct Kubernetes Secret into lungmen-akn's own cluster —
-// deliberately NOT as a Pulumi StackReference output (see rhodes-akn-bootstrap.ts
-// for the per-project passphrase-isolation reasoning). Explicit named provider,
-// not the ambient default: unlike rhodes.akn (a single-context project), the
-// lungmen.akn Pulumi program's ambient default provider is currently unset
-// (every existing lungmen.akn stack file goes through Vault/ESO, not
-// Kubernetes directly) — pinning this resource to an explicit provider avoids
-// ever depending on an ambient config that could point at the wrong cluster
-// during the old-cluster/new-cluster transition.
+// deliberately NOT as a Pulumi StackReference output. Each project's Pulumi
+// state is encrypted with its own, unique passphrase (see
+// docs/procedures/infrastructure/INF-20260705-00.pulumi-state-and-import.md);
+// a cross-project StackReference read of a *secret* output only decrypts if
+// the reading stack also holds the exporting stack's passphrase, which this
+// repo deliberately does not share.
+//
+// Explicit named provider, not the ambient default: the lungmen.akn Pulumi
+// program's every other stack file goes through Vault/ESO, never Kubernetes
+// directly, so there is no ambient default provider to depend on here.
 const lungmenAkn = new k8s.Provider("lungmen-akn", {
 	context: new pulumi.Config().require("lungmenAknKubernetesContext"),
 });
@@ -78,8 +79,8 @@ export const lungmenAknBootstrapAcl = new proxmox.Acl(
 // /pool/talos (see lungmen.akn/stack/proxmox.ts). Proxmox rejects an ACL grant
 // at a path the granting user has no rights on itself ("403 Permission check
 // failed"), so this identity needs Permissions.Modify (+ Pool.Allocate for
-// the pool path) at exactly those two paths — same narrow-scope reasoning as
-// rhodes-akn-bootstrap.ts.
+// the pool path) at exactly those two paths — not Administrator, which would
+// grant far more than "assign permissions here".
 // -----------------------------------------------------------------------------
 const lungmenAknBootstrapDelegateRole = new proxmox.VirtualEnvironmentRole(
 	"pve-role-lungmen-akn-bootstrap-delegate",

--- a/projects/chezmoi.sh/src/infrastructure/pulumi/stack/proxmox/access/lungmen-akn-bootstrap.ts
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/stack/proxmox/access/lungmen-akn-bootstrap.ts
@@ -1,0 +1,110 @@
+import * as k8s from "@pulumi/kubernetes";
+import * as proxmox from "@pulumi/proxmox";
+import * as pulumi from "@pulumi/pulumi";
+
+// -----------------------------------------------------------------------------
+// lungmen-akn-bootstrap@pve -- lets lungmen.akn's own Pulumi program
+// self-provision its PVE identities without consuming a token minted here.
+// Same pattern as rhodes-akn-bootstrap.ts (see that file for the full
+// reasoning) — mirrored here for lungmen.akn's Omni-based recreation
+// (chezmoidotsh/arcane#1188).
+// -----------------------------------------------------------------------------
+export const lungmenAknBootstrapUser = new proxmox.VirtualEnvironmentUser(
+	"pve-user-lungmen-akn-bootstrap",
+	{
+		userId: "lungmen-akn-bootstrap@pve",
+		comment:
+			"Delegated access-control admin for lungmen.akn's own Pulumi program (scoped to /access)",
+		enabled: true,
+	},
+);
+
+export const lungmenAknBootstrapToken = new proxmox.UserToken(
+	"pve-token-lungmen-akn-bootstrap",
+	{
+		userId: lungmenAknBootstrapUser.userId,
+		tokenName: "bootstrap",
+		comment:
+			"lungmen.akn Pulumi stack — self-provisions its own PVE identities",
+		privilegesSeparation: false,
+	},
+);
+
+// `lungmenAknBootstrapToken.value` is already the complete, ready-to-use
+// `USER@REALM!TOKENID=SECRET` credential string — see rhodes-akn-bootstrap.ts
+// for why this must be passed through as-is, not rebuilt from id/secret parts.
+const lungmenAknBootstrapApiToken = lungmenAknBootstrapToken.value;
+
+// Delivered as a direct Kubernetes Secret into lungmen-akn's own cluster —
+// deliberately NOT as a Pulumi StackReference output (see rhodes-akn-bootstrap.ts
+// for the per-project passphrase-isolation reasoning). Explicit named provider,
+// not the ambient default: unlike rhodes.akn (a single-context project), the
+// lungmen.akn Pulumi program's ambient default provider is currently unset
+// (every existing lungmen.akn stack file goes through Vault/ESO, not
+// Kubernetes directly) — pinning this resource to an explicit provider avoids
+// ever depending on an ambient config that could point at the wrong cluster
+// during the old-cluster/new-cluster transition.
+const lungmenAkn = new k8s.Provider("lungmen-akn", {
+	context: new pulumi.Config().require("lungmenAknKubernetesContext"),
+});
+
+new k8s.core.v1.Secret(
+	"lungmen-akn-bootstrap-pve",
+	{
+		metadata: { name: "lungmen-akn-bootstrap-pve", namespace: "kube-system" },
+		type: "Opaque",
+		stringData: {
+			"api-token": lungmenAknBootstrapApiToken,
+		},
+	},
+	{ provider: lungmenAkn },
+);
+
+// Administrator at /access only -- can manage users/roles/ACLs/tokens, but
+// unlike an Administrator grant at `/`, cannot touch VMs, storage, or SDN.
+export const lungmenAknBootstrapAcl = new proxmox.Acl(
+	"pve-acl-lungmen-akn-bootstrap",
+	{
+		path: "/access",
+		userId: lungmenAknBootstrapUser.userId,
+		roleId: "Administrator",
+		propagate: true,
+	},
+);
+
+// -----------------------------------------------------------------------------
+// Delegation rights: lungmen.akn's Pulumi program uses this identity to grant
+// its own kubernetes-cloud-provider@pve identity ACLs at /nodes/pve-01 and
+// /pool/talos (see lungmen.akn/stack/proxmox.ts). Proxmox rejects an ACL grant
+// at a path the granting user has no rights on itself ("403 Permission check
+// failed"), so this identity needs Permissions.Modify (+ Pool.Allocate for
+// the pool path) at exactly those two paths — same narrow-scope reasoning as
+// rhodes-akn-bootstrap.ts.
+// -----------------------------------------------------------------------------
+const lungmenAknBootstrapDelegateRole = new proxmox.VirtualEnvironmentRole(
+	"pve-role-lungmen-akn-bootstrap-delegate",
+	{
+		roleId: "LungmenAknBootstrapDelegate",
+		privileges: ["Permissions.Modify", "Pool.Allocate"],
+	},
+);
+
+export const lungmenAknBootstrapAclNodePve01 = new proxmox.Acl(
+	"pve-acl-lungmen-akn-bootstrap-node-pve-01",
+	{
+		path: "/nodes/pve-01",
+		userId: lungmenAknBootstrapUser.userId,
+		roleId: lungmenAknBootstrapDelegateRole.roleId,
+		propagate: true,
+	},
+);
+
+export const lungmenAknBootstrapAclPoolTalos = new proxmox.Acl(
+	"pve-acl-lungmen-akn-bootstrap-pool-talos",
+	{
+		path: "/pool/talos",
+		userId: lungmenAknBootstrapUser.userId,
+		roleId: lungmenAknBootstrapDelegateRole.roleId,
+		propagate: true,
+	},
+);

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/.application.patch
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/.application.patch
@@ -1,0 +1,42 @@
+apiVersion: arcane.chezmoi.sh/v1alpha1
+kind: ApplicationPatch
+metadata: {}
+spec:
+  info:
+    # -- Application metadata
+    - name: Description
+      value: Proxmox VE integration — cloud-controller-manager (node providerID/topology) and CSI plugin (dynamic block-volume provisioning), bundled together since the CSI plugin depends on the CCM's node labels
+    - name: Category
+      value: Infrastructure / Cloud Provider
+    - name: CCM Version
+      # renovate: datasource=helm depName=proxmox-cloud-controller-manager registryUrl=oci://ghcr.io/sergelogvinov/charts
+      value: "0.2.29"
+    - name: CSI Version
+      # renovate: datasource=helm depName=proxmox-csi-plugin registryUrl=oci://ghcr.io/sergelogvinov/charts
+      value: "0.5.9"
+    # -- Documentation & Resources
+    - name: CCM Documentation
+      value: https://github.com/sergelogvinov/proxmox-cloud-controller-manager/blob/main/docs/install.md
+    - name: CSI Documentation
+      value: https://github.com/sergelogvinov/proxmox-csi-plugin/blob/main/docs/options.md
+    - name: CCM GitHub Repository
+      value: https://github.com/sergelogvinov/proxmox-cloud-controller-manager
+    - name: CSI GitHub Repository
+      value: https://github.com/sergelogvinov/proxmox-csi-plugin
+    - name: CCM Helm Chart
+      value: oci://ghcr.io/sergelogvinov/charts/proxmox-cloud-controller-manager
+    - name: CSI Helm Chart
+      value: oci://ghcr.io/sergelogvinov/charts/proxmox-csi-plugin
+
+  syncPolicy:
+    automated:
+      enabled: false # Manual apply: this Application's CCM/CSI credentials come from a Pulumi-delivered Secret, not ArgoCD/ESO, so auto-sync could apply a config update against a stale or not-yet-rotated token and disrupt in-flight storage operations.
+
+    # proxmox-csi-plugin's node DaemonSet needs privileged/hostPath access
+    # (mounting Proxmox-attached block devices into kubelet's pod dir) --
+    # the "restricted" Pod Security default rejects that, so relax
+    # enforcement for the namespace ArgoCD creates for this Application.
+    managedNamespaceMetadata:
+      labels:
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/enforce-version: v1.33

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/apps.v1.DaemonSet.proxmox-csi-plugin-node.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/apps.v1.DaemonSet.proxmox-csi-plugin-node.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxmox-csi-plugin
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: proxmox-csi-plugin
+    app.kubernetes.io/version: v0.19.1
+    helm.sh/chart: proxmox-csi-plugin-0.5.9
+  name: proxmox-csi-plugin-node
+  namespace: proxmox-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: node
+      app.kubernetes.io/instance: proxmox-csi-plugin
+      app.kubernetes.io/name: proxmox-csi-plugin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: node
+        app.kubernetes.io/instance: proxmox-csi-plugin
+        app.kubernetes.io/name: proxmox-csi-plugin
+    spec:
+      containers:
+      - args:
+        - -v=5
+        - --csi-address=unix:///csi/csi.sock
+        - --node-id=$(NODE_NAME)
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: oci.chezmoi.sh/ghcr.io/sergelogvinov/proxmox-csi-node:v0.19.1
+        imagePullPolicy: IfNotPresent
+        name: proxmox-csi-plugin-node
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - SYS_ADMIN
+            - CHOWN
+            - DAC_OVERRIDE
+            drop:
+            - ALL
+          privileged: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /csi
+          name: socket
+        - mountPath: /var/lib/kubelet
+          mountPropagation: Bidirectional
+          name: kubelet
+        - mountPath: /dev
+          name: dev
+        - mountPath: /sys
+          name: sys
+      - args:
+        - -v=5
+        - --csi-address=unix:///csi/csi.sock
+        - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.proxmox.sinextra.dev/csi.sock
+        image: oci.chezmoi.sh/registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0
+        imagePullPolicy: IfNotPresent
+        name: csi-node-driver-registrar
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /csi
+          name: socket
+        - mountPath: /registration
+          name: registration
+      - args:
+        - -v=5
+        - --csi-address=unix:///csi/csi.sock
+        image: oci.chezmoi.sh/registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        imagePullPolicy: IfNotPresent
+        name: liveness-probe
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /csi
+          name: socket
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      securityContext:
+        runAsGroup: 0
+        runAsUser: 0
+      serviceAccountName: proxmox-csi-plugin-node
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet/plugins/csi.proxmox.sinextra.dev/
+          type: DirectoryOrCreate
+        name: socket
+      - hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: Directory
+        name: registration
+      - hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+        name: kubelet
+      - hostPath:
+          path: /dev
+          type: Directory
+        name: dev
+      - hostPath:
+          path: /sys
+          type: Directory
+        name: sys
+  updateStrategy:
+    type: RollingUpdate

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/apps.v1.Deployment.proxmox-cloud-controller-manager.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/apps.v1.Deployment.proxmox-cloud-controller-manager.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxmox-cloud-controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: proxmox-cloud-controller-manager
+    app.kubernetes.io/version: v0.14.0
+    helm.sh/chart: proxmox-cloud-controller-manager-0.2.29
+  name: proxmox-cloud-controller-manager
+  namespace: proxmox-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: proxmox-cloud-controller-manager
+      app.kubernetes.io/name: proxmox-cloud-controller-manager
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ce080eff0c26b50fe73bf9fcda017c8ad47c1000729fd0c555cfe3535c6d6222
+      labels:
+        app.kubernetes.io/instance: proxmox-cloud-controller-manager
+        app.kubernetes.io/name: proxmox-cloud-controller-manager
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: proxmox-cloud-controller-manager
+                  app.kubernetes.io/name: proxmox-cloud-controller-manager
+              topologyKey: topology.kubernetes.io/zone
+            weight: 1
+      containers:
+      - args:
+        - --v=2
+        - --cloud-provider=proxmox
+        - --cloud-config=/etc/proxmox/config.yaml
+        - --controllers=cloud-node,cloud-node-lifecycle
+        - --leader-elect-resource-name=cloud-controller-manager-proxmox
+        - --use-service-account-credentials
+        - --secure-port=10258
+        - --authorization-always-allow-paths=/healthz,/livez,/readyz,/metrics
+        env:
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        image: oci.chezmoi.sh/ghcr.io/sergelogvinov/proxmox-cloud-controller-manager:v0.14.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: metrics
+            scheme: HTTPS
+          initialDelaySeconds: 20
+          periodSeconds: 30
+          timeoutSeconds: 5
+        name: proxmox-cloud-controller-manager
+        ports:
+        - containerPort: 10258
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/proxmox
+          name: cloud-config
+          readOnly: true
+      enableServiceLinks: false
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+      priorityClassName: system-cluster-critical
+      securityContext:
+        fsGroup: 10258
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 10258
+        runAsNonRoot: true
+        runAsUser: 10258
+      serviceAccountName: proxmox-cloud-controller-manager
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: proxmox-cloud-controller-manager
+            app.kubernetes.io/name: proxmox-cloud-controller-manager
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+      volumes:
+      - name: cloud-config
+        secret:
+          defaultMode: 416
+          items:
+          - key: config.yaml
+            path: config.yaml
+          secretName: proxmox-cloud-provider

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/apps.v1.Deployment.proxmox-csi-plugin-controller.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/apps.v1.Deployment.proxmox-csi-plugin-controller.yaml
@@ -1,0 +1,191 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxmox-csi-plugin
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: proxmox-csi-plugin
+    app.kubernetes.io/version: v0.19.1
+    helm.sh/chart: proxmox-csi-plugin-0.5.9
+  name: proxmox-csi-plugin-controller
+  namespace: proxmox-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: proxmox-csi-plugin
+      app.kubernetes.io/name: proxmox-csi-plugin
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: ce080eff0c26b50fe73bf9fcda017c8ad47c1000729fd0c555cfe3535c6d6222
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: proxmox-csi-plugin
+        app.kubernetes.io/name: proxmox-csi-plugin
+    spec:
+      containers:
+      - args:
+        - -v=5
+        - --csi-address=unix:///csi/csi.sock
+        - --cloud-config=/etc/proxmox/config.yaml
+        image: oci.chezmoi.sh/ghcr.io/sergelogvinov/proxmox-csi-controller:v0.19.1
+        imagePullPolicy: IfNotPresent
+        name: proxmox-csi-plugin-controller
+        ports: null
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /etc/proxmox/
+          name: cloud-config
+      - args:
+        - -v=5
+        - --csi-address=unix:///csi/csi.sock
+        - --timeout=3m
+        - --leader-election
+        - --default-fstype=ext4
+        image: oci.chezmoi.sh/registry.k8s.io/sig-storage/csi-attacher:v4.10.0
+        imagePullPolicy: IfNotPresent
+        name: csi-attacher
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      - args:
+        - -v=5
+        - --csi-address=unix:///csi/csi.sock
+        - --timeout=3m
+        - --leader-election
+        - --enable-capacity
+        - --capacity-ownerref-level=2
+        - --default-fstype=ext4
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: oci.chezmoi.sh/registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
+        imagePullPolicy: IfNotPresent
+        name: csi-provisioner
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      - args:
+        - -v=5
+        - --csi-address=unix:///csi/csi.sock
+        - --timeout=3m
+        - --handle-volume-inuse-error=false
+        - --leader-election
+        image: oci.chezmoi.sh/registry.k8s.io/sig-storage/csi-resizer:v1.14.0
+        imagePullPolicy: IfNotPresent
+        name: csi-resizer
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      - args:
+        - -v=5
+        - --csi-address=unix:///csi/csi.sock
+        image: oci.chezmoi.sh/registry.k8s.io/sig-storage/livenessprobe:v2.16.0
+        imagePullPolicy: IfNotPresent
+        name: liveness-probe
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+      enableServiceLinks: false
+      hostAliases: []
+      initContainers: []
+      priorityClassName: system-cluster-critical
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+      serviceAccountName: proxmox-csi-plugin-controller
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: controller
+            app.kubernetes.io/instance: proxmox-csi-plugin
+            app.kubernetes.io/name: proxmox-csi-plugin
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+      volumes:
+      - emptyDir: {}
+        name: socket-dir
+      - name: cloud-config
+        secret:
+          items:
+          - key: config.yaml
+            path: config.yaml
+          secretName: proxmox-cloud-provider

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/cilium.io.v2.CiliumNetworkPolicy.allow-intra-namespace.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/cilium.io.v2.CiliumNetworkPolicy.allow-intra-namespace.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Permits intra-namespace communication in the proxmox-system namespace. Access to the
+      Kubernetes API and the Proxmox VE API is granted by the other policies in this directory,
+      not here.
+  name: allow-intra-namespace
+  namespace: proxmox-system
+spec:
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: proxmox-system
+  endpointSelector: {}
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: proxmox-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/cilium.io.v2.CiliumNetworkPolicy.allow-proxmox-to-kubernetes-api.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/cilium.io.v2.CiliumNetworkPolicy.allow-proxmox-to-kubernetes-api.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows the Proxmox cloud-controller-manager and CSI plugin (controller and node pods) to
+      access the Kubernetes API server. CCM patches Node objects with providerID/topology; the
+      CSI controller creates/attaches PersistentVolumes; the CSI node plugin reads its own Node
+      object (proxmox-csi-plugin-node's ClusterRole grants get on nodes).
+  name: allow-proxmox-to-kubernetes-api
+  namespace: proxmox-system
+spec:
+  egress:
+  - toEntities:
+    - kube-apiserver
+  endpointSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: In
+      values:
+      - proxmox-cloud-controller-manager
+      - proxmox-csi-plugin

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/cilium.io.v2.CiliumNetworkPolicy.allow-proxmox-to-proxmox-api.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/cilium.io.v2.CiliumNetworkPolicy.allow-proxmox-to-proxmox-api.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows the Proxmox cloud-controller-manager and CSI controller (not the CSI node
+      DaemonSet — verified against templates/node-deployment.yaml: it never mounts cloud-config
+      or takes a --cloud-config flag, so it never calls the Proxmox API directly) to reach the
+      Proxmox VE API (pve-01.pve.chezmoi.sh:8006) referenced in their config.yaml cluster entry,
+      for node topology lookups (CCM) and volume attach/detach operations (CSI controller).
+  name: allow-proxmox-to-proxmox-api
+  namespace: proxmox-system
+spec:
+  egress:
+  - toFQDNs:
+    - matchName: pve-01.pve.chezmoi.sh
+    toPorts:
+    - ports:
+      - port: "8006"
+        protocol: TCP
+  endpointSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: In
+      values:
+      - proxmox-cloud-controller-manager
+      - proxmox-csi-plugin
+    - key: app.kubernetes.io/component
+      operator: NotIn
+      values:
+      - node

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/core.v1.ServiceAccount.proxmox-cloud-controller-manager.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/core.v1.ServiceAccount.proxmox-cloud-controller-manager.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxmox-cloud-controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: proxmox-cloud-controller-manager
+    app.kubernetes.io/version: v0.14.0
+    helm.sh/chart: proxmox-cloud-controller-manager-0.2.29
+  name: proxmox-cloud-controller-manager
+  namespace: proxmox-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/core.v1.ServiceAccount.proxmox-csi-plugin-controller.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/core.v1.ServiceAccount.proxmox-csi-plugin-controller.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxmox-csi-plugin
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: proxmox-csi-plugin
+    app.kubernetes.io/version: v0.19.1
+    helm.sh/chart: proxmox-csi-plugin-0.5.9
+  name: proxmox-csi-plugin-controller
+  namespace: proxmox-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/core.v1.ServiceAccount.proxmox-csi-plugin-node.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/core.v1.ServiceAccount.proxmox-csi-plugin-node.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxmox-csi-plugin
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: proxmox-csi-plugin
+    app.kubernetes.io/version: v0.19.1
+    helm.sh/chart: proxmox-csi-plugin-0.5.9
+  name: proxmox-csi-plugin-node
+  namespace: proxmox-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.ClusterRole.proxmox-csi-plugin-controller.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.ClusterRole.proxmox-csi-plugin-controller.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxmox-csi-plugin
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: proxmox-csi-plugin
+    app.kubernetes.io/version: v0.19.1
+    helm.sh/chart: proxmox-csi-plugin-0.5.9
+  name: proxmox-csi-plugin-controller
+  namespace: proxmox-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.ClusterRole.proxmox-csi-plugin-node.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.ClusterRole.proxmox-csi-plugin-node.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxmox-csi-plugin
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: proxmox-csi-plugin
+    app.kubernetes.io/version: v0.19.1
+    helm.sh/chart: proxmox-csi-plugin-0.5.9
+  name: proxmox-csi-plugin-node
+  namespace: proxmox-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.ClusterRole.system-proxmox-cloud-controller-manager.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.ClusterRole.system-proxmox-cloud-controller-manager.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxmox-cloud-controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: proxmox-cloud-controller-manager
+    app.kubernetes.io/version: v0.14.0
+    helm.sh/chart: proxmox-cloud-controller-manager-0.2.29
+  name: system:proxmox-cloud-controller-manager
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.ClusterRoleBinding.proxmox-csi-plugin-controller.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.ClusterRoleBinding.proxmox-csi-plugin-controller.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxmox-csi-plugin
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: proxmox-csi-plugin
+    app.kubernetes.io/version: v0.19.1
+    helm.sh/chart: proxmox-csi-plugin-0.5.9
+  name: proxmox-csi-plugin-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxmox-csi-plugin-controller
+subjects:
+- kind: ServiceAccount
+  name: proxmox-csi-plugin-controller
+  namespace: proxmox-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.ClusterRoleBinding.proxmox-csi-plugin-node.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.ClusterRoleBinding.proxmox-csi-plugin-node.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proxmox-csi-plugin-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxmox-csi-plugin-node
+subjects:
+- kind: ServiceAccount
+  name: proxmox-csi-plugin-node
+  namespace: proxmox-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.ClusterRoleBinding.system-proxmox-cloud-controller-manager.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.ClusterRoleBinding.system-proxmox-cloud-controller-manager.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:proxmox-cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:proxmox-cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: proxmox-cloud-controller-manager
+  namespace: proxmox-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.Role.proxmox-csi-plugin-controller.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.Role.proxmox-csi-plugin-controller.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxmox-csi-plugin
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: proxmox-csi-plugin
+    app.kubernetes.io/version: v0.19.1
+    helm.sh/chart: proxmox-csi-plugin-0.5.9
+  name: proxmox-csi-plugin-controller
+  namespace: proxmox-system
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csistoragecapacities
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.RoleBinding.proxmox-csi-plugin-controller.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.RoleBinding.proxmox-csi-plugin-controller.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: proxmox-csi-plugin
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: proxmox-csi-plugin
+    app.kubernetes.io/version: v0.19.1
+    helm.sh/chart: proxmox-csi-plugin-0.5.9
+  name: proxmox-csi-plugin-controller
+  namespace: proxmox-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: proxmox-csi-plugin-controller
+subjects:
+- kind: ServiceAccount
+  name: proxmox-csi-plugin-controller
+  namespace: proxmox-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.RoleBinding.system-proxmox-cloud-controller-manager-extension-apiserver-authentication-reader.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/rbac.authorization.k8s.io.v1.RoleBinding.system-proxmox-cloud-controller-manager-extension-apiserver-authentication-reader.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:proxmox-cloud-controller-manager:extension-apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: proxmox-cloud-controller-manager
+  namespace: proxmox-system

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/storage.k8s.io.v1.CSIDriver.csi.proxmox.sinextra.dev.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/storage.k8s.io.v1.CSIDriver.csi.proxmox.sinextra.dev.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: csi.proxmox.sinextra.dev
+spec:
+  attachRequired: true
+  podInfoOnMount: true
+  storageCapacity: true
+  volumeLifecycleModes:
+  - Persistent

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/storage.k8s.io.v1.StorageClass.proxmox-lvmthin-ext4.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/storage.k8s.io.v1.StorageClass.proxmox-lvmthin-ext4.yaml
@@ -1,0 +1,15 @@
+---
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: proxmox-lvmthin-ext4
+parameters:
+  cache: writethrough
+  csi.storage.k8s.io/fstype: ext4
+  storage: nvme-lvm
+provisioner: csi.proxmox.sinextra.dev
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/storage.k8s.io.v1.StorageClass.proxmox-lvmthin-xfs.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/storage.k8s.io.v1.StorageClass.proxmox-lvmthin-xfs.yaml
@@ -1,0 +1,13 @@
+---
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: proxmox-lvmthin-xfs
+parameters:
+  cache: directsync
+  csi.storage.k8s.io/fstype: xfs
+  storage: nvme-lvm
+provisioner: csi.proxmox.sinextra.dev
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# NOT yet wired into ../kustomization.yaml (that file is still the OLD lungmen
+# cluster's live, ArgoCD-managed Cilium source — do not touch it here). These
+# 2 policies were applied directly to the new lungmen-akn cluster to unblock
+# proxmox-cloud-controller-manager (chezmoidotsh/arcane issue 1188); wiring
+# this into the real dist/ pipeline is part of the full Cilium Helm-managed
+# adoption (mirrors rhodes.akn's cilium/ directory), not done here.
+# allow-ingress-gateway.yaml is intentionally omitted — no ingress gateway
+# exists on this cluster yet.
+resources:
+  - network-policy.allow-dns.yaml
+  - network-policy.allow-kube-system-full.yaml

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/kustomization.yaml
@@ -1,14 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# NOT yet wired into ../kustomization.yaml (that file is still the OLD lungmen
-# cluster's live, ArgoCD-managed Cilium source — do not touch it here). These
-# 2 policies were applied directly to the new lungmen-akn cluster to unblock
-# proxmox-cloud-controller-manager (chezmoidotsh/arcane issue 1188); wiring
-# this into the real dist/ pipeline is part of the full Cilium Helm-managed
-# adoption (mirrors rhodes.akn's cilium/ directory), not done here.
-# allow-ingress-gateway.yaml is intentionally omitted — no ingress gateway
-# exists on this cluster yet.
+# NOT yet wired into ../kustomization.yaml: this holds the full Cilium
+# Helm-managed release (cluster.name/id for ClusterMesh, L2 announcement
+# policy), which isn't adopted yet. allow-ingress-gateway.yaml is omitted —
+# no ingress gateway exists on this cluster yet.
 resources:
   - network-policy.allow-dns.yaml
   - network-policy.allow-kube-system-full.yaml

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/network-policy.allow-dns.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/network-policy.allow-dns.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Lets every real pod resolve DNS via CoreDNS. Scoped to pods with a namespace label
+      (not endpointSelector: {}) to avoid matching Cilium's reserved identities like
+      reserved:ingress — see rhodes.akn's allow-ingress-gateway.yaml for why that matters.
+  name: allow-dns
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: io.kubernetes.pod.namespace
+        operator: Exists
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+          rules:
+            dns:
+              - matchPattern: "*"

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/network-policy.allow-kube-system-full.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/network-policy.allow-kube-system-full.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      kube-system (Cilium, CoreDNS, Kubernetes API, ...) needs far broader access than DNS/ingress
+      alone, so keep it fully open rather than relying on omission. Uses fromEntities/
+      toEntities: [all], not a bare `- {}` — under enableDefaultDeny, an empty rule item matches
+      nothing once another policy already default-denies this endpoint, silently dropping all
+      kube-system traffic with no error surfaced anywhere. Confirmed live on lungmen-akn
+      (chezmoidotsh/arcane issue 1188): without this, allow-dns.yaml's broad endpointSelector
+      catches CoreDNS's own pods too, cutting off their forward to the Talos host-DNS link-local
+      resolver (169.254.116.108) and turning every external DNS query into a silent SERVFAIL.
+  name: allow-kube-system-full
+  namespace: kube-system
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEntities:
+        - all
+  egress:
+    - toEntities:
+        - all

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/network-policy.allow-kube-system-full.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/network-policy.allow-kube-system-full.yaml
@@ -8,10 +8,10 @@ metadata:
       alone, so keep it fully open rather than relying on omission. Uses fromEntities/
       toEntities: [all], not a bare `- {}` — under enableDefaultDeny, an empty rule item matches
       nothing once another policy already default-denies this endpoint, silently dropping all
-      kube-system traffic with no error surfaced anywhere. Confirmed live on lungmen-akn
-      (chezmoidotsh/arcane issue 1188): without this, allow-dns.yaml's broad endpointSelector
-      catches CoreDNS's own pods too, cutting off their forward to the Talos host-DNS link-local
-      resolver (169.254.116.108) and turning every external DNS query into a silent SERVFAIL.
+      kube-system traffic with no error surfaced anywhere — including allow-dns.yaml's broad
+      endpointSelector, which also catches CoreDNS's own pods and would otherwise cut off their
+      forward to the Talos host-DNS link-local resolver (169.254.116.108), turning every
+      external DNS query into a silent SERVFAIL.
   name: allow-kube-system-full
   namespace: kube-system
 # trunk-ignore(trivy/KSV-0037): intentional, kube-system needs broad access — see description

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/network-policy.allow-kube-system-full.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/network-policy.allow-kube-system-full.yaml
@@ -14,6 +14,7 @@ metadata:
       resolver (169.254.116.108) and turning every external DNS query into a silent SERVFAIL.
   name: allow-kube-system-full
   namespace: kube-system
+# trunk-ignore(trivy/KSV-0037): intentional, kube-system needs broad access — see description
 spec:
   endpointSelector: {}
   ingress:

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/.application.patch
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/.application.patch
@@ -1,0 +1,42 @@
+apiVersion: arcane.chezmoi.sh/v1alpha1
+kind: ApplicationPatch
+metadata: {}
+spec:
+  info:
+    # -- Application metadata
+    - name: Description
+      value: Proxmox VE integration — cloud-controller-manager (node providerID/topology) and CSI plugin (dynamic block-volume provisioning), bundled together since the CSI plugin depends on the CCM's node labels
+    - name: Category
+      value: Infrastructure / Cloud Provider
+    - name: CCM Version
+      # renovate: datasource=helm depName=proxmox-cloud-controller-manager registryUrl=oci://ghcr.io/sergelogvinov/charts
+      value: "0.2.29"
+    - name: CSI Version
+      # renovate: datasource=helm depName=proxmox-csi-plugin registryUrl=oci://ghcr.io/sergelogvinov/charts
+      value: "0.5.9"
+    # -- Documentation & Resources
+    - name: CCM Documentation
+      value: https://github.com/sergelogvinov/proxmox-cloud-controller-manager/blob/main/docs/install.md
+    - name: CSI Documentation
+      value: https://github.com/sergelogvinov/proxmox-csi-plugin/blob/main/docs/options.md
+    - name: CCM GitHub Repository
+      value: https://github.com/sergelogvinov/proxmox-cloud-controller-manager
+    - name: CSI GitHub Repository
+      value: https://github.com/sergelogvinov/proxmox-csi-plugin
+    - name: CCM Helm Chart
+      value: oci://ghcr.io/sergelogvinov/charts/proxmox-cloud-controller-manager
+    - name: CSI Helm Chart
+      value: oci://ghcr.io/sergelogvinov/charts/proxmox-csi-plugin
+
+  syncPolicy:
+    automated:
+      enabled: false # Manual apply: this Application's CCM/CSI credentials come from a Pulumi-delivered Secret, not ArgoCD/ESO, so auto-sync could apply a config update against a stale or not-yet-rotated token and disrupt in-flight storage operations.
+
+    # proxmox-csi-plugin's node DaemonSet needs privileged/hostPath access
+    # (mounting Proxmox-attached block devices into kubelet's pod dir) --
+    # the "restricted" Pod Security default rejects that, so relax
+    # enforcement for the namespace ArgoCD creates for this Application.
+    managedNamespaceMetadata:
+      labels:
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/enforce-version: v1.33

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/kustomization.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: proxmox-system
+
+helmCharts:
+  - repo: oci://ghcr.io/sergelogvinov/charts
+    name: proxmox-cloud-controller-manager
+    # renovate: datasource=helm depName=proxmox-cloud-controller-manager registryUrl=oci://ghcr.io/sergelogvinov/charts
+    version: 0.2.29
+
+    releaseName: proxmox-cloud-controller-manager
+    namespace: proxmox-system
+
+    valuesFile: proxmox-cloud-controller-manager.helmvalues/default.yaml
+
+  - repo: oci://ghcr.io/sergelogvinov/charts
+    name: proxmox-csi-plugin
+    # renovate: datasource=helm depName=proxmox-csi-plugin registryUrl=oci://ghcr.io/sergelogvinov/charts
+    version: 0.5.9
+
+    releaseName: proxmox-csi-plugin
+    namespace: proxmox-system
+
+    valuesFile: proxmox-csi-plugin.helmvalues/default.yaml
+
+resources:
+  - security/
+
+images:
+  - name: ghcr.io/sergelogvinov/proxmox-cloud-controller-manager
+    newName: oci.chezmoi.sh/ghcr.io/sergelogvinov/proxmox-cloud-controller-manager
+  - name: ghcr.io/sergelogvinov/proxmox-csi-controller
+    newName: oci.chezmoi.sh/ghcr.io/sergelogvinov/proxmox-csi-controller
+  - name: ghcr.io/sergelogvinov/proxmox-csi-node
+    newName: oci.chezmoi.sh/ghcr.io/sergelogvinov/proxmox-csi-node
+  - name: registry.k8s.io/sig-storage/csi-attacher
+    newName: oci.chezmoi.sh/registry.k8s.io/sig-storage/csi-attacher
+  - name: registry.k8s.io/sig-storage/csi-node-driver-registrar
+    newName: oci.chezmoi.sh/registry.k8s.io/sig-storage/csi-node-driver-registrar
+  - name: registry.k8s.io/sig-storage/csi-provisioner
+    newName: oci.chezmoi.sh/registry.k8s.io/sig-storage/csi-provisioner
+  - name: registry.k8s.io/sig-storage/csi-resizer
+    newName: oci.chezmoi.sh/registry.k8s.io/sig-storage/csi-resizer
+  - name: registry.k8s.io/sig-storage/livenessprobe
+    newName: oci.chezmoi.sh/registry.k8s.io/sig-storage/livenessprobe

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/proxmox-cloud-controller-manager.helmvalues/default.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/proxmox-cloud-controller-manager.helmvalues/default.yaml
@@ -1,0 +1,60 @@
+---
+# proxmox-cloud-controller-manager — provides node topology labels and
+# providerID that proxmox-csi-plugin relies on for volume scheduling.
+# Cilium handles all networking (route/service controllers stay disabled).
+# Same setup as rhodes.akn — see that project's own copy of this file for
+# the validated experiment reference.
+
+# config.clusters is intentionally left unset (chart default: []), which
+# also keeps the chart from rendering its own Secret/proxmox-cloud-controller-
+# manager (templates/secrets.yaml guards on `len .Values.config.clusters`).
+# The Proxmox API token is Pulumi-owned end-to-end: Pulumi already needs
+# privileged kubeconfig access to deliver it, so routing it through
+# Vault/ESO would add indirection with no confidentiality benefit. That
+# Secret is created directly by
+# projects/lungmen.akn/src/infrastructure/pulumi/stack/proxmox.ts, which
+# self-provisions the kubernetes-cloud-provider-lungmen@pve identity against
+# pve-01 (via catalog/pulumi/components/proxmox-cluster-identity,
+# authenticated with a delegated credential minted by chezmoi.sh's
+# stack/proxmox/access/lungmen-akn-bootstrap.ts, scoped to /access only)
+# rather than consuming a token minted by that stack.
+# proxmox-csi-plugin shares this same Secret — see that chart's own
+# helmvalues comment for the merged-identity trade-off. Matches upstream's
+# own secrets.yaml shape (verified against
+# https://artifacthub.io/packages/helm/proxmox-ccm/proxmox-cloud-controller-manager?modal=template&template=secrets.yaml):
+#
+#   apiVersion: v1
+#   kind: Secret
+#   metadata:
+#     name: proxmox-cloud-provider
+#     namespace: proxmox-system
+#   data:
+#     config.yaml: <base64 of the YAML below>
+#
+#   clusters:
+#     - url: https://pve-01.pve.chezmoi.sh:8006/api2/json
+#       token_id: "kubernetes-cloud-provider-lungmen@pve!cloud-provider"
+#       token_secret: "<real token>"
+#       region: homelab
+#   features:
+#     provider: default
+#
+# existingConfigSecret/existingConfigSecretKey below point the Deployment at
+# that Pulumi-owned Secret instead.
+existingConfigSecret: proxmox-cloud-provider # trunk-ignore(checkov/CKV_SECRET_6): false positive; this is a reference to an existing secret, not a secret value.
+existingConfigSecretKey: config.yaml
+
+enabledControllers:
+  - cloud-node
+  - cloud-node-lifecycle
+
+nodeSelector:
+  node-role.kubernetes.io/control-plane: ""
+
+tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+  - effect: NoSchedule
+    key: node.cloudprovider.kubernetes.io/uninitialized
+    operator: Exists

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/proxmox-cloud-controller-manager.helmvalues/default.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/proxmox-cloud-controller-manager.helmvalues/default.yaml
@@ -2,8 +2,7 @@
 # proxmox-cloud-controller-manager — provides node topology labels and
 # providerID that proxmox-csi-plugin relies on for volume scheduling.
 # Cilium handles all networking (route/service controllers stay disabled).
-# Same setup as rhodes.akn — see that project's own copy of this file for
-# the validated experiment reference.
+# Validated in docs/experiments/20260617-proxmox-csi-ccm/.
 
 # config.clusters is intentionally left unset (chart default: []), which
 # also keeps the chart from rendering its own Secret/proxmox-cloud-controller-

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/proxmox-csi-plugin.helmvalues/default.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/proxmox-csi-plugin.helmvalues/default.yaml
@@ -1,0 +1,53 @@
+---
+# proxmox-csi-plugin — dynamic provisioning of block volumes on the Proxmox
+# hypervisor side. Volumes are decoupled from VM lifecycle (survive VM
+# rebuilds, reattach to any VM on the same Proxmox node). Replaces Longhorn
+# on this cluster (chezmoidotsh/arcane issue 1188 recreation) — same
+# rationale as rhodes.akn (see docs/experiments/20260617-proxmox-csi-ccm/,
+# conclusion #9).
+
+# storageClass entries below match rhodes.akn's (same pve-01 hypervisor,
+# same nvme-lvm storage backend — confirmed against this cluster's own
+# machine classes, catalog/omni/machineclasses/, which pin
+# storage_selector: 'name == "nvme-lvm"').
+
+# config.clusters is intentionally left unset (chart default: []) — same
+# Pulumi-owned token delivery as proxmox-cloud-controller-manager.helmvalues
+# /default.yaml in this same directory (see that file's comment for the full
+# rationale and the exact Secret shape Pulumi creates). CCM and CSI
+# deliberately share the same kubernetes-cloud-provider-lungmen@pve
+# identity/token and the same Secret here — a simplification over having two
+# separate least-privilege identities; see stack/proxmox.ts's header comment
+# for the trade-off. existingConfigSecret/existingConfigSecretKey below
+# point this chart's controller and node pods at that shared, Pulumi-owned
+# Secret.
+existingConfigSecret: proxmox-cloud-provider # trunk-ignore(checkov/CKV_SECRET_6): false positive; this is a reference to an existing secret, not a secret value.
+existingConfigSecretKey: config.yaml
+
+storageClass:
+  - name: proxmox-lvmthin-ext4
+    storage: nvme-lvm
+    reclaimPolicy: Delete
+    fstype: ext4
+    cache: writethrough
+    ssd: false
+    annotations:
+      storageclass.kubernetes.io/is-default-class: "true"
+  - name: proxmox-lvmthin-xfs
+    storage: nvme-lvm
+    reclaimPolicy: Delete
+    fstype: xfs
+    cache: directsync
+    ssd: false
+
+controller:
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoSchedule
+
+node:
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoSchedule

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/proxmox-csi-plugin.helmvalues/default.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/proxmox-csi-plugin.helmvalues/default.yaml
@@ -2,14 +2,12 @@
 # proxmox-csi-plugin — dynamic provisioning of block volumes on the Proxmox
 # hypervisor side. Volumes are decoupled from VM lifecycle (survive VM
 # rebuilds, reattach to any VM on the same Proxmox node). Replaces Longhorn
-# on this cluster (chezmoidotsh/arcane issue 1188 recreation) — same
-# rationale as rhodes.akn (see docs/experiments/20260617-proxmox-csi-ccm/,
+# on this cluster (see docs/experiments/20260617-proxmox-csi-ccm/,
 # conclusion #9).
 
-# storageClass entries below match rhodes.akn's (same pve-01 hypervisor,
-# same nvme-lvm storage backend — confirmed against this cluster's own
-# machine classes, catalog/omni/machineclasses/, which pin
-# storage_selector: 'name == "nvme-lvm"').
+# storageClass entries below use pve-01's nvme-lvm storage backend — matches
+# this cluster's machine classes (catalog/omni/machineclasses/), which pin
+# storage_selector: 'name == "nvme-lvm"'.
 
 # config.clusters is intentionally left unset (chart default: []) — same
 # Pulumi-owned token delivery as proxmox-cloud-controller-manager.helmvalues

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/security/kustomization.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/security/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - network-policy.allow-intra-namespace.yaml
+  - network-policy.allow-proxmox-to-kubernetes-api.yaml
+  - network-policy.allow-proxmox-to-proxmox-api.yaml

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/security/network-policy.allow-intra-namespace.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/security/network-policy.allow-intra-namespace.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Permits intra-namespace communication in the proxmox-system namespace. Access to the
+      Kubernetes API and the Proxmox VE API is granted by the other policies in this directory,
+      not here.
+  name: allow-intra-namespace
+  namespace: proxmox-system
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: proxmox-system
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: proxmox-system

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/security/network-policy.allow-proxmox-to-kubernetes-api.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/security/network-policy.allow-proxmox-to-kubernetes-api.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows the Proxmox cloud-controller-manager and CSI plugin (controller and node pods) to
+      access the Kubernetes API server. CCM patches Node objects with providerID/topology; the
+      CSI controller creates/attaches PersistentVolumes; the CSI node plugin reads its own Node
+      object (proxmox-csi-plugin-node's ClusterRole grants get on nodes).
+  name: allow-proxmox-to-kubernetes-api
+  namespace: proxmox-system
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - proxmox-cloud-controller-manager
+          - proxmox-csi-plugin
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/security/network-policy.allow-proxmox-to-proxmox-api.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/security/network-policy.allow-proxmox-to-proxmox-api.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows the Proxmox cloud-controller-manager and CSI controller (not the CSI node
+      DaemonSet — verified against templates/node-deployment.yaml: it never mounts cloud-config
+      or takes a --cloud-config flag, so it never calls the Proxmox API directly) to reach the
+      Proxmox VE API (pve-01.pve.chezmoi.sh:8006) referenced in their config.yaml cluster entry,
+      for node topology lookups (CCM) and volume attach/detach operations (CSI controller).
+  name: allow-proxmox-to-proxmox-api
+  namespace: proxmox-system
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - proxmox-cloud-controller-manager
+          - proxmox-csi-plugin
+      - key: app.kubernetes.io/component
+        operator: NotIn
+        values:
+          - node
+  egress:
+    - toFQDNs:
+        - matchName: pve-01.pve.chezmoi.sh
+      toPorts:
+        - ports:
+            - port: "8006"
+              protocol: TCP

--- a/projects/lungmen.akn/src/infrastructure/omni/lungmen.clustertemplate.yaml
+++ b/projects/lungmen.akn/src/infrastructure/omni/lungmen.clustertemplate.yaml
@@ -9,7 +9,13 @@
 # Overrides relative to the base:
 #   Cluster.name                   lungmen-akn            (was base-default)
 #   cluster.network.podSubnets     172.30.32.0/19         (ADR-014: lungmen pod CIDR — unique per cluster)
-#   Workers.machineClass.size      2                      (same as base default — kept explicit)
+#   Workers.machineClass.size      3                      (base default is 2; lungmen's real workload —
+#                                                          immich/jellyfin/n8n/paperless/forgejo/databases —
+#                                                          measured ~9Gi steady-state on the current
+#                                                          all-in-one node, which doesn't fit a single
+#                                                          w1.large's ~7.5-7.8Gi allocatable during a
+#                                                          one-at-a-time rolling Talos update; 3 nodes
+#                                                          leaves 16Gi allocatable on the 2 survivors)
 #
 # NOTE: serviceSubnets (172.31.0.0/19) and clusterDNS (172.31.0.10) match the SHARED
 # defaults in the base template. They are duplicated here because this is a standalone
@@ -119,7 +125,7 @@ kind: Workers
 name: workers
 machineClass:
   name: w1.large # V2 dual-NIC (catalog/omni/machineclasses/w1.large.yaml)
-  size: 2 # lungmen topology: 2 workers (matches base default)
+  size: 3 # lungmen topology: sized to survive a one-at-a-time Talos reboot under real load, see note above
 updateStrategy:
   rolling:
     maxParallelism: 1

--- a/projects/lungmen.akn/src/infrastructure/omni/lungmen.clustertemplate.yaml
+++ b/projects/lungmen.akn/src/infrastructure/omni/lungmen.clustertemplate.yaml
@@ -18,8 +18,7 @@
 #                                                          leaves 16Gi allocatable on the 2 survivors)
 #   machine.kubelet.extraArgs.cloud-provider  external  (REQUIRED from day one — the
 #     Proxmox CCM silently no-ops without it, and providerID is immutable once a
-#     node registers; fixing this later means delete+recreate the node. See
-#     rhodes.clustertemplate.yaml and .agents/sessions/20260720-rhodes-cluster-bringup-planning.md.)
+#     node registers; fixing this later means delete+recreate the node)
 #
 # NOTE: serviceSubnets (172.31.0.0/19) and clusterDNS (172.31.0.10) match the SHARED
 # defaults in the base template. They are duplicated here because this is a standalone
@@ -85,8 +84,7 @@ patches:
           extraArgs:
             rotate-server-certificates: "true" # enables kubelet-serving-cert-approver
             # REQUIRED from day one — Proxmox CCM silently no-ops otherwise, and
-            # providerID is immutable post-registration (see rhodes.clustertemplate.yaml
-            # and .agents/sessions/20260720-rhodes-cluster-bringup-planning.md).
+            # providerID is immutable post-registration.
             cloud-provider: external
           extraConfig:
             featureGates:
@@ -101,12 +99,11 @@ patches:
           cni:
             name: custom
             urls:
-              # Pinned to the same SHA rhodes.akn uses (already proven live): the
-              # 1.19.5-native.yaml pin previously here predates the fix that adds a
-              # toleration for node.cloudprovider.kubernetes.io/uninitialized on the
-              # installer Job. Without it, cloud-provider=external (below) taints every
-              # node and the Job can never schedule — a permanent deadlock, not a
-              # transient delay (see the manifest's own comment).
+              # The installer Job's tolerations must include
+              # node.cloudprovider.kubernetes.io/uninitialized (see this manifest's own
+              # comment) — cloud-provider=external (below) taints every node from boot,
+              # and without that toleration the Job can never schedule: a permanent
+              # deadlock, not a transient delay.
               - https://raw.githubusercontent.com/chezmoidotsh/arcane/09f0b0a42929e86bedc882f894884b5eb1d80e59/catalog/talos/manifests/cilium/1.20.0-native.yaml
           podSubnets:
             - 172.30.32.0/19
@@ -121,7 +118,7 @@ patches:
           extraArgs:
             feature-gates: UserNamespacesSupport=true,ImageVolume=true
         extraManifests:
-          # Pinned to the same SHA as the Cilium manifest above (matches rhodes.akn).
+          # Pinned to the same SHA as the Cilium manifest above.
           - https://raw.githubusercontent.com/chezmoidotsh/arcane/09f0b0a42929e86bedc882f894884b5eb1d80e59/catalog/talos/manifests/kubelet-serving-cert-approver/0.11.0.yaml
           - https://raw.githubusercontent.com/chezmoidotsh/arcane/09f0b0a42929e86bedc882f894884b5eb1d80e59/catalog/talos/manifests/metric-server/0.8.1.yaml
 ---

--- a/projects/lungmen.akn/src/infrastructure/omni/lungmen.clustertemplate.yaml
+++ b/projects/lungmen.akn/src/infrastructure/omni/lungmen.clustertemplate.yaml
@@ -101,11 +101,13 @@ patches:
           cni:
             name: custom
             urls:
-              # SHA points to the commit on this branch that added 1.19.5-native.yaml.
-              # After merging, update to the resulting merge commit SHA (or a tag).
-              # Squash-merge risk: the branch SHA leaves main's history — repin before
-              # applying to a live cluster.
-              - https://raw.githubusercontent.com/chezmoidotsh/arcane/97c8cb69f5c648d8b7ac687603d429092e5f0b2d/catalog/talos/manifests/cilium/1.19.5-native.yaml
+              # Pinned to the same SHA rhodes.akn uses (already proven live): the
+              # 1.19.5-native.yaml pin previously here predates the fix that adds a
+              # toleration for node.cloudprovider.kubernetes.io/uninitialized on the
+              # installer Job. Without it, cloud-provider=external (below) taints every
+              # node and the Job can never schedule — a permanent deadlock, not a
+              # transient delay (see the manifest's own comment).
+              - https://raw.githubusercontent.com/chezmoidotsh/arcane/9a58e751d48be11bc7e67f3f2a6bf676973ea440/catalog/talos/manifests/cilium/1.20.0-native.yaml
           podSubnets:
             - 172.30.32.0/19
           serviceSubnets:
@@ -119,10 +121,9 @@ patches:
           extraArgs:
             feature-gates: UserNamespacesSupport=true,ImageVolume=true
         extraManifests:
-          # Pinned to the commit on this branch that added these manifests.
-          # Update to the merge commit SHA after merging (same squash-merge caveat as above).
-          - https://raw.githubusercontent.com/chezmoidotsh/arcane/97c8cb69f5c648d8b7ac687603d429092e5f0b2d/catalog/talos/manifests/kubelet-serving-cert-approver/0.11.0.yaml
-          - https://raw.githubusercontent.com/chezmoidotsh/arcane/97c8cb69f5c648d8b7ac687603d429092e5f0b2d/catalog/talos/manifests/metric-server/0.8.1.yaml
+          # Pinned to the same SHA as the Cilium manifest above (matches rhodes.akn).
+          - https://raw.githubusercontent.com/chezmoidotsh/arcane/9a58e751d48be11bc7e67f3f2a6bf676973ea440/catalog/talos/manifests/kubelet-serving-cert-approver/0.11.0.yaml
+          - https://raw.githubusercontent.com/chezmoidotsh/arcane/9a58e751d48be11bc7e67f3f2a6bf676973ea440/catalog/talos/manifests/metric-server/0.8.1.yaml
 ---
 kind: ControlPlane
 machineClass:

--- a/projects/lungmen.akn/src/infrastructure/omni/lungmen.clustertemplate.yaml
+++ b/projects/lungmen.akn/src/infrastructure/omni/lungmen.clustertemplate.yaml
@@ -107,7 +107,7 @@ patches:
               # installer Job. Without it, cloud-provider=external (below) taints every
               # node and the Job can never schedule — a permanent deadlock, not a
               # transient delay (see the manifest's own comment).
-              - https://raw.githubusercontent.com/chezmoidotsh/arcane/9a58e751d48be11bc7e67f3f2a6bf676973ea440/catalog/talos/manifests/cilium/1.20.0-native.yaml
+              - https://raw.githubusercontent.com/chezmoidotsh/arcane/09f0b0a42929e86bedc882f894884b5eb1d80e59/catalog/talos/manifests/cilium/1.20.0-native.yaml
           podSubnets:
             - 172.30.32.0/19
           serviceSubnets:
@@ -122,8 +122,8 @@ patches:
             feature-gates: UserNamespacesSupport=true,ImageVolume=true
         extraManifests:
           # Pinned to the same SHA as the Cilium manifest above (matches rhodes.akn).
-          - https://raw.githubusercontent.com/chezmoidotsh/arcane/9a58e751d48be11bc7e67f3f2a6bf676973ea440/catalog/talos/manifests/kubelet-serving-cert-approver/0.11.0.yaml
-          - https://raw.githubusercontent.com/chezmoidotsh/arcane/9a58e751d48be11bc7e67f3f2a6bf676973ea440/catalog/talos/manifests/metric-server/0.8.1.yaml
+          - https://raw.githubusercontent.com/chezmoidotsh/arcane/09f0b0a42929e86bedc882f894884b5eb1d80e59/catalog/talos/manifests/kubelet-serving-cert-approver/0.11.0.yaml
+          - https://raw.githubusercontent.com/chezmoidotsh/arcane/09f0b0a42929e86bedc882f894884b5eb1d80e59/catalog/talos/manifests/metric-server/0.8.1.yaml
 ---
 kind: ControlPlane
 machineClass:

--- a/projects/lungmen.akn/src/infrastructure/omni/lungmen.clustertemplate.yaml
+++ b/projects/lungmen.akn/src/infrastructure/omni/lungmen.clustertemplate.yaml
@@ -16,6 +16,10 @@
 #                                                          w1.large's ~7.5-7.8Gi allocatable during a
 #                                                          one-at-a-time rolling Talos update; 3 nodes
 #                                                          leaves 16Gi allocatable on the 2 survivors)
+#   machine.kubelet.extraArgs.cloud-provider  external  (REQUIRED from day one — the
+#     Proxmox CCM silently no-ops without it, and providerID is immutable once a
+#     node registers; fixing this later means delete+recreate the node. See
+#     rhodes.clustertemplate.yaml and .agents/sessions/20260720-rhodes-cluster-bringup-planning.md.)
 #
 # NOTE: serviceSubnets (172.31.0.0/19) and clusterDNS (172.31.0.10) match the SHARED
 # defaults in the base template. They are duplicated here because this is a standalone
@@ -80,6 +84,10 @@ patches:
             - 172.31.0.10 # Shared service CIDR default (all clusters, ClusterMesh-ready)
           extraArgs:
             rotate-server-certificates: "true" # enables kubelet-serving-cert-approver
+            # REQUIRED from day one — Proxmox CCM silently no-ops otherwise, and
+            # providerID is immutable post-registration (see rhodes.clustertemplate.yaml
+            # and .agents/sessions/20260720-rhodes-cluster-bringup-planning.md).
+            cloud-provider: external
           extraConfig:
             featureGates:
               UserNamespacesSupport: true

--- a/projects/lungmen.akn/src/infrastructure/pulumi/index.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/index.ts
@@ -2,6 +2,7 @@ export * from "./stack/cert-manager";
 export * from "./stack/cloudnative-pg";
 export * from "./stack/pangolin";
 export * from "./stack/pocket-id";
+export * from "./stack/proxmox";
 export * from "./stack/tailscale-operator";
 export * from "./stack/vault";
 export * from "./stack/velero";

--- a/projects/lungmen.akn/src/infrastructure/pulumi/package.json
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/package.json
@@ -9,8 +9,11 @@
 		"@chezmoi.sh/pulumi-cluster-vault": "workspace:*",
 		"@chezmoi.sh/pulumi-garage-cnpg-backup": "workspace:*",
 		"@chezmoi.sh/pulumi-lib": "workspace:*",
+		"@chezmoi.sh/pulumi-proxmox-cluster-identity": "workspace:*",
+		"@pulumi/kubernetes": "catalog:",
 		"@pulumi/pangolin": "workspace:*",
 		"@pulumi/pocket-id": "workspace:*",
+		"@pulumi/proxmox": "workspace:*",
 		"@pulumi/pulumi": "catalog:",
 		"@pulumi/tailscale": "catalog:",
 		"@pulumi/vault": "catalog:"

--- a/projects/lungmen.akn/src/infrastructure/pulumi/stack/proxmox.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/stack/proxmox.ts
@@ -5,9 +5,9 @@ import * as pulumi from "@pulumi/pulumi";
 
 // -----------------------------------------------------------------------------
 // Proxmox CCM/CSI identity + Secret delivery (Pulumi-owned end-to-end, never
-// Vault/ESO). Mirrors rhodes.akn's stack/proxmox.ts — see that file's header
-// comment for the full reasoning (chezmoidotsh/arcane#1188 recreates
-// lungmen.akn the same way #370 recreated amiya.akn as rhodes.akn).
+// Vault/ESO): Pulumi already needs privileged kubeconfig access to deliver
+// the Secret below, so routing it through Vault/ESO would add indirection
+// with no confidentiality benefit.
 // -----------------------------------------------------------------------------
 // This stack mints the kubernetes-cloud-provider@pve identity itself,
 // directly against pve-01, using a delegated, narrowly-scoped credential
@@ -16,21 +16,23 @@ import * as pulumi from "@pulumi/pulumi";
 // purpose. See catalog/pulumi/components/proxmox-cluster-identity's README
 // for the full pattern.
 //
-// CCM and CSI share a single identity/token/Secret (same trade-off accepted
-// on rhodes.akn — see rhodes.akn's stack/proxmox.ts for the reasoning).
+// CCM and CSI deliberately share a single identity/token/Secret rather than
+// one least-privilege role each. Risk: a compromise of this one token
+// carries both concerns' privileges (node/VM audit AND volume/VM lifecycle)
+// instead of being contained to one — acceptable for this single-node,
+// single-cluster deployment.
 //
 // The delegated credential arrives as a Kubernetes Secret chezmoi.sh's own
 // stack writes directly into the new lungmen-akn cluster (kube-system), not
-// through a Pulumi StackReference (per-project passphrase isolation, see
+// through a Pulumi StackReference — reading a *secret* StackReference output
+// requires holding the exporting stack's own passphrase, and this repo
+// deliberately keeps every project's Pulumi state passphrase separate (see
 // docs/procedures/infrastructure/INF-20260705-00.pulumi-state-and-import.md).
 //
-// Explicit named provider, not the ambient default: unlike rhodes.akn (a
-// single-context project), this project's existing stack files
-// (cert-manager.ts, vault.ts, cloudnative-pg.ts, ...) all go through
-// Vault/ESO and never touch Kubernetes directly, and during the old-cluster/
-// new-cluster transition an ambient default could too easily end up pointed
-// at the wrong one. Pinning explicitly to the new cluster's Omni context
-// avoids that class of mistake entirely.
+// Explicit named provider, not the ambient default: this project's other
+// stack files (cert-manager.ts, vault.ts, cloudnative-pg.ts, ...) all go
+// through Vault/ESO and never touch Kubernetes directly, so there is no
+// ambient default provider to depend on here.
 const lungmenAkn = new k8s.Provider("lungmen-akn", {
 	context: "omni-lungmen-akn",
 });
@@ -40,9 +42,9 @@ const bootstrapSecret = k8s.core.v1.Secret.get(
 	"kube-system/lungmen-akn-bootstrap-pve",
 	{ provider: lungmenAkn },
 );
-// Already the complete, ready-to-use `USER@REALM!TOKENID=SECRET` string — see
-// chezmoi.sh's stack/proxmox/access/lungmen-akn-bootstrap.ts for why this
-// must not be rebuilt from separate id/secret parts.
+// Already the complete, ready-to-use `USER@REALM!TOKENID=SECRET` string.
+// Re-concatenating userId!tokenName onto it produces a doubly-prefixed,
+// invalid token — pass it through as-is, don't rebuild it.
 const bootstrapApiToken = bootstrapSecret.data["api-token"].apply((v) =>
 	Buffer.from(v, "base64").toString("utf-8"),
 );
@@ -56,12 +58,8 @@ const pveProvider = new proxmox.Provider("pve-01", {
 const cloudProviderIdentity = new ProxmoxClusterIdentityComponent(
 	"kubernetes-cloud-provider",
 	{
-		// userId/roleId are global on pve-01, not scoped per Kubernetes cluster —
-		// rhodes.akn's stack/proxmox.ts already owns the unqualified
-		// "kubernetes-cloud-provider@pve" / "KubernetesCloudProvider" names
-		// (confirmed live: creating this identity without the "-lungmen" suffix
-		// failed with "resource already exists"). Every cluster's identity needs
-		// its own distinct name.
+		// userId/roleId are global on pve-01, not scoped per Kubernetes cluster:
+		// each cluster's cloud-provider identity needs its own distinct name.
 		userId: "kubernetes-cloud-provider-lungmen@pve",
 		comment:
 			"Kubernetes CCM+CSI (lungmen.akn) - node/VM audit and volume lifecycle",
@@ -89,8 +87,8 @@ const cloudProviderIdentity = new ProxmoxClusterIdentityComponent(
 			],
 		},
 		// Node-scoped: topology + lifecycle status (CCM). Pool-scoped: every
-		// Talos VM's disk/config lifecycle (CSI) — same shared `talos` pool
-		// rhodes.akn uses (see chezmoi.sh's stack/proxmox/pools.ts).
+		// Talos VM's disk/config lifecycle (CSI) — the shared `talos` pool every
+		// cluster's VMs belong to (see chezmoi.sh's stack/proxmox/pools.ts).
 		aclPaths: ["/nodes/pve-01", "/pool/talos"],
 		tokenName: "cloud-provider",
 		tokenComment: "proxmox-cloud-controller-manager + proxmox-csi-plugin token",
@@ -98,16 +96,36 @@ const cloudProviderIdentity = new ProxmoxClusterIdentityComponent(
 	},
 );
 
+// proxmox-cloud-controller-manager and proxmox-csi-plugin both run in this
+// namespace (projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/).
+// Created here rather than left to ArgoCD's CreateNamespace=true (not yet
+// adopted by ArgoCD) so the config Secret below has somewhere to land.
+// retainOnDelete: a `pulumi destroy` must not take the namespace (and every
+// live CCM/CSI pod in it) down with it.
+const proxmoxSystemNamespace = new k8s.core.v1.Namespace(
+	"proxmox-system",
+	{
+		metadata: {
+			name: "proxmox-system",
+			labels: {
+				// proxmox-csi-plugin's node DaemonSet needs privileged/hostPath
+				// access (mounting Proxmox-attached block devices into kubelet's
+				// pod dir) — the "restricted" Pod Security default rejects that.
+				"pod-security.kubernetes.io/enforce": "privileged",
+				"pod-security.kubernetes.io/enforce-version": "v1.33",
+			},
+		},
+	},
+	{ provider: lungmenAkn, retainOnDelete: true },
+);
+
 // The Secret shape below matches what each chart's own templates/secrets.yaml
-// would otherwise generate — see rhodes.akn's stack/proxmox.ts for the
-// verification references. A single config.yaml key holding the full
-// clusters/features config as YAML (also valid JSON).
-//
-// Namespaces aren't created by this stack (ArgoCD's CreateNamespace=true sync
-// option does, once ArgoCD adopts this cluster) — this Secret can only be
-// applied once proxmox-system already exists (created via `kubectl apply` on
-// the dist/-rendered namespace manifest during bootstrap, before ArgoCD
-// exists on lungmen-akn).
+// would otherwise generate (verified against
+// https://artifacthub.io/packages/helm/proxmox-ccm/proxmox-cloud-controller-manager?modal=template&template=secrets.yaml
+// and the vendored proxmox-csi-plugin chart's equivalent template): a single
+// config.yaml key holding the full clusters/features config as YAML — which
+// is also valid JSON, so pulumi.jsonStringify is enough, no YAML library
+// needed.
 new k8s.core.v1.Secret(
 	"proxmox-cloud-provider-config",
 	{
@@ -127,5 +145,5 @@ new k8s.core.v1.Secret(
 			}),
 		},
 	},
-	{ provider: lungmenAkn },
+	{ provider: lungmenAkn, dependsOn: [proxmoxSystemNamespace] },
 );

--- a/projects/lungmen.akn/src/infrastructure/pulumi/stack/proxmox.ts
+++ b/projects/lungmen.akn/src/infrastructure/pulumi/stack/proxmox.ts
@@ -1,0 +1,131 @@
+import { ProxmoxClusterIdentityComponent } from "@chezmoi.sh/pulumi-proxmox-cluster-identity";
+import * as k8s from "@pulumi/kubernetes";
+import * as proxmox from "@pulumi/proxmox";
+import * as pulumi from "@pulumi/pulumi";
+
+// -----------------------------------------------------------------------------
+// Proxmox CCM/CSI identity + Secret delivery (Pulumi-owned end-to-end, never
+// Vault/ESO). Mirrors rhodes.akn's stack/proxmox.ts — see that file's header
+// comment for the full reasoning (chezmoidotsh/arcane#1188 recreates
+// lungmen.akn the same way #370 recreated amiya.akn as rhodes.akn).
+// -----------------------------------------------------------------------------
+// This stack mints the kubernetes-cloud-provider@pve identity itself,
+// directly against pve-01, using a delegated, narrowly-scoped credential
+// (lungmen-akn-bootstrap@pve, Administrator at /access only) that chezmoi.sh's
+// stack/proxmox/access/lungmen-akn-bootstrap.ts mints for exactly this
+// purpose. See catalog/pulumi/components/proxmox-cluster-identity's README
+// for the full pattern.
+//
+// CCM and CSI share a single identity/token/Secret (same trade-off accepted
+// on rhodes.akn — see rhodes.akn's stack/proxmox.ts for the reasoning).
+//
+// The delegated credential arrives as a Kubernetes Secret chezmoi.sh's own
+// stack writes directly into the new lungmen-akn cluster (kube-system), not
+// through a Pulumi StackReference (per-project passphrase isolation, see
+// docs/procedures/infrastructure/INF-20260705-00.pulumi-state-and-import.md).
+//
+// Explicit named provider, not the ambient default: unlike rhodes.akn (a
+// single-context project), this project's existing stack files
+// (cert-manager.ts, vault.ts, cloudnative-pg.ts, ...) all go through
+// Vault/ESO and never touch Kubernetes directly, and during the old-cluster/
+// new-cluster transition an ambient default could too easily end up pointed
+// at the wrong one. Pinning explicitly to the new cluster's Omni context
+// avoids that class of mistake entirely.
+const lungmenAkn = new k8s.Provider("lungmen-akn", {
+	context: "omni-lungmen-akn",
+});
+
+const bootstrapSecret = k8s.core.v1.Secret.get(
+	"lungmen-akn-bootstrap-pve",
+	"kube-system/lungmen-akn-bootstrap-pve",
+	{ provider: lungmenAkn },
+);
+// Already the complete, ready-to-use `USER@REALM!TOKENID=SECRET` string — see
+// chezmoi.sh's stack/proxmox/access/lungmen-akn-bootstrap.ts for why this
+// must not be rebuilt from separate id/secret parts.
+const bootstrapApiToken = bootstrapSecret.data["api-token"].apply((v) =>
+	Buffer.from(v, "base64").toString("utf-8"),
+);
+
+const pveProvider = new proxmox.Provider("pve-01", {
+	endpoint: "https://pve-01.pve.chezmoi.sh:8006/api2/json",
+	insecure: true,
+	apiToken: bootstrapApiToken,
+});
+
+const cloudProviderIdentity = new ProxmoxClusterIdentityComponent(
+	"kubernetes-cloud-provider",
+	{
+		// userId/roleId are global on pve-01, not scoped per Kubernetes cluster —
+		// rhodes.akn's stack/proxmox.ts already owns the unqualified
+		// "kubernetes-cloud-provider@pve" / "KubernetesCloudProvider" names
+		// (confirmed live: creating this identity without the "-lungmen" suffix
+		// failed with "resource already exists"). Every cluster's identity needs
+		// its own distinct name.
+		userId: "kubernetes-cloud-provider-lungmen@pve",
+		comment:
+			"Kubernetes CCM+CSI (lungmen.akn) - node/VM audit and volume lifecycle",
+		role: {
+			roleId: "KubernetesCloudProviderLungmen",
+			// Covers both CCM (node/VM audit) and CSI (volume + VM lifecycle, for
+			// dynamic provisioning) — see this file's header comment for the
+			// merged-identity trade-off.
+			privileges: [
+				"Sys.Audit",
+				"VM.Audit",
+				"VM.GuestAgent.Audit",
+				"Datastore.Allocate",
+				"Datastore.AllocateSpace",
+				"Datastore.Audit",
+				"VM.Allocate",
+				"VM.Clone",
+				"VM.Config.CPU",
+				"VM.Config.Disk",
+				"VM.Config.HWType",
+				"VM.Config.Memory",
+				"VM.Config.Options",
+				"VM.Migrate",
+				"VM.PowerMgmt",
+			],
+		},
+		// Node-scoped: topology + lifecycle status (CCM). Pool-scoped: every
+		// Talos VM's disk/config lifecycle (CSI) — same shared `talos` pool
+		// rhodes.akn uses (see chezmoi.sh's stack/proxmox/pools.ts).
+		aclPaths: ["/nodes/pve-01", "/pool/talos"],
+		tokenName: "cloud-provider",
+		tokenComment: "proxmox-cloud-controller-manager + proxmox-csi-plugin token",
+		provider: pveProvider,
+	},
+);
+
+// The Secret shape below matches what each chart's own templates/secrets.yaml
+// would otherwise generate — see rhodes.akn's stack/proxmox.ts for the
+// verification references. A single config.yaml key holding the full
+// clusters/features config as YAML (also valid JSON).
+//
+// Namespaces aren't created by this stack (ArgoCD's CreateNamespace=true sync
+// option does, once ArgoCD adopts this cluster) — this Secret can only be
+// applied once proxmox-system already exists (created via `kubectl apply` on
+// the dist/-rendered namespace manifest during bootstrap, before ArgoCD
+// exists on lungmen-akn).
+new k8s.core.v1.Secret(
+	"proxmox-cloud-provider-config",
+	{
+		metadata: { name: "proxmox-cloud-provider", namespace: "proxmox-system" },
+		type: "Opaque",
+		stringData: {
+			"config.yaml": pulumi.jsonStringify({
+				clusters: [
+					{
+						url: "https://pve-01.pve.chezmoi.sh:8006/api2/json",
+						token_id: cloudProviderIdentity.tokenId,
+						token_secret: cloudProviderIdentity.tokenSecret,
+						region: "homelab",
+					},
+				],
+				features: { provider: "default" },
+			}),
+		},
+	},
+	{ provider: lungmenAkn },
+);


### PR DESCRIPTION
## Summary

PR1 of the `lungmen.akn` recreation (see issue 1188): provisions the new
`lungmen-akn` cluster via the Omni template, mints its Proxmox CCM/CSI
identity through Pulumi, deploys the cloud-controller-manager and CSI plugin
directly (no ArgoCD yet — bootstrap phase, same order as the rhodes.akn
precedent, issue 370), and deregisters the pre-recreation `lungmen.akn`
cluster from ArgoCD so it stops being reconciled while the migration is in
progress.

**Related Issue:** #1188

## Changes Made

### Omni cluster template

- **[`projects/lungmen.akn/src/infrastructure/omni/lungmen.clustertemplate.yaml`](projects/lungmen.akn/src/infrastructure/omni/lungmen.clustertemplate.yaml)** — worker count bumped 2→3 (measured against the current cluster's real footprint), adds the required `cloud-provider: external` kubelet flag, repins the Cilium/kubelet-serving-cert-approver/metric-server manifests to a SHA that includes a fix this cluster actually needed live

<!-- markdownlint-disable MD024 -->

### Proxmox CCM/CSI identity (Pulumi)

<!-- markdownlint-enable MD024 -->

- **[`projects/chezmoi.sh/.../stack/proxmox/access/lungmen-akn-bootstrap.ts`](projects/chezmoi.sh/src/infrastructure/pulumi/stack/proxmox/access/lungmen-akn-bootstrap.ts)** — delegated `lungmen-akn-bootstrap@pve` identity, mirrors rhodes.akn's own bootstrap identity
- **[`projects/lungmen.akn/.../stack/proxmox.ts`](projects/lungmen.akn/src/infrastructure/pulumi/stack/proxmox.ts)** — self-provisions `kubernetes-cloud-provider-lungmen@pve` and delivers the config Secret directly into the new cluster (Pulumi-owned end-to-end, never Vault/ESO — same pattern as rhodes.akn)

### CCM/CSI deployment

- **[`projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/`](projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/)** — kustomize + helmvalues sources for proxmox-cloud-controller-manager and proxmox-csi-plugin, plus the NetworkPolicies they need; copied from rhodes.akn (same hypervisor, same storage backend)
- **[`projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/`](projects/lungmen.akn/src/infrastructure/kubernetes/cilium/security/)** — `allow-dns`/`allow-kube-system-full` CiliumNetworkPolicies, parked here (not yet wired into `cilium/kustomization.yaml`, which is still the *old* cluster's live ArgoCD-managed source) so the fix survives a future recreation instead of living only in already-applied cluster state

## Technical Impact

### Infrastructure Components

`lungmen-akn`: 1 control-plane + 3 workers on Omni, Cilium (native routing), proxmox-cloud-controller-manager + proxmox-csi-plugin. No ArgoCD on this cluster yet — everything in this PR was applied directly (`kubectl apply -f dist/...`), matching the rhodes.akn bring-up order (CNI/CCM/CSI before ArgoCD adopts).

### Security Implementation

CCM/CSI credential is Pulumi-owned end-to-end (never Vault/ESO) — same reasoning as rhodes.akn: Pulumi already needs privileged kubeconfig access to deliver the Secret, so routing it through ESO would add indirection with no confidentiality benefit. `userId`/`roleId` are suffixed `-lungmen`/`Lungmen`: these are global on `pve-01`, not scoped per cluster, and the unqualified names are already owned by rhodes.akn's identity (confirmed live — the first apply attempt failed with "resource already exists" on both). The PVE token was rotated once after a debug command accidentally printed it in plaintext during verification.

### Integration Points

`lungmen.akn`'s ArgoCD registration (cluster Secret `cluster-lungmen-akn-talosnet` on rhodes, plus its generated `system`/`applications` ApplicationSets and ~22 Applications) was removed so the pre-recreation cluster stops being reconciled during the migration. `preserveResourcesOnDeletion: true` on those ApplicationSets meant the underlying workloads on the old cluster were never touched — confirmed live (immich/paperless-ngx pods still `Running` after deregistration).

## Testing Validation

- [x] `lungmen-akn` nodes `Ready`, Cilium healthy (7 agents + envoy + operator)
- [x] `providerID` set on all 4 nodes, `uninitialized` taint cleared
- [x] Test PVC bound via `proxmox-lvmthin-ext4`; pod wrote/read through the mounted volume
- [x] Old `lungmen.akn` cluster's live workloads unaffected by the ArgoCD deregistration
- [ ] `omnictl cluster template validate` / `dist:render` clean in CI

## Future Enhancements

- Full Cilium Helm-managed adoption (cluster.name/id for ClusterMesh, `allow-ingress-gateway` policy) — `cilium/security/` here is intentionally partial
- PR2: align `src/infrastructure/kubernetes` with rhodes.akn's layout, prepare CNPG restore
- PR3: scale up, DNS/Tailscale/Pangolin cutover, ArgoCD adoption, old cluster decommission

## Related Issues

Addresses #1188 (PR1)

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
