### PR TITLE
Add Retain storage class for actual-budget/jellyfin/paperless-ngx

### DIFF
--- a/projects/lungmen.akn/dist/apps/actual-budget/apps.v1.StatefulSet.actual-budget.yaml
+++ b/projects/lungmen.akn/dist/apps/actual-budget/apps.v1.StatefulSet.actual-budget.yaml
@@ -91,3 +91,4 @@ spec:
       resources:
         requests:
           storage: 1Gi
+      storageClassName: proxmox-lvmthin-ext4-retain

--- a/projects/lungmen.akn/dist/apps/jellyfin/apps.v1.StatefulSet.jellyfin.yaml
+++ b/projects/lungmen.akn/dist/apps/jellyfin/apps.v1.StatefulSet.jellyfin.yaml
@@ -114,3 +114,4 @@ spec:
       resources:
         requests:
           storage: 10Gi
+      storageClassName: proxmox-lvmthin-ext4-retain

--- a/projects/lungmen.akn/dist/apps/paperless-ngx/apps.v1.StatefulSet.paperless-ngx.yaml
+++ b/projects/lungmen.akn/dist/apps/paperless-ngx/apps.v1.StatefulSet.paperless-ngx.yaml
@@ -175,3 +175,4 @@ spec:
       resources:
         requests:
           storage: 10Gi
+      storageClassName: proxmox-lvmthin-ext4-retain

--- a/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/storage.k8s.io.v1.StorageClass.proxmox-lvmthin-ext4-retain.yaml
+++ b/projects/lungmen.akn/dist/infrastructure/kubernetes/proxmox/storage.k8s.io.v1.StorageClass.proxmox-lvmthin-ext4-retain.yaml
@@ -1,0 +1,13 @@
+---
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: proxmox-lvmthin-ext4-retain
+parameters:
+  cache: writethrough
+  csi.storage.k8s.io/fstype: ext4
+  storage: nvme-lvm
+provisioner: csi.proxmox.sinextra.dev
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer

--- a/projects/lungmen.akn/src/apps/actual-budget/actual-budget.statefulset.yaml
+++ b/projects/lungmen.akn/src/apps/actual-budget/actual-budget.statefulset.yaml
@@ -77,6 +77,9 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
+        # -- Retain policy: a stray PVC/StatefulSet deletion detaches the disk instead of
+        # destroying it (see proxmox-csi-plugin.helmvalues/default.yaml).
+        storageClassName: proxmox-lvmthin-ext4-retain
         resources:
           requests:
             storage: 1Gi

--- a/projects/lungmen.akn/src/apps/jellyfin/jellyfin.statefulset.yaml
+++ b/projects/lungmen.akn/src/apps/jellyfin/jellyfin.statefulset.yaml
@@ -108,6 +108,9 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
+        # -- Retain policy: a stray PVC/StatefulSet deletion detaches the disk instead of
+        # destroying it (see proxmox-csi-plugin.helmvalues/default.yaml).
+        storageClassName: proxmox-lvmthin-ext4-retain
         resources:
           requests:
             storage: 10Gi

--- a/projects/lungmen.akn/src/apps/paperless-ngx/paperless-ngx.statefulset.yaml
+++ b/projects/lungmen.akn/src/apps/paperless-ngx/paperless-ngx.statefulset.yaml
@@ -171,6 +171,9 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
+        # -- Retain policy: a stray PVC/StatefulSet deletion detaches the disk instead of
+        # destroying it (see proxmox-csi-plugin.helmvalues/default.yaml).
+        storageClassName: proxmox-lvmthin-ext4-retain
         resources:
           requests:
             storage: 10Gi

--- a/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/proxmox-csi-plugin.helmvalues/default.yaml
+++ b/projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/proxmox-csi-plugin.helmvalues/default.yaml
@@ -37,6 +37,17 @@ storageClass:
     fstype: xfs
     cache: directsync
     ssd: false
+  # -- Retain variant for volumes that hold data restored from backup outside CNPG's own
+  # S3 recovery (actual-budget, jellyfin, paperless-ngx — see their volumeClaimTemplates).
+  # A stray `kubectl delete pvc`/StatefulSet mistake on the default (Delete) class destroys
+  # the underlying disk along with the PVC; this class only detaches it (PV goes Released,
+  # data recoverable) — same nvme-lvm backend and fstype as proxmox-lvmthin-ext4 otherwise.
+  - name: proxmox-lvmthin-ext4-retain
+    storage: nvme-lvm
+    reclaimPolicy: Retain
+    fstype: ext4
+    cache: writethrough
+    ssd: false
 
 controller:
   nodeSelector:


### PR DESCRIPTION
## Summary

Adds a `Retain`-policy StorageClass variant for the three lungmen.akn apps whose local PVCs hold data that isn't otherwise recoverable from S3 (actual-budget, jellyfin's config, paperless-ngx's documents) — the default `proxmox-lvmthin-ext4` class (`reclaimPolicy: Delete`) destroys the underlying disk on PVC deletion, which came up as a real risk while validating PV restoration for issue 1188.

**Related Issue:** #1188

## Changes Made

### New StorageClass: `proxmox-lvmthin-ext4-retain`

- **[`proxmox-csi-plugin.helmvalues/default.yaml`](projects/lungmen.akn/src/infrastructure/kubernetes/proxmox/proxmox-csi-plugin.helmvalues/default.yaml)** — same `nvme-lvm` backend/ext4/writethrough as the default class, `reclaimPolicy: Retain` instead. Scoped addition, not a change to the cluster-wide default (which CNPG's PVCs also use).
- **[`actual-budget.statefulset.yaml`](projects/lungmen.akn/src/apps/actual-budget/actual-budget.statefulset.yaml)**, **[`jellyfin.statefulset.yaml`](projects/lungmen.akn/src/apps/jellyfin/jellyfin.statefulset.yaml)**, **[`paperless-ngx.statefulset.yaml`](projects/lungmen.akn/src/apps/paperless-ngx/paperless-ngx.statefulset.yaml)** — their local `volumeClaimTemplates` now reference the new class.

## Technical Impact

### Infrastructure Components

A PVC delete (accidental or during troubleshooting) on these three apps' local volumes now detaches and releases the PV instead of destroying it — the disk stays recoverable.

## Testing Validation

- [x] `dist:render` clean; `conftest`/OPA and `trunk check` report no new issues
- [ ] Live apply on `lungmen-akn` and a fresh PVC bind against the new class — not yet applied live (apps are currently held at 0 replicas pending PR3's restore work)

## Related Issues

Addresses #1188

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
