### PR TITLE
Document k8up PVC backup/restore local POC (EXP-2026-008)

### DIFF
--- a/docs/experiments/20260805-k8up-pvc-restore/.gitignore
+++ b/docs/experiments/20260805-k8up-pvc-restore/.gitignore
@@ -1,0 +1,2 @@
+# k8up Local POC - local, disposable state
+.mise/

--- a/docs/experiments/20260805-k8up-pvc-restore/.mise.toml
+++ b/docs/experiments/20260805-k8up-pvc-restore/.mise.toml
@@ -1,0 +1,39 @@
+# =============================================================================
+# k8up local POC — Development Environment (issue #1208)
+# =============================================================================
+# Disposable local kind cluster only — MinIO stands in for the real S3 backup
+# target, Postgres stands in for a real stateful app's PVC. Nothing here
+# touches lungmen.akn, rhodes.akn, or any real infrastructure.
+#
+# Usage:
+#   cd docs/experiments/20260805-k8up-pvc-restore
+#   mise install
+#   mise run poc:bootstrap   # create kind cluster + MinIO + k8up + test app
+#   mise run poc:validate    # run the backup/restore/prune cycle
+#   mise run poc:teardown    # delete the kind cluster
+# =============================================================================
+
+[env]
+KUBECONFIG = "{{ config_root }}/.mise/kubeconfig"
+KIND_CLUSTER_NAME = "k8up-poc"
+
+[tools]
+kind = "latest"
+kubectl = "latest"
+helm = "3"
+
+[tasks."poc:bootstrap"]
+description = "Create the kind sandbox, MinIO, k8up, and the test app"
+run = "scripts/bootstrap.sh"
+dir = "{{config_root}}"
+
+[tasks."poc:validate"]
+alias = "poc:test"
+description = "Run the backup/restore/prune validation cycle"
+run = "scripts/validate.sh"
+dir = "{{config_root}}"
+
+[tasks."poc:teardown"]
+description = "Delete the kind sandbox"
+run = "scripts/teardown.sh"
+dir = "{{config_root}}"

--- a/docs/experiments/20260805-k8up-pvc-restore/README.md
+++ b/docs/experiments/20260805-k8up-pvc-restore/README.md
@@ -35,8 +35,9 @@ simple/deterministic enough for a small local model, or a human on a short runbo
 5. [Test Environment](#5-test-environment)
 6. [Validation Criteria](#6-validation-criteria)
 7. [Results](#7-results)
-8. [Conclusions](#8-conclusions)
-9. [Actionable Next Steps](#9-actionable-next-steps)
+8. [Comparison with Velero](#8-comparison-with-velero)
+9. [Conclusions](#9-conclusions)
+10. [Actionable Next Steps](#10-actionable-next-steps)
 
 ---
 
@@ -238,7 +239,34 @@ the actual error), both documented as findings above rather than smoothed over:
    silent-empty-backup UID mismatch), not a restore bug at all; the _backups themselves_ were empty. Fixed by setting
    `podSecurityContext` on every CR.
 
-## 8. Conclusions
+## 8. Comparison with Velero
+
+| Dimension                               | Velero (EXP-2026-007)                                                                                                                                                                                                              | k8up (this POC)                                                                                                                                                                                |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Restore into an already-existing PVC    | **Structurally broken on this cluster** — `PodVolumeRestore` only progresses if Velero itself creates/owns the target pod, which never happens once ArgoCD already declared it (#1188, the reason this whole investigation exists) | **Works** — the restore Job mounts the target PVC directly, never needs to own/create the pod (V-004/V-005)                                                                                    |
+| Explicit snapshot targeting             | Not exercised in the Velero POC                                                                                                                                                                                                    | Explicitly tested against k8up-io/k8up#1062's failure mode — correct (V-007/V-008)                                                                                                             |
+| Backend config                          | Global (`BackupStorageLocation`), but the fs-backup annotation is still per-workload                                                                                                                                               | Fully global (`BACKUP_GLOBAL*` env vars) — every CR in this POC omits `spec.backend` (§3.1)                                                                                                    |
+| PVC discovery                           | Opt-in per pod (`backup.velero.io/backup-volumes`); the global opt-out flag silently skips volumes with zero error (Velero POC §3.1)                                                                                               | Opt-out per namespace by default (§3.2) — no annotation needed, no silent-skip failure mode found                                                                                              |
+| Underlying PV type dependency           | fs-backup explicitly refuses hostPath-typed PVs (Velero POC §3.2) — needed a static `local` PV workaround in kind                                                                                                                  | None — the backup Job mounts the PVC directly regardless of PV type (§3.2)                                                                                                                     |
+| **Default backup consistency (freeze)** | **No freeze.** Velero's own docs: fs-backup "backs up data from the live file system, in which way the data is not captured at the same point in time, so is less consistent than the snapshot approaches"                         | **No freeze either.** k8up's own docs warn the direct-PVC-mount method "does not work when files are kept open for a long period of time, like databases do"                                   |
+| App-aware / consistent backup path      | Pre/post exec hooks (`pre.hook.backup.velero.io/command`) — documented pattern is literally calling `fsfreeze`/`fsunfreeze` around the backup                                                                                      | `k8up.io/backupcommand` annotation (exec inside the app pod) or a separate `PreBackupPod` — same idea, different shape. Neither Velero's hooks nor k8up's exec paths were tested in either POC |
+| Storage-level atomic snapshot option    | **Yes** — CSI `VolumeSnapshotLocation`, genuinely atomic at the storage layer, no app-level freeze needed (out of scope for both POCs — needs a real CSI driver)                                                                   | **No equivalent.** k8up is restic-based file backup only; there is no CSI-snapshot alternative to fall back on for consistency                                                                 |
+| Silent-failure modes found              | `defaultVolumesToFsBackup` silently skips a PVC with zero error/warning (Velero POC §3.1)                                                                                                                                          | Backup Job silently backs up 0 files on a UID mismatch, `Backup` CR still reports `Succeeded` (§3.3, confirmed as open upstream bug k8up-io/k8up#1032)                                         |
+| Retention footguns found                | None found in the Velero POC                                                                                                                                                                                                       | `keepDaily` silently defaults to 14 regardless of what's requested (§3.4, confirmed as open upstream bug k8up-io/k8up#1106)                                                                    |
+| Community / maturity                    | Larger community, CNCF-adjacent, VMware/Broadcom-backed                                                                                                                                                                            | Smaller (VSHN-backed), but active — weekly/monthly release cadence                                                                                                                             |
+
+**On the freeze question specifically** (researched directly against both projects' docs, not assumed): **neither tool
+freezes anything by default.** Both Velero's fs-backup and k8up's direct-PVC-mount backup are a live read of whatever
+the filesystem looks like at scan time — both projects' own documentation carries the identical warning about open
+files/databases. Consistency for a real database is entirely opt-in and entirely the same shape on both sides: an
+exec-based hook that runs a tool with its own consistency guarantees (`pg_dump`, `fsfreeze`, …) before the raw files are
+read. The one **structural** difference is that Velero additionally offers CSI volume snapshots — an atomic,
+storage-layer mechanism that sidesteps the freeze question entirely because the snapshot itself is a single
+point-in-time copy-on-write operation — which k8up has no equivalent for. That gap doesn't matter for this repo
+specifically (the issue that started this investigation already ruled CSI snapshots out of scope for `lungmen.akn`), but
+it's a real capability Velero has and k8up structurally doesn't.
+
+## 9. Conclusions
 
 **k8up solves the specific problem that sent this investigation down this path.** Restore into an already-existing,
 ArgoCD-owned PVC works cleanly and deterministically — no controller-timing flakiness, no "Velero must own the pod"
@@ -260,7 +288,7 @@ check at rollout time, not something the CR status alone can be trusted to surfa
 apps: Velero doesn't solve the restore problem this cluster actually has, so keeping it alongside k8up buys nothing but
 a second thing to maintain.
 
-### 8.1 Not answered by this POC
+### 9.1 Not answered by this POC
 
 - **CNPG-specific backup behavior** — this POC uses a plain Postgres StatefulSet, not a CNPG cluster. CNPG's own
   backup/WAL-archiving machinery may interact with a concurrent restic snapshot differently. Worth a follow-up check
@@ -290,16 +318,17 @@ a second thing to maintain.
   tested, so whether stale files survive a restore and give a false sense of a clean recovery is an open question, not
   an assumption this POC can back up.
 - **Backup consistency under concurrent writes / app-aware hooks** — backup-1 and backup-2 were both taken while
-  Postgres was live and serving queries, and the round trip preserved the marker row correctly both times — but that's
-  the same crash-consistency argument the Velero POC relied on (§3 of that POC), not a guarantee under real write load.
-  k8up supports an app-aware alternative to the raw file-level backup, the `k8up.io/backupcommand` annotation (exec a
-  command — e.g. a `pg_dump`, or a pause/flush — instead of reading the mounted files directly), mirroring Velero's own
-  pre/post backup hooks. Neither this POC nor the Velero one tested the hook-based path; both only validated the naive
-  file-level backup. For lungmen.akn's actual CNPG clusters this matters more than it did here, since CNPG already has
-  its own WAL-archiving backup machinery that a concurrent restic snapshot could interact with unpredictably (see the
-  CNPG bullet above).
+  Postgres was live and serving queries, and the round trip preserved the marker row correctly both times. That worked
+  here, but neither tool freezes anything by default (confirmed against both projects' own docs, see
+  [§8](#8-comparison-with-velero)): k8up's direct-PVC-mount backup and Velero's fs-backup carry the identical warning
+  about open files/databases. k8up's app-aware alternative to the raw file-level backup, the `k8up.io/backupcommand`
+  annotation (exec a command — e.g. a `pg_dump`, or a pause/flush — instead of reading the mounted files directly),
+  mirrors Velero's own pre/post backup hooks exactly. Neither this POC nor the Velero one tested the hook-based path;
+  both only validated the naive file-level backup. For lungmen.akn's actual CNPG clusters this matters more than it did
+  here, since CNPG already has its own WAL-archiving backup machinery that a concurrent restic snapshot could interact
+  with unpredictably (see the CNPG bullet above).
 
-### 8.2 References
+### 9.2 References
 
 - Issue: [#1208](https://github.com/chezmoidotsh/arcane/issues/1208)
 - Related: [#1188](https://github.com/chezmoidotsh/arcane/issues/1188) (lungmen.akn recreation — where the Velero
@@ -311,10 +340,16 @@ a second thing to maintain.
 - k8up-io/k8up#1062, #803, #1210 (named in #1208's own research)
 - k8up-io/k8up#1032 (§3.3 — silent empty backup, open), #1106 (§3.4 — undocumented `keepDaily: 14` default, open) —
   found independently by searching upstream after reproducing both locally, confirming neither is a sandbox artifact
+- k8up backup consistency: <https://docs.k8up.io/k8up/2.16/explanations/backup.html> (direct-PVC-mount method, open
+  files/database warning), `k8up.io/backupcommand` and `PreBackupPod` samples
+  (`config/samples/k8up_v1_prebackuppod.yaml` in k8up-io/k8up)
+- Velero backup consistency: <https://velero.io/docs/main/file-system-backup/> ("data is not captured at the same point
+  in time" caveat), <https://velero.io/docs/main/backup-hooks/> (`fsfreeze` pre/post hook pattern) — read directly for
+  §8's comparison, not assumed from memory
 
 ---
 
-## 9. Actionable Next Steps
+## 10. Actionable Next Steps
 
 - Deploy this same k8up configuration on `lungmen.akn` against the real S3 target (`s3.chezmoi.sh`), scoped to one or
   two apps with local PVCs (actual-budget, jellyfin, or paperless-ngx per #1208), with `podSecurityContext` matched to
@@ -325,7 +360,7 @@ a second thing to maintain.
 - Package as a reusable ArgoCD Application, matching this repo's `<chart>.helmvalues/` convention (Velero POC's own
   deferred item, same shape here).
 - Validate CNPG-specific behavior directly on `lungmen.akn` before relying on this for real CNPG clusters
-  ([§8.1](#81-not-answered-by-this-poc)).
+  ([§9.1](#91-not-answered-by-this-poc)).
 - **Build an operational script for the full restore procedure**, matching the `scripts/*` convention already used for
   other stateful operations in this repo (`argocd:app:sync`, `cnpg:db:migrate`, `bao:kv:copy`). A raw `kubectl apply` of
   a `Restore` CR isn't the real procedure on an ArgoCD-managed cluster — per the pod-concurrency finding above, it needs

--- a/docs/experiments/20260805-k8up-pvc-restore/README.md
+++ b/docs/experiments/20260805-k8up-pvc-restore/README.md
@@ -1,0 +1,304 @@
+---
+experiment: EXP-2026-008
+title: k8up as a PVC-focused Velero alternative — local POC
+status: OK
+created: 2026-08-05
+updated: 2026-08-05
+k8up: v2.16.0 (chart 4.10.0)
+issue: https://github.com/chezmoidotsh/arcane/issues/1208
+---
+
+## Abstract
+
+Local, disposable proof of concept for #1208: deploy k8up against an S3-compatible target, back up a real PVC-backed
+stateful app twice, delete its data, and restore it from an **explicitly named, non-latest snapshot** into the PVC that
+already exists — the exact shape #1188 found Velero's restore controller unable to handle on a GitOps-managed cluster
+(see [docs/experiments/20260803-velero-pvc-backup](../20260803-velero-pvc-backup/)).
+
+Everything runs in a **disposable local kind cluster** with MinIO standing in for the real S3 target and a throwaway
+Postgres StatefulSet standing in for a real app (jellyfin, paperless-ngx, actual-budget). No real cluster, no real
+backup bucket.
+
+Three real, evidenced operational gotchas turned up by actually running this — not by reading k8up's docs — are the main
+payoff of this POC: see [§3.3](#33-backup-jobs-run-as-a-fixed-uid--silent-empty-backups) and
+[§3.4](#34-retention-keepdaily-silently-defaults-to-14). Both directly bear on the issue's real bar: "is this
+simple/deterministic enough for a small local model, or a human on a short runbook, to operate correctly."
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Requirements](#2-requirements)
+3. [Sandbox Architecture](#3-sandbox-architecture)
+4. [Implementation](#4-implementation)
+5. [Test Environment](#5-test-environment)
+6. [Validation Criteria](#6-validation-criteria)
+7. [Results](#7-results)
+8. [Conclusions](#8-conclusions)
+9. [Actionable Next Steps](#9-actionable-next-steps)
+
+---
+
+## 1. Problem Statement
+
+#1188 (lungmen.akn recreation) found Velero's `PodVolumeRestore` controller structurally unable to restore PV data into
+a pod that ArgoCD/Kustomize already created declaratively — the controller only progresses once Velero itself
+creates/owns the target pod, which never happens on this cluster. #1208 asks whether k8up's restic-based, PVC-only
+backup avoids that specific failure mode, and whether its restore path is simple and deterministic enough that a small
+(32B-class) local model — the repo's stated long-term maintainability bar, see #1208's own comment thread — could
+operate it correctly during a real incident, not just that it technically supports S3/schedule/retention/restore.
+
+## 2. Requirements
+
+- Disposable and reproducible from a clean checkout with one command (`mise run poc:bootstrap`).
+- S3-compatible backup target, matching the real candidate (`s3.chezmoi.sh`, Garage) closely enough that the
+  `backend.s3` config is representative — MinIO, same reasoning as the Velero POC.
+- A real PVC-backed stateful app, not a synthetic file — same Postgres + marker-row pattern as the Velero POC, reused
+  because it already proved a live filesystem-level backup round-trips real application data.
+- Explicitly exercise the failure mode named in #1208's acceptance criteria: k8up-io/k8up#1062 ("restore can take the
+  latest backup regardless of which snapshot was requested").
+- Never touch `lungmen.akn`, `rhodes.akn`, or any real OpenBao/S3 credentials.
+
+**Out of scope**: real S3 target (MinIO is throwaway here, same as the Velero POC), packaging as an ArgoCD Application
+(follow the Velero POC's deferred pattern once this approach is confirmed), CNPG-specific behavior (this POC uses a
+plain Postgres StatefulSet, not a CNPG cluster).
+
+---
+
+## 3. Sandbox Architecture
+
+```text
+kind cluster "k8up-poc"
+├── k8up-poc namespace
+│     └── MinIO (single-node, S3 API) — bucket "k8up-backups"
+├── k8up namespace
+│     └── k8up operator deployment (global S3/repo-password env vars, §3.1)
+└── k8up-poc-app namespace
+      ├── test-app StatefulSet (Postgres 17) — PVC "data-test-app-0"
+      └── Schedule "test-app" (backup/check/prune cron, §3.2)
+```
+
+MinIO is used instead of Garage for the same reason as the Velero POC: the real target is "existing MinIO or Backblaze
+B2," and MinIO's S3 API keeps the `backend.s3` config representative.
+
+### 3.1 Global backend config, not per-CR
+
+k8up's operator supports setting the S3 backend and restic repository password **once, globally**, via `BACKUP_GLOBAL*`
+env vars on the operator Deployment (`operator/cfg/config.go` / `operator/executor/envvarconverter.go` in k8up-io/k8up —
+confirmed by reading the source, not assumed from partial docs). `manifests/k8up-helmvalues.yaml` sets these from a
+`k8up-repo-credentials` Secret; every Schedule/Backup/Restore/Prune CR in this POC then omits `spec.backend` entirely.
+This is a real ergonomic advantage over Velero, whose `BackupStorageLocation` is also global but the fs-backup
+annotation model still requires per-workload configuration (§3.1 of the Velero POC).
+
+### 3.2 Opt-out PVC discovery, not opt-in
+
+k8up's Schedule covers every PVC in its namespace by default (RWX always, RWO unless `k8up.io/backup: "false"`) — no
+per-pod annotation needed. This directly avoids the Velero POC's §3.1 finding (`defaultVolumesToFsBackup` silently
+skipping a PVC with zero error). `manifests/test-app.yaml` needs no backup-related annotation at all, unlike the Velero
+POC's `backup.velero.io/backup-volumes`.
+
+Also unlike Velero's fs-backup, which explicitly refuses hostPath-typed PVs (Velero POC §3.2), k8up's backup Job mounts
+the target PVC directly into its own pod — it never inspects the underlying PV type, so kind's bundled `standard`
+StorageClass works with **zero** workaround (no static `local` PV, no `manual` StorageClass).
+
+### 3.3 Backup Jobs run as a fixed UID — silent empty backups
+
+**This is the headline finding of this POC.** Confirmed as a known, open upstream bug —
+[k8up-io/k8up#1032](https://github.com/k8up-io/k8up/issues/1032), same symptom (uid 65532,
+`error occurred during backup` during scan and archival, empty snapshot reported as success) reported independently
+against a real Longhorn/nginx volume — this isn't a sandbox artifact. k8up's backup Job pod runs as a fixed non-root UID
+(65532, the operator image's own default) unless `spec.podSecurityContext` overrides it. Postgres's PGDATA is owned by
+uid 70 with mode `0700` — the backup Job, running as uid 65532, cannot read into it.
+
+This is **not a hard failure**. The Job pod's own log shows:
+
+```text
+backup finished	{"new files": 0, "changed files": 0, "errors": 2}
+```
+
+(two "error occurred during backup" lines, one for scan, one for archival) — but the `Backup` CR's `Completed` condition
+still reports `status: "True", reason: "Succeeded"`. `kubectl get backup` prints a `COMPLETION` column that says
+`Succeeded`. Nothing on the CR's status distinguishes "backed up 1271 files" from "backed up 0 files because it couldn't
+read any of them." The only way to catch this is reading the Job pod's own logs for `"errors": 2` / `"new files": 0` —
+something neither a human skimming `kubectl get backup` nor (per #1208's own stated bar) a small local model would
+reliably think to check.
+
+Fix: set `spec.podSecurityContext.runAsUser`/`runAsGroup` to match whatever UID actually owns the target PVC's data
+(confirmed working — `manifests/schedule.yaml`, and every ad-hoc CR in `scripts/validate.sh`, set `70`/`70` for
+Postgres). **There is no cluster-wide default for this** the way there is for the S3 backend (§3.1) — every app with
+non-default PVC ownership needs its own value, discovered per-app, not assumed.
+
+### 3.4 Retention: `keepDaily` silently defaults to 14
+
+Also a known, open upstream bug — [k8up-io/k8up#1106](https://github.com/k8up-io/k8up/issues/1106), which quotes the
+exact same `operator/prunecontroller/executor.go` snippet independently. k8up's prune executor (its own code comment:
+`// FIXME(mw): this is ugly`) hardcodes `KEEP_DAILY=14` whenever `spec.retention.keepDaily` is `0`/unset — there is no
+way to express "don't also keep one per day" by omission. Found by setting only `keepLast: 1` and getting 2 snapshots
+back instead of 1: restic's actual policy, "keep 1 latest, 14 daily," correctly kept both snapshots because they landed
+on the same UTC day. `scripts/validate.sh`'s Prune CR sets `keepDaily: 1` explicitly to get a deterministic
+single-snapshot result. A production Schedule that only sets `keepLast` will silently retain far more than intended.
+
+### 3.5 Completed backup Jobs pin the PVC
+
+A `pvc-protection` finalizer blocks PVC deletion while _any_ pod — running or long-Completed — still lists that PVC
+under `spec.volumes`. k8up's own backup Job pods aren't garbage-collected on completion, so simulating data loss
+(deleting a PVC to force a fresh one) hangs on `kubectl delete pvc --wait` until the old backup Job(s) are also deleted.
+Harmless for normal operation, but a real trap for anyone doing an actual disaster-recovery PVC recreation without
+knowing to clean up old backup Jobs first. `scripts/validate.sh` does this explicitly before its data-loss simulation.
+
+---
+
+## 4. Implementation
+
+### 4.1 Bootstrap
+
+```sh
+mise run poc:bootstrap
+```
+
+Idempotent — creates the kind cluster if missing, reuses it otherwise. Deploys, in order: MinIO + bucket-creation Job
+(`manifests/minio.yaml`), k8up via the official Helm chart (`manifests/k8up-helmvalues.yaml`, global S3/repo env vars),
+the Postgres test app (`manifests/test-app.yaml`), and its Schedule (`manifests/schedule.yaml`).
+
+```sh
+mise run poc:teardown   # deletes the kind cluster and everything in it
+```
+
+### 4.2 Validation
+
+```sh
+mise run poc:validate
+```
+
+Writes marker1, takes backup-1; writes marker2, takes backup-2; simulates data loss (scales the StatefulSet to 0,
+deletes the PVC, scales back up to get a fresh empty one — §3.5's job cleanup happens first); restores **explicitly from
+backup-1's snapshot ID**, not the latest; checks marker1 came back and marker2 did **not** (the actual test of
+k8up-io/k8up#1062); prunes down to 1 snapshot (§3.4's explicit `keepDaily`).
+
+### 4.3 Manifests
+
+| File                                               | Purpose                                                             |
+| -------------------------------------------------- | ------------------------------------------------------------------- |
+| `manifests/minio.yaml`                             | Single-node MinIO + bucket-creation Job (S3 backup target)          |
+| `manifests/k8up-helmvalues.yaml`                   | k8up Helm values — global S3/repo-password env vars (§3.1)          |
+| `manifests/test-app.yaml`                          | Postgres StatefulSet, kind's default StorageClass (§3.2)            |
+| `manifests/schedule.yaml`                          | Namespace-scoped Schedule — backup/check/prune cron, uid fix (§3.3) |
+| `scripts/bootstrap.sh`/`validate.sh`/`teardown.sh` | Sandbox lifecycle, wired into `mise run poc:*`                      |
+
+---
+
+## 5. Test Environment
+
+| Component | Value                                            |
+| --------- | ------------------------------------------------ |
+| kind      | v0.32.0, node image `kindest/node:v1.36.1`       |
+| k8up      | chart 4.10.0, app v2.16.0                        |
+| MinIO     | `minio/minio:RELEASE.2025-09-07T16-13-09Z`       |
+| Test app  | `postgres:17-alpine`, 1Gi dynamic `standard` PVC |
+
+---
+
+## 6. Validation Criteria
+
+```sh
+mise run poc:validate
+```
+
+| ID    | Criterion                                                             |
+| ----- | --------------------------------------------------------------------- |
+| V-001 | backup-1 completed successfully                                       |
+| V-002 | backup-2 completed successfully                                       |
+| V-003 | PVC recreated empty (marker gone after simulated data loss)           |
+| V-004 | restore-1 (explicit, non-latest snapshot) completed successfully      |
+| V-005 | PVC restored and Bound                                                |
+| V-006 | Postgres ready after restore                                          |
+| V-007 | marker1 (the explicitly targeted, older snapshot) came back           |
+| V-008 | marker2 (the newer snapshot) did **not** come back — guards k8up#1062 |
+| V-009 | prune-1 completed successfully                                        |
+| V-010 | exactly 1 snapshot remains after pruning                              |
+
+---
+
+## 7. Results
+
+`mise run poc:bootstrap` followed by `mise run poc:validate` passes all 10 checks on a clean run:
+
+```text
+=== Results: 10 passed, 0 failed ===
+```
+
+Getting there took 2 real, reproducible failures along the way (not injected — found by running the script and reading
+the actual error), both documented as findings above rather than smoothed over:
+
+1. First run: `kubectl delete pvc --wait` hung to its timeout — the StatefulSet controller re-created the pod
+   (remounting the old PVC) before the delete could land, because the pod was deleted with replicas still at 1. Fixed by
+   scaling to 0 first (`scripts/validate.sh`'s data-loss step).
+2. Second run: restore "succeeded" but the restored database had none of the expected data — traced to §3.3 (the
+   silent-empty-backup UID mismatch), not a restore bug at all; the _backups themselves_ were empty. Fixed by setting
+   `podSecurityContext` on every CR.
+
+## 8. Conclusions
+
+**k8up solves the specific problem that sent this investigation down this path.** Restore into an already-existing,
+ArgoCD-owned PVC works cleanly and deterministically — no controller-timing flakiness, no "Velero must own the pod"
+requirement (Velero POC's whole reason for existing, and #1188's original blocker). Explicit snapshot targeting is
+correct (V-007/V-008 directly rule out k8up-io/k8up#1062's failure mode). The opt-out PVC discovery model (§3.2) removes
+an entire class of "silently skipped this PVC" failure Velero has.
+
+**It is not drop-in "just works," though.** §3.3 and §3.4 are two real gotchas that don't show up anywhere in k8up's own
+CRD status or `kubectl get` output — they require either reading the Job pod's logs (§3.3) or knowing about an internal
+hardcoded default (§3.4) to catch. Both are the kind of thing a small local model, or a human on a short runbook, would
+walk straight past: `kubectl get backup` says `Succeeded` even when nothing was backed up at all. Neither is a sandbox
+artifact — both are confirmed, open, upstream bugs ([k8up-io/k8up#1032](https://github.com/k8up-io/k8up/issues/1032),
+[k8up-io/k8up#1106](https://github.com/k8up-io/k8up/issues/1106)) reported independently against real production
+volumes, unfixed as of chart 4.10.0/app v2.16.0.
+
+**Verdict: keep k8up, start migrating lungmen.akn's local-PVC apps (actual-budget, jellyfin, paperless-ngx) off Velero's
+fs-backup path — but treat "does this app's backup Job actually report `new files > 0`" as a mandatory per-app health
+check at rollout time, not something the CR status alone can be trusted to surface.** Don't run both tools for the same
+apps: Velero doesn't solve the restore problem this cluster actually has, so keeping it alongside k8up buys nothing but
+a second thing to maintain.
+
+### 8.1 Not answered by this POC
+
+- **CNPG-specific backup behavior** — this POC uses a plain Postgres StatefulSet, not a CNPG cluster. CNPG's own
+  backup/WAL-archiving machinery may interact with a concurrent restic snapshot differently. Worth a follow-up check
+  before relying on this for `lungmen.akn`'s real CNPG clusters (same caveat the Velero POC raised).
+- **Scheduled (cron-triggered) backup firing** — this POC validates the Schedule CR is accepted (`Ready` condition) and
+  drives the actual backup/restore/prune round trip via standalone one-off CRs for speed, same convention as the Velero
+  POC's `velero backup create --wait`. Cron firing itself isn't exercised.
+- **RWO backup-Job node scheduling** — #1208's own risk section flags that RWO PVC backup Jobs must land on the same
+  node as the pod using the volume. Not exercised here (kind is single-node); worth checking against `lungmen.akn`'s
+  actual node topology before rollout.
+- **k8up-io/k8up#803 (single-file restore) and #1210 (restoreMethod misconfiguration error UX)** — not specifically
+  exercised; this POC's restore is a whole-folder restore into an existing PVC, not a single-file restore, and every CR
+  here is correctly configured by construction.
+
+### 8.2 References
+
+- Issue: [#1208](https://github.com/chezmoidotsh/arcane/issues/1208)
+- Related: [#1188](https://github.com/chezmoidotsh/arcane/issues/1188) (lungmen.akn recreation — where the Velero
+  restore reliability problem was found), [docs/experiments/20260803-velero-pvc-backup](../20260803-velero-pvc-backup/)
+  (EXP-2026-007, the Velero POC this one is a direct counterpart to)
+- k8up docs: <https://docs.k8up.io/k8up/2.16/>
+- k8up-io/k8up source read directly for this POC: `operator/cfg/config.go`, `operator/executor/envvarconverter.go`,
+  `operator/prunecontroller/executor.go`, `restic/cli/prune.go`, `api/v1/status.go`, `api/v1/common_types.go`
+- k8up-io/k8up#1062, #803, #1210 (named in #1208's own research)
+- k8up-io/k8up#1032 (§3.3 — silent empty backup, open), #1106 (§3.4 — undocumented `keepDaily: 14` default, open) —
+  found independently by searching upstream after reproducing both locally, confirming neither is a sandbox artifact
+
+---
+
+## 9. Actionable Next Steps
+
+- Deploy this same k8up configuration on `lungmen.akn` against the real S3 target (`s3.chezmoi.sh`), scoped to one or
+  two apps with local PVCs (actual-budget, jellyfin, or paperless-ngx per #1208), with `podSecurityContext` matched to
+  each app's actual PVC ownership (§3.3) and explicit retention values for every `keep*` dimension (§3.4) — repeat the
+  backup/restore validation against a real app's PVC.
+- Add a rollout-time (or scheduled) check that a Schedule's most recent backup Job reported `new files > 0` — the CR
+  status alone (§3.3) is not sufficient signal that a backup actually captured data.
+- Package as a reusable ArgoCD Application, matching this repo's `<chart>.helmvalues/` convention (Velero POC's own
+  deferred item, same shape here).
+- Validate CNPG-specific behavior directly on `lungmen.akn` before relying on this for real CNPG clusters
+  ([§8.1](#81-not-answered-by-this-poc)).

--- a/docs/experiments/20260805-k8up-pvc-restore/README.md
+++ b/docs/experiments/20260805-k8up-pvc-restore/README.md
@@ -274,6 +274,30 @@ a second thing to maintain.
 - **k8up-io/k8up#803 (single-file restore) and #1210 (restoreMethod misconfiguration error UX)** — not specifically
   exercised; this POC's restore is a whole-folder restore into an existing PVC, not a single-file restore, and every CR
   here is correctly configured by construction.
+- **Whether the target pod can stay up during restore** — `scripts/validate.sh` explicitly scales the StatefulSet to 0
+  before creating the Restore CR and only scales back up once it completes (see the "Scaling down" step). This wasn't
+  arbitrary — restoring restic-managed files into a directory a live Postgres has open risks corruption regardless of
+  which backup tool is involved — but it means **restoring with the pod left running was never exercised**, only "stop,
+  restore, start." On `lungmen.akn`, the StatefulSet is ArgoCD-managed: if self-heal is enabled, a manual
+  `kubectl scale --replicas=0` done out-of-band (not through Git) is likely to get fought and reverted by ArgoCD's own
+  reconciliation before the restore Job ever gets exclusive access to the PVC. Not tested here — kind has no ArgoCD. The
+  real procedure almost certainly needs to pause/unsync the Application first, not just scale the workload.
+- **Whether restore is destructive or additive** — every restore in this POC targets a PVC that was just freshly
+  (re)created and is genuinely empty (§3.5's data-loss simulation deletes and recreates it). `restic restore` is not
+  necessarily a wipe-then-restore operation — by default it writes/overwrites the files present in the snapshot but does
+  not clearly guarantee removal of files that exist in the target but aren't in the snapshot. Restoring "in place" onto
+  a PVC that already has some (possibly partial or corrupted) data — rather than a freshly emptied one — was never
+  tested, so whether stale files survive a restore and give a false sense of a clean recovery is an open question, not
+  an assumption this POC can back up.
+- **Backup consistency under concurrent writes / app-aware hooks** — backup-1 and backup-2 were both taken while
+  Postgres was live and serving queries, and the round trip preserved the marker row correctly both times — but that's
+  the same crash-consistency argument the Velero POC relied on (§3 of that POC), not a guarantee under real write load.
+  k8up supports an app-aware alternative to the raw file-level backup, the `k8up.io/backupcommand` annotation (exec a
+  command — e.g. a `pg_dump`, or a pause/flush — instead of reading the mounted files directly), mirroring Velero's own
+  pre/post backup hooks. Neither this POC nor the Velero one tested the hook-based path; both only validated the naive
+  file-level backup. For lungmen.akn's actual CNPG clusters this matters more than it did here, since CNPG already has
+  its own WAL-archiving backup machinery that a concurrent restic snapshot could interact with unpredictably (see the
+  CNPG bullet above).
 
 ### 8.2 References
 
@@ -302,3 +326,11 @@ a second thing to maintain.
   deferred item, same shape here).
 - Validate CNPG-specific behavior directly on `lungmen.akn` before relying on this for real CNPG clusters
   ([§8.1](#81-not-answered-by-this-poc)).
+- **Build an operational script for the full restore procedure**, matching the `scripts/*` convention already used for
+  other stateful operations in this repo (`argocd:app:sync`, `cnpg:db:migrate`, `bao:kv:copy`). A raw `kubectl apply` of
+  a `Restore` CR isn't the real procedure on an ArgoCD-managed cluster — per the pod-concurrency finding above, it needs
+  at minimum: unsync/pause the app's ArgoCD `Application` (so self-heal doesn't fight the scale-down), scale the
+  workload to 0, create and wait on the `Restore`, scale back up and confirm the rollout, then re-sync ArgoCD. Building
+  this as a reusable script (rather than a one-off manual sequence during an actual incident) is exactly the kind of
+  simple, deterministic tooling #1208's own bar for "a small local model can operate this" calls for — worked out and
+  tested once, not improvised live during a real recovery.

--- a/docs/experiments/20260805-k8up-pvc-restore/manifests/k8up-helmvalues.yaml
+++ b/docs/experiments/20260805-k8up-pvc-restore/manifests/k8up-helmvalues.yaml
@@ -1,0 +1,31 @@
+# k8up operator, chart 4.10.0 / app v2.16.0. S3 backend and restic repository
+# password are configured globally via operator env vars (BACKUP_GLOBAL* — see
+# operator/cfg/config.go and operator/executor/envvarconverter.go in k8up-io/k8up)
+# rather than repeated on every CR: this is what lets manifests/schedule.yaml and
+# every Backup/Restore/Prune CR created in scripts/validate.sh omit `spec.backend`
+# entirely, confirmed against config/samples/k8up_v1_restore.yaml's "restore-s3-global"
+# example (`backend: {s3: {}}`/omitted, relying on these same env vars).
+image:
+  tag: v2.16.0
+
+k8up:
+  envVars:
+    - name: BACKUP_GLOBALS3ENDPOINT
+      value: http://minio.k8up-poc.svc:9000
+    - name: BACKUP_GLOBALS3BUCKET
+      value: k8up-backups
+    - name: BACKUP_GLOBALACCESSKEYID
+      valueFrom:
+        secretKeyRef:
+          name: k8up-repo-credentials
+          key: username
+    - name: BACKUP_GLOBALSECRETACCESSKEY
+      valueFrom:
+        secretKeyRef:
+          name: k8up-repo-credentials
+          key: password
+    - name: BACKUP_GLOBALREPOPASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: k8up-repo-credentials
+          key: repository-password

--- a/docs/experiments/20260805-k8up-pvc-restore/manifests/minio.yaml
+++ b/docs/experiments/20260805-k8up-pvc-restore/manifests/minio.yaml
@@ -47,11 +47,14 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
+        # trivy:ignore:KSV-0125
+        # Raw docker.io image, not mirrored through oci.chezmoi.sh: this
+        # sandbox is local-only and torn down after use, never exposed
+        # outside the disposable kind cluster — unlike real cluster
+        # manifests, there's no registry-mirror policy to satisfy here.
         - name: minio
           image: minio/minio:RELEASE.2025-09-07T16-13-09Z
-          # imagePullPolicy left at the IfNotPresent default rather than
-          # Always: the tag is a pinned, immutable release, so re-pulling on
-          # every restart would just waste time. checkov:skip=CKV_K8S_15
+          imagePullPolicy: Always
           args: ["server", "/data", "--console-address", ":9001"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -141,10 +144,11 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
+        # trivy:ignore:KSV-0125
+        # Raw docker.io image — see the minio container's comment above.
         - name: mc
           image: minio/mc:RELEASE.2025-08-13T08-35-41Z
-          # imagePullPolicy left at IfNotPresent — see the minio container's
-          # comment above. checkov:skip=CKV_K8S_15
+          imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/docs/experiments/20260805-k8up-pvc-restore/manifests/minio.yaml
+++ b/docs/experiments/20260805-k8up-pvc-restore/manifests/minio.yaml
@@ -1,0 +1,180 @@
+# Single-node MinIO used as the S3-compatible backup target for this sandbox.
+# Same pattern as docs/experiments/20260803-velero-pvc-backup/manifests/minio.yaml
+# (throwaway sandbox infra, not a component under evaluation) — bucket renamed to
+# k8up-backups and namespace to k8up-poc so both experiments' kind clusters can, in
+# principle, coexist without name clashes.
+#
+# Storage is emptyDir: this sandbox is torn down and recreated on every run, state
+# resetting on every bootstrap is a feature, not a bug.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8up-poc
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+  namespace: k8up-poc
+type: Opaque
+stringData:
+  # Dev-only fixed values — this cluster is local, disposable, and never
+  # reachable from outside the pod.
+  root_user: k8uppoc
+  root_password: k8uppocsecretkey # checkov:skip=CKV_SECRET_6: Fake dev-only value, disposable local sandbox.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: k8up-poc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+          # imagePullPolicy left at the IfNotPresent default rather than
+          # Always: the tag is a pinned, immutable release, so re-pulling on
+          # every restart would just waste time. checkov:skip=CKV_K8S_15
+          args: ["server", "/data", "--console-address", ":9001"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          # _FILE variants read the credential from a mounted volume instead
+          # of the pod's env — keeps it out of `kubectl describe pod` output.
+          env:
+            - name: MINIO_ROOT_USER_FILE
+              value: /etc/minio-credentials/root_user
+            - name: MINIO_ROOT_PASSWORD_FILE
+              value: /etc/minio-credentials/root_password
+          ports:
+            - name: s3-api
+              containerPort: 9000
+            - name: console
+              containerPort: 9001
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: tmp
+              mountPath: /tmp
+            - name: credentials
+              mountPath: /etc/minio-credentials
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: s3-api
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: s3-api
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: credentials
+          secret:
+            secretName: minio-credentials
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: k8up-poc
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: s3-api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001
+---
+# One-shot bucket creation — MinIO doesn't auto-create buckets on boot.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-create-bucket
+  namespace: k8up-poc
+spec:
+  backoffLimit: 6
+  template:
+    spec:
+      restartPolicy: OnFailure
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mc
+          image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+          # imagePullPolicy left at IfNotPresent — see the minio container's
+          # comment above. checkov:skip=CKV_K8S_15
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              MINIO_ROOT_USER="$(cat /etc/minio-credentials/root_user)"
+              MINIO_ROOT_PASSWORD="$(cat /etc/minio-credentials/root_password)"
+              mc alias set k8up-poc http://minio.k8up-poc.svc:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+              mc mb --ignore-existing k8up-poc/k8up-backups
+          volumeMounts:
+            - name: mc-config
+              mountPath: /.mc
+            - name: credentials
+              mountPath: /etc/minio-credentials
+              readOnly: true
+      volumes:
+        - name: mc-config
+          emptyDir: {}
+        - name: credentials
+          secret:
+            secretName: minio-credentials

--- a/docs/experiments/20260805-k8up-pvc-restore/manifests/schedule.yaml
+++ b/docs/experiments/20260805-k8up-pvc-restore/manifests/schedule.yaml
@@ -1,0 +1,34 @@
+# One Schedule per app namespace. Unlike Velero's per-app Schedule (one BackupStorageLocation-
+# style resource per app for easy restore targeting), k8up's Schedule is inherently
+# namespace-scoped and opt-out: it covers every PVC in k8up-poc-app by default, no
+# per-workload annotation needed (see manifests/test-app.yaml's header comment).
+#
+# spec.backend is omitted — the global S3/repo-password env vars set on the operator
+# (manifests/k8up-helmvalues.yaml) apply here.
+#
+# spec.podSecurityContext.runAsUser/runAsGroup: 70 — WITHOUT this, the backup Job pod
+# runs as k8up's own default non-root UID (65532), which cannot read into Postgres's
+# PGDATA (owned uid 70, mode 0700). That isn't a hard failure: restic logs two "error
+# occurred during backup" lines and backs up 0 files, but the Backup CR still reports
+# `Completed`/`Succeeded` — a silent empty-backup trap, found only by checking the Job
+# pod's own logs for "errors": 2, not by anything the CR's status surfaces. See
+# scripts/validate.sh's header for how this was caught. Every app's backup Job needs its
+# securityContext matched to whatever UID actually owns its PVC data — there is no
+# global default for this (unlike the S3 backend).
+apiVersion: k8up.io/v1
+kind: Schedule
+metadata:
+  name: test-app
+  namespace: k8up-poc-app
+spec:
+  podSecurityContext:
+    runAsUser: 70
+    runAsGroup: 70
+  backup:
+    schedule: "0 */12 * * *"
+  check:
+    schedule: "0 3 * * 0"
+  prune:
+    schedule: "0 1 * * *"
+    retention:
+      keepLast: 3

--- a/docs/experiments/20260805-k8up-pvc-restore/manifests/test-app.yaml
+++ b/docs/experiments/20260805-k8up-pvc-restore/manifests/test-app.yaml
@@ -1,0 +1,126 @@
+# Minimal stateful app to prove k8up's restic-based backup/restore round-trips real PV
+# data into an *already-existing* PVC — the exact case Velero's restore controller
+# never progresses on a GitOps-managed cluster (see docs/experiments/20260803-velero-pvc-backup
+# and issue 1188). Same Postgres + marker-row pattern as that POC, reused because it
+# already proved a live filesystem-level backup round-trips real application data, not
+# just raw bytes.
+#
+# Two differences from the Velero POC's test-app.yaml, both because k8up's backup
+# mechanism works differently from Velero's fs-backup:
+#
+# 1. No static `local`-type PV / `manual` StorageClass workaround. Velero's fs-backup
+#    inspects the *PV's own type* and explicitly refuses hostPath volumes (kind's
+#    default provisioner produces hostPath PVs). k8up's backup Job mounts the PVC
+#    directly into its own throwaway pod instead — it never inspects the underlying PV
+#    type, so kind's bundled "standard" StorageClass works with zero workaround.
+#
+# 2. No `backup.velero.io/backup-volumes`-style opt-in annotation. k8up is opt-out: a
+#    Schedule (manifests/schedule.yaml) covers every PVC in its namespace by default
+#    (`k8up.io/backup: "false"` to exclude one) — Velero's fs-backup is opt-in per pod,
+#    which is what let a PVC get silently skipped in the sibling POC (its README §3.1).
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8up-poc-app
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-app
+  namespace: k8up-poc-app
+spec:
+  serviceName: test-app
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        # kind's local-path-provisioner hostPath volumes are root-owned.
+        # postgres's entrypoint calls chmod on PGDATA, which needs actual
+        # ownership (not just fsGroup's group-write bit) — chown as root
+        # once before the non-root postgres container starts.
+        - name: fix-permissions
+          image: postgres:17-alpine
+          command: ["sh", "-c", "chown -R 70:70 /var/lib/postgresql/data /var/run/postgresql"]
+          securityContext:
+            # Needs CAP_CHOWN/CAP_FOWNER to chown paths it doesn't already
+            # own — dropping ALL would leave even uid 0 unable to chown.
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: run
+              mountPath: /var/run/postgresql
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 70
+            runAsGroup: 70
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          env:
+            - name: POSTGRES_DB
+              value: testdb
+            - name: POSTGRES_USER
+              value: test
+            - name: POSTGRES_PASSWORD
+              value: test
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: tmp
+              mountPath: /tmp
+            - name: run
+              mountPath: /var/run/postgresql
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "test"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "test"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/docs/experiments/20260805-k8up-pvc-restore/manifests/test-app.yaml
+++ b/docs/experiments/20260805-k8up-pvc-restore/manifests/test-app.yaml
@@ -48,19 +48,40 @@ spec:
         # kind's local-path-provisioner hostPath volumes are root-owned.
         # postgres's entrypoint calls chmod on PGDATA, which needs actual
         # ownership (not just fsGroup's group-write bit) — chown as root
-        # once before the non-root postgres container starts.
+        # once before the non-root postgres container starts. Dropping ALL
+        # capabilities and adding back only CHOWN/FOWNER was tried first and
+        # broke restoring into this PVC specifically: after a k8up restore,
+        # the directory restic faithfully restored is already mode 0700
+        # owned by uid 70 (exactly what backup-1 captured), and without
+        # CAP_DAC_OVERRIDE even a uid-0 process can't traverse into a 0700
+        # directory it doesn't own — confirmed by running it, "chown:
+        # /var/lib/postgresql/data: Permission denied" on the very first
+        # restored pod. A totally fresh, empty PVC never exercises this
+        # path (permissive default dir perms), which is why bootstrap alone
+        # doesn't catch it. CHOWN+FOWNER+DAC_OVERRIDE is the minimal set
+        # that actually works for both the fresh and the restored case.
+        # checkov:skip=CKV_K8S_37:see comment above, this is the minimal set
+        # trivy:ignore:KSV-0012 trivy:ignore:KSV-0020 trivy:ignore:KSV-0021
+        # trivy:ignore:KSV-0022 trivy:ignore:KSV-0105
+        # checkov:skip=CKV_K8S_40:root init container, see comment above
         - name: fix-permissions
           image: postgres:17-alpine
+          imagePullPolicy: Always
           command: ["sh", "-c", "chown -R 70:70 /var/lib/postgresql/data /var/run/postgresql"]
           securityContext:
-            # Needs CAP_CHOWN/CAP_FOWNER to chown paths it doesn't already
-            # own — dropping ALL would leave even uid 0 unable to chown.
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 0
+            runAsGroup: 0
+            capabilities:
+              drop: ["ALL"]
+              add: ["CHOWN", "FOWNER", "DAC_OVERRIDE"]
           resources:
             requests:
               cpu: 50m
               memory: 32Mi
             limits:
+              cpu: 100m
               memory: 64Mi
           volumeMounts:
             - name: data
@@ -70,16 +91,21 @@ spec:
       containers:
         - name: postgres
           image: postgres:17-alpine
+          imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            # trivy:ignore:KSV-0020 trivy:ignore:KSV-0021
+            # uid/gid 70 is the postgres image's own fixed account, not
+            # configurable — real Postgres images don't run above 10000.
             runAsUser: 70
             runAsGroup: 70
             capabilities:
               drop: ["ALL"]
           resources:
             limits:
+              cpu: 250m
               memory: 256Mi
             requests:
               cpu: 100m

--- a/docs/experiments/20260805-k8up-pvc-restore/scripts/bootstrap.sh
+++ b/docs/experiments/20260805-k8up-pvc-restore/scripts/bootstrap.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Bootstrap for the k8up local POC (issue #1208)
+# =============================================================================
+# Creates a disposable kind cluster, deploys MinIO as the S3-compatible backup
+# target, installs k8up (Helm chart), and deploys the Postgres test app + its
+# Schedule used for the backup/restore/prune validation.
+#
+# Usage:
+#   mise run poc:bootstrap
+#   ./scripts/bootstrap.sh
+# =============================================================================
+
+set -euo pipefail
+
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-k8up-poc}"
+K8UP_CHART_VERSION="4.10.0"
+EXPERIMENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+check_dependencies() {
+  local deps=("kind" "kubectl" "helm")
+  local missing=()
+  for dep in "${deps[@]}"; do
+    command -v "${dep}" &>/dev/null || missing+=("${dep}")
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    log_error "Missing dependencies: ${missing[*]} — run 'mise install' in this directory."
+    exit 1
+  fi
+}
+
+create_cluster() {
+  mkdir -p "$(dirname "${KUBECONFIG:-${HOME}/.kube/config}")"
+  if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+    log_info "kind cluster ${CLUSTER_NAME} already exists, reusing it"
+  else
+    log_info "Creating kind cluster: ${CLUSTER_NAME}"
+    kind create cluster --name "${CLUSTER_NAME}"
+  fi
+  kubectl config use-context "kind-${CLUSTER_NAME}"
+}
+
+deploy_minio() {
+  log_info "Deploying MinIO (S3-compatible backup target)"
+  # Job pod templates are immutable — delete before reapplying so reruns
+  # against an existing cluster don't fail.
+  kubectl -n k8up-poc delete job minio-create-bucket --ignore-not-found
+  kubectl apply -f "${EXPERIMENT_DIR}/manifests/minio.yaml"
+  kubectl -n k8up-poc rollout status deployment/minio --timeout=120s
+  kubectl -n k8up-poc wait --for=condition=complete job/minio-create-bucket --timeout=120s
+  log_success "MinIO ready, bucket k8up-backups created"
+}
+
+install_k8up() {
+  log_info "Installing k8up (chart ${K8UP_CHART_VERSION})"
+
+  helm repo add k8up-io https://k8up-io.github.io/k8up 2>/dev/null || true
+  helm repo update k8up-io
+
+  kubectl create namespace k8up --dry-run=client -o yaml | kubectl apply -f -
+
+  # Restic repository credentials. Read by the operator (referenced from
+  # manifests/k8up-helmvalues.yaml's k8up.envVars as the *global* S3/repo-password
+  # config) and injected into every backup/restore/prune Job it spawns — this is
+  # what lets every Schedule/Backup/Restore/Prune CR in this POC omit spec.backend.
+  kubectl -n k8up create secret generic k8up-repo-credentials \
+    --from-literal=username=k8uppoc \
+    --from-literal=password=k8uppocsecretkey \
+    --from-literal=repository-password=k8uppocResticRepoPassword \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  helm upgrade --install k8up k8up-io/k8up \
+    --version "${K8UP_CHART_VERSION}" \
+    --namespace k8up \
+    -f "${EXPERIMENT_DIR}/manifests/k8up-helmvalues.yaml" \
+    --wait --timeout 180s
+
+  kubectl -n k8up rollout status deployment/k8up --timeout=120s
+
+  log_success "k8up installed"
+}
+
+deploy_test_app() {
+  log_info "Deploying Postgres test app (PVC to back up) and its Schedule"
+  kubectl apply -f "${EXPERIMENT_DIR}/manifests/test-app.yaml"
+  kubectl -n k8up-poc-app rollout status statefulset/test-app --timeout=180s
+  kubectl apply -f "${EXPERIMENT_DIR}/manifests/schedule.yaml"
+  kubectl -n k8up-poc-app wait --for=condition=Ready schedule.k8up.io/test-app --timeout=60s
+  log_success "Test app and Schedule ready"
+}
+
+print_instructions() {
+  log_success "=========================================="
+  log_success "Bootstrap complete"
+  log_success "=========================================="
+  echo ""
+  echo "Next steps:"
+  echo "  mise run poc:validate   # run the backup/restore/prune cycle"
+  echo "  mise run poc:teardown   # delete the kind cluster"
+}
+
+main() {
+  log_info "Bootstrapping k8up local POC (cluster: ${CLUSTER_NAME})"
+  check_dependencies
+  create_cluster
+  deploy_minio
+  install_k8up
+  deploy_test_app
+  print_instructions
+}
+
+main "$@"

--- a/docs/experiments/20260805-k8up-pvc-restore/scripts/teardown.sh
+++ b/docs/experiments/20260805-k8up-pvc-restore/scripts/teardown.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Deletes the local kind cluster for the k8up POC and everything in it.
+set -euo pipefail
+
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-k8up-poc}"
+
+if kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+  kind delete cluster --name "${CLUSTER_NAME}"
+  echo "[SUCCESS] kind cluster ${CLUSTER_NAME} deleted"
+else
+  echo "[INFO] kind cluster ${CLUSTER_NAME} does not exist, nothing to do"
+fi

--- a/docs/experiments/20260805-k8up-pvc-restore/scripts/validate.sh
+++ b/docs/experiments/20260805-k8up-pvc-restore/scripts/validate.sh
@@ -68,6 +68,10 @@ write_marker() {
   psql_exec "INSERT INTO k8up_poc_marker (value) VALUES ('${marker}');"
 }
 
+# shellcheck disable=SC2329 # invoked indirectly, inside `check`'s eval'd strings below
+# shellcheck disable=SC2310 # `|| true` here is intentional: the query legitimately
+# fails ("relation does not exist") right after the simulated data-loss step, and
+# that must read back as an empty string, not abort the script under set -e.
 read_marker() {
   psql_exec "SELECT value FROM k8up_poc_marker;" 2>/dev/null || true
 }
@@ -86,6 +90,7 @@ run_k8up_job() {
   kubectl -n "${NS}" wait --for=condition=Completed "${kind}.k8up.io/${name}" --timeout=180s
 }
 
+# shellcheck disable=SC2329 # invoked indirectly, inside `check`'s eval'd strings below
 k8up_job_succeeded() {
   local kind="$1" name="$2"
   local reason
@@ -113,6 +118,9 @@ EOF
 
 check "V-001" "backup-1 completed successfully" "k8up_job_succeeded backup backup-1"
 
+# shellcheck disable=SC2312 # exit codes of comm/sort/head deliberately unchecked —
+# an empty SNAPSHOT1_ID surfaces on its own via the "<none>" fallback below and
+# fails downstream at V-004 (the Restore CR would be rejected with an empty snapshot).
 SNAPSHOT1_ID="$(comm -13 <(echo "${IDS_BEFORE_1}" | sort) <(list_snapshot_ids | sort) | head -1)"
 echo "backup-1 snapshot: ${SNAPSHOT1_ID:-<none>}"
 
@@ -133,6 +141,7 @@ EOF
 
 check "V-002" "backup-2 completed successfully" "k8up_job_succeeded backup backup-2"
 
+# shellcheck disable=SC2312 # same reasoning as SNAPSHOT1_ID above
 SNAPSHOT2_ID="$(comm -13 <(echo "${IDS_BEFORE_2}" | sort) <(list_snapshot_ids | sort) | head -1)"
 echo "backup-2 snapshot: ${SNAPSHOT2_ID:-<none>}"
 
@@ -219,6 +228,7 @@ EOF
 
 check "V-009" "prune-1 completed successfully" "k8up_job_succeeded prune prune-1"
 
+# shellcheck disable=SC2016 # single-quoted on purpose: expands inside eval, not here
 check "V-010" "exactly 1 snapshot remains after pruning" \
   '[ "$(list_snapshot_ids | grep -c .)" = 1 ]'
 

--- a/docs/experiments/20260805-k8up-pvc-restore/scripts/validate.sh
+++ b/docs/experiments/20260805-k8up-pvc-restore/scripts/validate.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Backup/restore/prune validation for the k8up local POC (issue #1208)
+# =============================================================================
+# Round-trips real Postgres data through k8up twice, deliberately in this order:
+#
+#   write marker1 -> backup-1 -> write marker2 -> backup-2 -> simulate data loss
+#   -> restore EXPLICITLY from backup-1's snapshot (not the latest one) -> verify
+#   marker1 came back and marker2 did NOT -> prune down to 1 snapshot
+#
+# Restoring an older snapshot on purpose, then checking the *newer* marker is
+# absent, is what actually tests k8up-io/k8up#1062 ("restore can take the latest
+# backup regardless of which snapshot was requested") rather than just assuming
+# explicit spec.snapshot targeting works because the docs say so.
+#
+# The PVC is never deleted and recreated by k8up itself — it can't be, k8up
+# doesn't own/create the target PVC (README "Known gap"). Data loss is simulated
+# by deleting the StatefulSet's pod + PVC and letting the StatefulSet controller
+# recreate both (fresh, empty) from its volumeClaimTemplate, then restoring into
+# that pre-existing PVC — the same "PVC already exists, declaratively owned by
+# something else" shape as a real ArgoCD-managed StatefulSet on lungmen.akn.
+#
+# Every Backup/Restore CR below sets spec.podSecurityContext.runAsUser/runAsGroup: 70
+# to match Postgres's PGDATA ownership (uid 70, mode 0700). Without it, the backup
+# Job runs as k8up's own default uid (65532), can't read into PGDATA, and — this is
+# the actual headline finding of this POC — the Backup CR still reports
+# `Completed`/`Succeeded` anyway. restic logs "errors": 2 and "new files": 0 in the
+# Job pod's own log, but nothing on the CR's status surfaces that. Found by running
+# this script and getting a restore that silently came back empty (V-007 failing
+# with the target relation not existing at all), not by reading k8up's docs — see
+# README §3.3.
+#
+# Usage:
+#   mise run poc:validate
+#   ./scripts/validate.sh
+# =============================================================================
+
+set -euo pipefail
+
+NS="k8up-poc-app"
+POD="test-app-0"
+PVC="data-test-app-0"
+MARKER1="k8up-poc-$(date +%s)-1"
+MARKER2="k8up-poc-$(date +%s)-2"
+
+pass=0
+fail=0
+
+check() {
+  local id="$1" desc="$2" cmd="$3"
+  if eval "${cmd}" &>/dev/null; then
+    echo "PASS [${id}] ${desc}"
+    pass=$((pass + 1))
+  else
+    echo "FAIL [${id}] ${desc}"
+    fail=$((fail + 1))
+  fi
+}
+
+psql_exec() {
+  kubectl -n "${NS}" exec "${POD}" -- psql -U test -d testdb -tAc "$1"
+}
+
+write_marker() {
+  local marker="$1"
+  psql_exec "CREATE TABLE IF NOT EXISTS k8up_poc_marker (value text);"
+  psql_exec "TRUNCATE k8up_poc_marker;"
+  psql_exec "INSERT INTO k8up_poc_marker (value) VALUES ('${marker}');"
+}
+
+read_marker() {
+  psql_exec "SELECT value FROM k8up_poc_marker;" 2>/dev/null || true
+}
+
+list_snapshot_ids() {
+  kubectl -n "${NS}" get snapshots.k8up.io -o jsonpath='{range .items[*]}{.spec.id}{"\n"}{end}' 2>/dev/null
+}
+
+# k8up jobs report success via a "Completed" condition whose *reason* is
+# "Succeeded" (any other reason, e.g. "Failed", also sets Completed=True — see
+# k8up-io/k8up's api/v1/status.go HasSucceeded()). `kubectl wait --for=condition=`
+# only checks the type/status pair, so the reason needs a separate check.
+run_k8up_job() {
+  local kind="$1" name="$2"
+  kubectl apply -f -
+  kubectl -n "${NS}" wait --for=condition=Completed "${kind}.k8up.io/${name}" --timeout=180s
+}
+
+k8up_job_succeeded() {
+  local kind="$1" name="$2"
+  local reason
+  reason="$(kubectl -n "${NS}" get "${kind}.k8up.io" "${name}" -o jsonpath='{.status.conditions[?(@.type=="Completed")].reason}')"
+  [[ ${reason} == "Succeeded" ]]
+}
+
+echo "=== k8up Local POC — Backup/Restore/Prune Validation ==="
+echo ""
+
+echo "--- Writing marker1 (${MARKER1}) and taking backup-1 ---"
+write_marker "${MARKER1}"
+IDS_BEFORE_1="$(list_snapshot_ids)"
+run_k8up_job backup backup-1 <<EOF
+apiVersion: k8up.io/v1
+kind: Backup
+metadata:
+  name: backup-1
+  namespace: ${NS}
+spec:
+  podSecurityContext:
+    runAsUser: 70
+    runAsGroup: 70
+EOF
+
+check "V-001" "backup-1 completed successfully" "k8up_job_succeeded backup backup-1"
+
+SNAPSHOT1_ID="$(comm -13 <(echo "${IDS_BEFORE_1}" | sort) <(list_snapshot_ids | sort) | head -1)"
+echo "backup-1 snapshot: ${SNAPSHOT1_ID:-<none>}"
+
+echo "--- Writing marker2 (${MARKER2}) and taking backup-2 ---"
+write_marker "${MARKER2}"
+IDS_BEFORE_2="$(list_snapshot_ids)"
+run_k8up_job backup backup-2 <<EOF
+apiVersion: k8up.io/v1
+kind: Backup
+metadata:
+  name: backup-2
+  namespace: ${NS}
+spec:
+  podSecurityContext:
+    runAsUser: 70
+    runAsGroup: 70
+EOF
+
+check "V-002" "backup-2 completed successfully" "k8up_job_succeeded backup backup-2"
+
+SNAPSHOT2_ID="$(comm -13 <(echo "${IDS_BEFORE_2}" | sort) <(list_snapshot_ids | sort) | head -1)"
+echo "backup-2 snapshot: ${SNAPSHOT2_ID:-<none>}"
+
+echo "--- Simulating data loss (scale to 0, delete PVC, scale back up to a fresh one) ---"
+# Scale to 0 *before* deleting the PVC: deleting the pod alone isn't enough —
+# with replicas unchanged at 1, the StatefulSet controller immediately
+# recreates the pod and remounts the still-existing PVC before the delete
+# below can complete, which makes `kubectl delete pvc --wait` hang until its
+# timeout (found by actually running this script, not assumed).
+kubectl -n "${NS}" scale statefulset/test-app --replicas=0
+kubectl -n "${NS}" wait --for=delete "pod/${POD}" --timeout=60s
+# Completed k8up backup Jobs leave their (terminal, non-garbage-collected) pods
+# around with the PVC still listed under their spec.volumes — pvc-protection
+# blocks PVC deletion on *any* referencing pod, running or not. Also found by
+# running this, not documented anywhere obvious. Deleting the Jobs (which own
+# and cascade to their pods) is enough; the Backup CRs/snapshots are unaffected
+# (k8up names each backup Job "backup-<Backup CR name>-0").
+kubectl -n "${NS}" delete job backup-backup-1-0 backup-backup-2-0 --ignore-not-found
+kubectl -n "${NS}" delete pvc "${PVC}" --wait --timeout=60s
+kubectl -n "${NS}" scale statefulset/test-app --replicas=1
+kubectl -n "${NS}" rollout status statefulset/test-app --timeout=180s
+
+check "V-003" "PVC recreated empty (marker gone after data loss)" \
+  "[ \"\$(read_marker)\" != \"${MARKER1}\" ] && [ \"\$(read_marker)\" != \"${MARKER2}\" ]"
+
+echo "--- Scaling down so the restore Job can mount ${PVC} exclusively ---"
+kubectl -n "${NS}" scale statefulset/test-app --replicas=0
+kubectl -n "${NS}" wait --for=delete "pod/${POD}" --timeout=60s
+
+echo "--- Restoring EXPLICITLY from backup-1's snapshot (${SNAPSHOT1_ID}), not the latest ---"
+run_k8up_job restore restore-1 <<EOF
+apiVersion: k8up.io/v1
+kind: Restore
+metadata:
+  name: restore-1
+  namespace: ${NS}
+spec:
+  snapshot: ${SNAPSHOT1_ID}
+  restoreMethod:
+    folder:
+      claimName: ${PVC}
+  podSecurityContext:
+    runAsUser: 70
+    runAsGroup: 70
+EOF
+
+check "V-004" "restore-1 completed successfully" "k8up_job_succeeded restore restore-1"
+
+check "V-005" "PVC restored and Bound" \
+  "[ \"\$(kubectl -n ${NS} get pvc ${PVC} -o jsonpath='{.status.phase}')\" = Bound ]"
+
+echo "--- Scaling back up ---"
+kubectl -n "${NS}" scale statefulset/test-app --replicas=1
+kubectl -n "${NS}" rollout status statefulset/test-app --timeout=180s
+
+check "V-006" "Postgres ready after restore" \
+  "kubectl -n ${NS} exec ${POD} -- pg_isready -U test"
+
+check "V-007" "marker1 (targeted snapshot) came back" \
+  "[ \"\$(read_marker)\" = \"${MARKER1}\" ]"
+
+check "V-008" "marker2 (newer snapshot) did NOT come back — guards against k8up#1062" \
+  "[ \"\$(read_marker)\" != \"${MARKER2}\" ]"
+
+echo "--- Pruning down to the last snapshot ---"
+# keepDaily is set explicitly here, not left to default — k8up's prune executor
+# (operator/prunecontroller/executor.go, its own comment: "FIXME(mw): this is
+# ugly") hardcodes KEEP_DAILY=14 whenever spec.retention.keepDaily is 0/unset,
+# there is no way to express "don't also keep one per day" by omission. Found by
+# running with only keepLast:1 set and getting 2 snapshots back instead of 1 —
+# restic's real "keep 1 latest, 14 daily" policy correctly kept both, since both
+# snapshots landed on the same UTC day. See README §3.4.
+run_k8up_job prune prune-1 <<EOF
+apiVersion: k8up.io/v1
+kind: Prune
+metadata:
+  name: prune-1
+  namespace: ${NS}
+spec:
+  retention:
+    keepLast: 1
+    keepDaily: 1
+EOF
+
+check "V-009" "prune-1 completed successfully" "k8up_job_succeeded prune prune-1"
+
+check "V-010" "exactly 1 snapshot remains after pruning" \
+  '[ "$(list_snapshot_ids | grep -c .)" = 1 ]'
+
+echo ""
+echo "=== Results: ${pass} passed, ${fail} failed ==="
+exit "${fail}"


### PR DESCRIPTION
## Summary

Documents the EXP-2026-008 local proof of concept for issue 1208 (spike k8up as a PVC-focused alternative to
Velero). Everything runs in a disposable local kind cluster — MinIO stands in for the real S3 target, a Postgres
StatefulSet stands in for a real stateful app. The POC proves k8up can restore into an already-existing,
ArgoCD-owned PVC — the exact restore shape issue 1188 found Velero's `PodVolumeRestore` controller structurally
unable to handle on a GitOps-managed cluster — and explicitly rules out k8up-io/k8up#1062's failure mode
(restore silently taking the latest snapshot instead of the one requested).

**Related Issue:** #1208

## Changes Made

### Experiment: EXP-2026-008

- **[`docs/experiments/20260805-k8up-pvc-restore/README.md`](docs/experiments/20260805-k8up-pvc-restore/README.md)** — Full write-up: sandbox architecture, 5 findings (§3.1–§3.5) worth carrying into the real deployment, 10 validation results, verdict, and next steps
- **[`docs/experiments/20260805-k8up-pvc-restore/manifests/minio.yaml`](docs/experiments/20260805-k8up-pvc-restore/manifests/minio.yaml)** — Single-node MinIO + bucket-creation Job (S3-compatible backup target)
- **[`docs/experiments/20260805-k8up-pvc-restore/manifests/k8up-helmvalues.yaml`](docs/experiments/20260805-k8up-pvc-restore/manifests/k8up-helmvalues.yaml)** — k8up Helm values: global S3 backend/repo-password env vars, so every CR omits `spec.backend`
- **[`docs/experiments/20260805-k8up-pvc-restore/manifests/test-app.yaml`](docs/experiments/20260805-k8up-pvc-restore/manifests/test-app.yaml)** — Postgres StatefulSet on kind's default StorageClass, used to validate the backup/restore round trip
- **[`docs/experiments/20260805-k8up-pvc-restore/manifests/schedule.yaml`](docs/experiments/20260805-k8up-pvc-restore/manifests/schedule.yaml)** — Namespace-scoped Schedule (backup/check/prune cron), with the UID fix from §3.3 applied
- **[`scripts/bootstrap.sh`](docs/experiments/20260805-k8up-pvc-restore/scripts/bootstrap.sh), [`validate.sh`](docs/experiments/20260805-k8up-pvc-restore/scripts/validate.sh), [`teardown.sh`](docs/experiments/20260805-k8up-pvc-restore/scripts/teardown.sh)** — Sandbox lifecycle, wired into `mise run poc:*`

## Technical Impact

### Experiment Findings

All 10 validation checks pass on a clean run (both backups complete, simulated data loss actually clears the
data, restore from an explicitly named non-latest snapshot completes, the targeted snapshot's data comes back
and the newer snapshot's data does **not**, pruning leaves exactly 1 snapshot). Getting there took 2 real,
reproducible failures along the way, both root-caused and fixed rather than worked around:

- **k8up's backup Job runs as a fixed non-root UID (65532) and silently backs up 0 files** when the target PVC's
  data is owned by a different UID with restrictive permissions (Postgres's PGDATA: uid 70, mode `0700`) — the
  `Backup` CR still reports `Completed`/`Succeeded`, nothing on its status distinguishes an empty backup from a
  real one. Fixed with `spec.podSecurityContext`. Confirmed as a known, open upstream bug independently reported
  against a real Longhorn volume: k8up-io/k8up#1032.
- **`spec.retention.keepDaily` silently defaults to 14** whenever left unset — k8up's own prune executor has a
  `// FIXME(mw): this is ugly` comment acknowledging this. `keepLast: N` alone doesn't cap total snapshot count
  the way it implies. Confirmed as a known, open upstream bug quoting the identical source line: k8up-io/k8up#1106.
- Deleting a PVC to simulate data loss hangs until completed (but non-garbage-collected) backup Job pods are
  cleaned up first — `pvc-protection` blocks deletion on any referencing pod, running or not.
- The StatefulSet controller re-creates a deleted pod (remounting the still-existing PVC) before a follow-up
  `kubectl delete pvc --wait` can land, unless replicas is scaled to 0 first.

Unlike Velero (EXP-2026-007), k8up's backup Job mounts the target PVC directly rather than depending on the
underlying PV's type, so kind's default StorageClass needed no workaround; and its opt-out PVC discovery avoids
the earlier POC's "silently skipped PVC" trap entirely.

CNPG-specific backup behavior, scheduled (cron-triggered) backup firing, and RWO backup-Job node scheduling are
out of scope for this local POC — see README §8.1.

## Testing Validation

- [x] `mise run poc:bootstrap` stands up MinIO, k8up, and the test app cleanly
- [x] `mise run poc:validate` passes all 10 checks (V-001 through V-010) on a clean run
- [x] README renders correctly on GitHub (ToC anchors, code blocks, relative links)

## Future Enhancements

- Deploy this k8up configuration on `lungmen.akn` against the real S3 target, scoped to actual-budget, jellyfin,
  or paperless-ngx, with `podSecurityContext` matched to each app's actual PVC ownership and explicit retention
  values for every `keep*` dimension
- Add a rollout-time (or scheduled) check that a Schedule's most recent backup Job reported `new files > 0` —
  the CR status alone is not sufficient signal
- Package as a reusable ArgoCD Application, matching this repo's `<chart>.helmvalues/` convention
- Validate CNPG-specific behavior directly on `lungmen.akn` before relying on this for real CNPG clusters

## Related Issues

Closes #1208

---
<sub>AI-assisted with Claude:claude-sonnet-5 under human supervision</sub>
