### PR TITLE
Stop Grafana operator fighting our own admin ExternalSecret

### DIFF
--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.Grafana.grafana.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.Grafana.grafana.yaml
@@ -33,3 +33,4 @@ spec:
             - secretRef:
                 name: grafana-admin-credentials
             name: grafana
+  disableDefaultAdminSecret: true

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml
@@ -6,6 +6,11 @@ metadata:
   labels:
     dashboards: grafana
 spec:
+  # The admin credentials come from our own ExternalSecret (grafana-admin-credentials,
+  # sourced from Vault), not the operator's own auto-generated one -- both want to own
+  # a Secret of that same name otherwise, which the operator refuses (already owned by
+  # another controller).
+  disableDefaultAdminSecret: true
   config:
     server:
       root_url: https://o11y.chezmoi.sh


### PR DESCRIPTION
<!-- Use this template for significant new features or infrastructure additions -->

## Root Cause

After PR #1217 merged and ArgoCD synced, the `Grafana` CR on rhodes.akn kept failing its "admin user"
reconcile stage every 2 minutes:

```
failed to reconcile Grafana stage: Object o11y-system/grafana-admin-credentials is already owned by
another ExternalSecret controller grafana-admin-credentials
```

The Grafana Operator auto-creates and owns a `Secret` named `<cr-name>-admin-credentials` by default
unless told not to. Our own `grafana.admin-credentials.externalsecret.yaml` also targets a `Secret`
named `grafana-admin-credentials` (sourced from Vault), so the two controllers fought over ownership
and the `Grafana` CR never left the failing stage — no instance ever came up.

## Fix

- **[`grafana.instance.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml)**
  — sets `spec.disableDefaultAdminSecret: true`, confirmed against the operator's own CRD schema
  (`disableDefaultAdminSecret: prevents operator from creating default admin-credentials secret`).

## Technical Impact

### Behavioural Changes

Grafana's admin credentials now come exclusively from our own Vault-sourced ExternalSecret, matching
the design in PR #1217 — the operator no longer attempts to manage a competing Secret of the same
name.

### Regression Risk

Low — single boolean flag, scoped to rhodes.akn's `Grafana` CR only, no other resource affected.

### Observability

`kubectl -n o11y-system get grafana` should show the CR reach a healthy stage (no more repeating
"admin user" failure events); `kubectl -n o11y-system logs deploy/grafana-operator` should stop
emitting the ownership-conflict error on its ~2min reconcile loop.

## Related Issues

Follow-up to #1217

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
