### PR TITLE
Fix Grafana operator auth by moving admin creds to named env vars

### DIFF
--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.Grafana.grafana.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.Grafana.grafana.yaml
@@ -27,10 +27,19 @@ spec:
             app.kubernetes.io/name: grafana
         spec:
           containers:
-          - envFrom:
+          - env:
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  key: GF_SECURITY_ADMIN_USER
+                  name: grafana-admin-credentials
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: GF_SECURITY_ADMIN_PASSWORD
+                  name: grafana-admin-credentials
+            envFrom:
             - secretRef:
                 name: grafana-oidc-client
-            - secretRef:
-                name: grafana-admin-credentials
             name: grafana
   disableDefaultAdminSecret: true

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml
@@ -35,5 +35,21 @@ spec:
               envFrom:
                 - secretRef:
                     name: grafana-oidc-client
-                - secretRef:
-                    name: grafana-admin-credentials
+              # GF_SECURITY_ADMIN_USER/_PASSWORD must be named `env:` entries, not
+              # bulk-imported via envFrom: the operator's own API client (used to
+              # provision GrafanaDatasource/GrafanaDashboard) reads admin
+              # credentials straight off the container's env list by name -- it
+              # never looks inside envFrom-referenced secrets, so those would
+              # otherwise resolve to an empty user/password and every API call
+              # fails with "ensure connectivity and valid credentials".
+              env:
+                - name: GF_SECURITY_ADMIN_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-credentials
+                      key: GF_SECURITY_ADMIN_USER
+                - name: GF_SECURITY_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-credentials
+                      key: GF_SECURITY_ADMIN_PASSWORD


### PR DESCRIPTION
<!-- Use this template for significant new features or infrastructure additions -->

## Root Cause

Follow-up to #1218: fixing the Secret-ownership conflict got the `Grafana` CR past its "admin user"
stage, but every stage after that (`datasources`, `dashboards`) then failed with:

```
failed to authenticate with instance: failed to authenticate with grafana, ensure connectivity and
valid credentials
```

Traced into the operator's own source
([`controllers/client/auth.go`, `getContainerEnvCredentials`](https://github.com/grafana/grafana-operator/blob/master/controllers/client/auth.go)):
for a self-managed instance, the operator builds its own API client's basic-auth credentials by
scanning the Grafana container's `env:` list **by name** (`GF_SECURITY_ADMIN_USER`/`_PASSWORD`) — it
never looks inside `envFrom`-referenced secrets. Our admin credentials were only ever wired in via
`envFrom`, so the operator always resolved an empty user/password and every provisioning API call
failed auth — even though Grafana itself booted fine with the same secret (confirmed by exec'ing into
the running pod and logging in with the exact env values it received: `200 OK`).

## Fix

- **[`grafana.instance.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml)**
  — moves `GF_SECURITY_ADMIN_USER`/`GF_SECURITY_ADMIN_PASSWORD` to explicit `env:` entries with
  `valueFrom.secretKeyRef`, keeping `envFrom` only for the OIDC client secret (unaffected, no such
  name-scanning constraint applies to that path).

## Technical Impact

### Behavioural Changes

The operator can now authenticate against the self-managed Grafana instance to provision
`GrafanaDatasource`/`GrafanaDashboard` resources. No change to what credentials Grafana itself uses to
create the admin account — same Secret, same values, just referenced in the container spec in the
shape the operator's own client code actually reads.

### Regression Risk

Low — env var values are unchanged, only how they're wired into the container spec. Verified the
exact same credentials already work against the live pod's `/api/org` endpoint.

### Observability

`kubectl -n o11y-system get grafanadatasource,grafanadashboard` should stop showing `NO MATCHING
INSTANCES`; `kubectl -n o11y-system logs deploy/grafana-operator` should stop repeating the auth
failure.

## Related Issues

Follow-up to #1217, #1218

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
