### PR TITLE
Grant Admin role to OIDC logins on Grafana

### DIFF
--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.Grafana.grafana.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.Grafana.grafana.yaml
@@ -14,6 +14,7 @@ spec:
       auth_url: https://auth.chezmoi.sh/authorize
       enabled: "true"
       name: Pocket ID
+      role_attribute_path: '''Admin'''
       scopes: openid profile email
       token_url: https://auth.chezmoi.sh/api/oidc/token
       use_pkce: "true"

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml
@@ -23,6 +23,12 @@ spec:
       scopes: openid profile email
       use_pkce: "true"
       allow_sign_up: "true"
+      # The OIDC client is already group-restricted to the admin group (see
+      # stack/pocket-id/grafana.ts) -- anyone who can log in at all is an
+      # admin, so a constant role expression is simpler and more robust than
+      # matching a groups claim (which would also need "groups" added to
+      # scopes above).
+      role_attribute_path: "'Admin'"
   deployment:
     spec:
       template:


### PR DESCRIPTION
<!-- Use this template for significant new features or infrastructure additions -->

## Root Cause

OIDC login against Pocket-Id works after #1220, but every user lands with the `Viewer` role in
Grafana. `auth.generic_oauth` never set `role_attribute_path`, so Grafana falls back to its own
`auto_assign_org_role` default rather than granting any elevated role.

## Fix

- **[`grafana.instance.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml)**
  — sets `role_attribute_path: "'Admin'"`. The OIDC client is already group-restricted to the admin
  group (`stack/pocket-id/grafana.ts`, `AllowedUserGroups`), so anyone who can complete login at all
  is meant to be a Grafana admin — a constant role expression is simpler and more robust than
  matching a `groups` claim, which would also require adding `groups` to `scopes`.

## Technical Impact

### Behavioural Changes

OIDC logins now get the `Admin` org role instead of `Viewer`. Grafana re-evaluates
`role_attribute_path` on every login by default, so existing sessions pick this up on next sign-in —
no manual database fix needed.

### Regression Risk

Low — single config value, and login access itself is unchanged (still gated by the same
group-restricted OIDC client).

### Observability

Log in at `https://o11y.chezmoi.sh`, check the account menu shows `Admin` (not `Viewer`), and confirm
admin-only pages (e.g. Data sources, Users) are reachable.

## Related Issues

Follow-up to #1217, #1220

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
