### PR TITLE
Move Grafana to CNPG database, switch traces to Tempo, enable OTEL log presets

### DIFF
--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/barmancloud.cnpg.io.v1.ObjectStore.selfhosted.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/barmancloud.cnpg.io.v1.ObjectStore.selfhosted.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: selfhosted
+  namespace: o11y-system
+spec:
+  configuration:
+    data:
+      compression: bzip2
+    destinationPath: s3://cnpg-rhodes-akn/grafana
+    endpointURL: https://s3.chezmoi.sh
+    s3Credentials:
+      accessKeyId:
+        key: access_key_id
+        name: cnpg-backup-credentials
+      region:
+        key: region
+        name: cnpg-backup-credentials
+      secretAccessKey:
+        key: access_secret_key
+        name: cnpg-backup-credentials
+    wal:
+      compression: bzip2
+  instanceSidecarConfiguration:
+    env:
+    - name: AWS_REQUEST_CHECKSUM_CALCULATION
+      value: when_required
+    - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+      value: when_required
+  retentionPolicy: 7d

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/cilium.io.v2.CiliumNetworkPolicy.allow-grafana-database-to-s3-backup.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/cilium.io.v2.CiliumNetworkPolicy.allow-grafana-database-to-s3-backup.yaml
@@ -33,3 +33,4 @@ spec:
       app.kubernetes.io/component: database
       app.kubernetes.io/managed-by: cloudnative-pg
       app.kubernetes.io/name: postgresql
+      cnpg.io/cluster: grafana-database

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/cilium.io.v2.CiliumNetworkPolicy.allow-grafana-database-to-s3-backup.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/cilium.io.v2.CiliumNetworkPolicy.allow-grafana-database-to-s3-backup.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows Grafana's PostgreSQL database to perform backup operations to S3
+      storage. Enables scheduled backups and WAL archiving to the configured
+      S3 endpoint.
+  name: allow-grafana-database-to-s3-backup
+  namespace: o11y-system
+spec:
+  egress:
+  - toFQDNs:
+    - matchName: s3.chezmoi.sh
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: TCP
+  - toEndpoints:
+    - matchLabels:
+        io.kubernetes.pod.namespace: kube-system
+        k8s-app: kube-dns
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      rules:
+        dns:
+        - matchPattern: '*'
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: database
+      app.kubernetes.io/managed-by: cloudnative-pg
+      app.kubernetes.io/name: postgresql

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/external-secrets.io.v1.ExternalSecret.grafana-database-credentials.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/external-secrets.io.v1.ExternalSecret.grafana-database-credentials.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-database-credentials
+  namespace: o11y-system
+spec:
+  data:
+  - remoteRef:
+      key: rhodes.akn/grafana/database/credentials
+      property: username
+    secretKey: username
+  - remoteRef:
+      key: rhodes.akn/grafana/database/credentials
+      property: password
+    secretKey: password
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  target:
+    creationPolicy: Owner
+    name: grafana-database-credentials
+    template:
+      data:
+        password: '{{ .password }}'
+        username: '{{ .username }}'
+      engineVersion: v2
+      type: Opaque

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.Grafana.grafana.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.Grafana.grafana.yaml
@@ -17,6 +17,12 @@ spec:
       scopes: openid profile email
       token_url: https://auth.chezmoi.sh/api/oidc/token
       use_pkce: "true"
+    database:
+      host: grafana-database-rw:5432
+      name: grafana
+      ssl_mode: disable
+      type: postgres
+      user: grafana
     server:
       root_url: https://o11y.chezmoi.sh
     users:
@@ -40,6 +46,11 @@ spec:
                 secretKeyRef:
                   key: GF_SECURITY_ADMIN_PASSWORD
                   name: grafana-admin-credentials
+            - name: GF_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: grafana-database-credentials
             envFrom:
             - secretRef:
                 name: grafana-oidc-client

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.GrafanaDatasource.victorialogs.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.GrafanaDatasource.victorialogs.yaml
@@ -8,6 +8,16 @@ spec:
   datasource:
     access: proxy
     editable: false
+    jsonData:
+      otelPreset:
+        detection:
+          severity:
+            field: severity_text
+            source: manual
+            valueCase: string
+          traceIdField: trace_id
+        enabled: true
+        tracesDatasourceUid: victoriatraces-jaeger
     name: VictoriaLogs
     type: victoriametrics-logs-datasource
     url: https://data.o11y.chezmoi.sh/logs

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.GrafanaDatasource.victoriatraces-jaeger.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.GrafanaDatasource.victoriatraces-jaeger.yaml
@@ -2,16 +2,16 @@
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 metadata:
-  name: victoriatraces
+  name: victoriatraces-jaeger
   namespace: o11y-system
 spec:
   datasource:
     access: proxy
     editable: false
-    name: VictoriaTraces
-    type: tempo
-    url: https://data.o11y.chezmoi.sh/traces/select/tempo
+    name: VictoriaTraces (Jaeger -- log links)
+    type: jaeger
+    url: https://data.o11y.chezmoi.sh/traces/select/jaeger
   instanceSelector:
     matchLabels:
       dashboards: grafana
-  uid: victoriatraces-tempo
+  uid: victoriatraces-jaeger

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/postgresql.cnpg.io.v1.Cluster.grafana-database.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/postgresql.cnpg.io.v1.Cluster.grafana-database.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: grafana-database
+  name: grafana-database
+  namespace: o11y-system
+spec:
+  bootstrap:
+    initdb:
+      database: grafana
+      owner: grafana
+  description: PostgreSQL database dedicated to Grafana
+  enablePDB: false
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    major: 18
+    name: default
+  instances: 1
+  managed:
+    roles:
+    - comment: PostgreSQL role for grafana
+      connectionLimit: -1
+      ensure: present
+      inherit: true
+      login: true
+      name: grafana
+      passwordSecret:
+        name: grafana-database-credentials
+  plugins:
+  - enabled: true
+    isWALArchiver: true
+    name: barman-cloud.cloudnative-pg.io
+    parameters:
+      barmanObjectName: selfhosted
+      serverName: grafana-database
+  postgresql:
+    parameters:
+      max_slot_wal_keep_size: 900MB
+      max_wal_size: 100MB
+  storage:
+    size: 250Mi
+  walStorage:
+    size: 1Gi

--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/postgresql.cnpg.io.v1.ScheduledBackup.grafana-database.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/postgresql.cnpg.io.v1.ScheduledBackup.grafana-database.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: grafana-database
+  namespace: o11y-system
+spec:
+  backupOwnerReference: cluster
+  cluster:
+    name: grafana-database
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  schedule: '@weekly'

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/datasources/grafana.datasource.victorialogs.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/datasources/grafana.datasource.victorialogs.yaml
@@ -19,3 +19,16 @@ spec:
     access: proxy
     url: https://data.o11y.chezmoi.sh/logs
     editable: false
+    jsonData:
+      otelPreset:
+        enabled: true
+        # Only Jaeger-type datasources are supported as a trace-link target.
+        tracesDatasourceUid: victoriatraces-jaeger
+        detection:
+          # Field names set by the o11y LXC's Vector pipeline
+          # (config/vector/transforms.validate.yaml's to_vlogs_format).
+          traceIdField: trace_id
+          severity:
+            field: severity_text
+            valueCase: string
+            source: manual

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/datasources/grafana.datasource.victoriatraces-jaeger.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/datasources/grafana.datasource.victoriatraces-jaeger.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: victoriatraces-jaeger
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  # Fixed uid so the VictoriaLogs OpenTelemetry preset (grafana.datasource.
+  # victorialogs.yaml) can reference it as jsonData.otelPreset.tracesDatasourceUid
+  # -- that feature currently only supports Jaeger-type datasources, not Tempo.
+  uid: victoriatraces-jaeger
+  datasource:
+    name: VictoriaTraces (Jaeger -- log links)
+    # Same VictoriaTraces backend as victoriatraces.yaml (Tempo), exposed via
+    # its Jaeger-compatible query API instead. Not meant to be browsed
+    # directly -- exists only as the OTel-preset trace-link target.
+    type: jaeger
+    access: proxy
+    url: https://data.o11y.chezmoi.sh/traces/select/jaeger
+    editable: false

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/datasources/grafana.datasource.victoriatraces.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/datasources/grafana.datasource.victoriatraces.yaml
@@ -7,10 +7,16 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: grafana
+  uid: victoriatraces-tempo
   datasource:
     name: VictoriaTraces
-    # VictoriaTraces exposes a Jaeger-compatible query API -- no plugin needed.
-    type: jaeger
+    # VictoriaTraces implements the Tempo HTTP API (min version v0.9.4,
+    # confirmed live) -- gives TraceQL and the Grafana Traces Drilldown plugin,
+    # which the plain Jaeger API doesn't support. The Jaeger API is also kept
+    # (victoriatraces-jaeger.yaml) purely as a link target for VictoriaLogs'
+    # OpenTelemetry preset, whose trace-linking currently only supports Jaeger
+    # datasources.
+    type: tempo
     access: proxy
-    url: https://data.o11y.chezmoi.sh/traces
+    url: https://data.o11y.chezmoi.sh/traces/select/tempo
     editable: false

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/datasources/kustomization.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/datasources/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - grafana.datasource.victoriametrics.yaml
   - grafana.datasource.victorialogs.yaml
   - grafana.datasource.victoriatraces.yaml
+  - grafana.datasource.victoriatraces-jaeger.yaml

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.cnpg.cluster.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.cnpg.cluster.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: grafana-database
+  name: grafana-database
+spec:
+  # Fresh instance -- unlike pocket-id/vault, Grafana never lived on amiya.akn,
+  # so this bootstraps from scratch rather than recovering from a backup. Moving
+  # Grafana off its default embedded SQLite (which has no persistent volume on
+  # this deployment -- every pod restart wipes users/dashboards) is the whole
+  # point of this Cluster.
+  bootstrap:
+    initdb:
+      database: grafana
+      owner: grafana
+  description: PostgreSQL database dedicated to Grafana
+  enablePDB: false
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    name: default
+    major: 18
+  instances: 1
+  managed:
+    roles:
+      - name: grafana
+        connectionLimit: -1
+        comment: PostgreSQL role for grafana
+        ensure: present
+        inherit: true
+        login: true
+        passwordSecret:
+          name: grafana-database-credentials
+  plugins:
+    - enabled: true
+      isWALArchiver: true
+      name: barman-cloud.cloudnative-pg.io
+      parameters:
+        barmanObjectName: selfhosted
+        serverName: grafana-database
+  postgresql:
+    parameters:
+      # Limit WAL retention to avoid DB crash due to storage bloat
+      max_slot_wal_keep_size: 900MB
+      max_wal_size: 100MB
+  storage:
+    size: 250Mi
+  walStorage:
+    size: 1Gi

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.cnpg.objectstore.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.cnpg.objectstore.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: selfhosted
+spec:
+  configuration:
+    data:
+      compression: bzip2
+    destinationPath: s3://cnpg-rhodes-akn/grafana
+    endpointURL: https://s3.chezmoi.sh
+    s3Credentials:
+      accessKeyId:
+        name: cnpg-backup-credentials
+        key: access_key_id
+      secretAccessKey:
+        name: cnpg-backup-credentials
+        key: access_secret_key
+      region:
+        name: cnpg-backup-credentials
+        key: region
+    wal:
+      compression: bzip2
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required
+  retentionPolicy: 7d

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.cnpg.scheduledbackup.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.cnpg.scheduledbackup.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: grafana-database
+spec:
+  backupOwnerReference: cluster
+  cluster:
+    name: grafana-database
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  schedule: "@weekly"

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.database.externalsecret.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.database.externalsecret.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-database-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault.chezmoi.sh
+  target:
+    name: grafana-database-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      engineVersion: v2
+      data:
+        # CNPG's managed-role passwordSecret requires exactly these two keys.
+        username: "{{ .username }}"
+        password: "{{ .password }}"
+        # Consumed directly by grafana.instance.yaml's GF_DATABASE_PASSWORD env
+        # override (key: password) -- same Secret, two consumers.
+  data:
+    - secretKey: username
+      remoteRef:
+        key: rhodes.akn/grafana/database/credentials
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: rhodes.akn/grafana/database/credentials
+        property: password

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml
@@ -14,6 +14,16 @@ spec:
   config:
     server:
       root_url: https://o11y.chezmoi.sh
+    database:
+      # Moves Grafana off its default embedded SQLite -- this deployment has no
+      # persistent volume, so every pod restart previously wiped all users,
+      # datasources, and dashboards. GF_DATABASE_PASSWORD (below) supplies the
+      # password; this section only holds non-secret connection settings.
+      type: postgres
+      host: grafana-database-rw:5432
+      name: grafana
+      user: grafana
+      ssl_mode: disable
     users:
       # The OIDC client is already group-restricted to the admin group (see
       # stack/pocket-id/grafana.ts) -- anyone who can log in at all is meant
@@ -62,3 +72,8 @@ spec:
                     secretKeyRef:
                       name: grafana-admin-credentials
                       key: GF_SECURITY_ADMIN_PASSWORD
+                - name: GF_DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-database-credentials
+                      key: password

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/kustomization.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/kustomization.yaml
@@ -16,6 +16,10 @@ resources:
   - grafana.instance.yaml
   - grafana.oidc.externalsecret.yaml
   - grafana.admin-credentials.externalsecret.yaml
+  - grafana.database.externalsecret.yaml
+  - grafana.cnpg.objectstore.yaml
+  - grafana.cnpg.cluster.yaml
+  - grafana.cnpg.scheduledbackup.yaml
   - grafana.main.httproute.yaml
   - datasources/
   - dashboards/

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/security/kustomization.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/security/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - network-policy.allow-grafana-from-ingress-gateway.yaml
   - network-policy.allow-grafana-from-newt.yaml
   - network-policy.allow-operator-to-grafana-com.yaml
+  - network-policy.allow-grafana-database-to-s3-backup.yaml

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/security/network-policy.allow-grafana-database-to-s3-backup.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/security/network-policy.allow-grafana-database-to-s3-backup.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    policy.networking.k8s.io/description: |
+      Allows Grafana's PostgreSQL database to perform backup operations to S3
+      storage. Enables scheduled backups and WAL archiving to the configured
+      S3 endpoint.
+  name: allow-grafana-database-to-s3-backup
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: database
+      app.kubernetes.io/managed-by: cloudnative-pg
+      app.kubernetes.io/name: postgresql
+  egress:
+    - toFQDNs:
+        - matchName: s3.chezmoi.sh
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+          rules:
+            dns:
+              - matchPattern: "*"

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/security/network-policy.allow-grafana-database-to-s3-backup.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/security/network-policy.allow-grafana-database-to-s3-backup.yaml
@@ -14,6 +14,7 @@ spec:
       app.kubernetes.io/component: database
       app.kubernetes.io/managed-by: cloudnative-pg
       app.kubernetes.io/name: postgresql
+      cnpg.io/cluster: grafana-database
   egress:
     - toFQDNs:
         - matchName: s3.chezmoi.sh

--- a/projects/rhodes.akn/src/infrastructure/pulumi/stack/cloudnative-pg.ts
+++ b/projects/rhodes.akn/src/infrastructure/pulumi/stack/cloudnative-pg.ts
@@ -24,7 +24,7 @@ const component = new GarageCloudNativePGObjectStore("garage-cnpg-backup", {
 // Namespaces aren't created by this stack (kubectl/ArgoCD does — see
 // docs/disaster-recovery/{openbao,pocket-id}.md Step 1) — this Secret can only
 // be applied once the target namespace already exists.
-for (const namespace of ["vault", "pocket-id"]) {
+for (const namespace of ["vault", "pocket-id", "o11y-system"]) {
 	new k8s.core.v1.Secret(
 		`cnpg-backup-credentials-${namespace}`,
 		{

--- a/projects/rhodes.akn/src/infrastructure/pulumi/stack/grafana.ts
+++ b/projects/rhodes.akn/src/infrastructure/pulumi/stack/grafana.ts
@@ -37,3 +37,35 @@ export const grafanaAdminCredentials = new vault.kv.SecretV2(
 	},
 	{ parent: grafanaAdminPassword },
 );
+
+// Grafana's own CNPG-backed database (issue 1159 follow-up) -- moves it off
+// the default embedded SQLite, which has no persistent volume on this
+// deployment and was losing all users/dashboards on every pod restart.
+const grafanaDatabasePassword = new random.RandomPassword(
+	"password-grafana-database",
+	{
+		length: 32,
+		special: false,
+	},
+);
+
+export const grafanaDatabaseCredentials = new vault.kv.SecretV2(
+	"grafana-database-vault-secret",
+	{
+		mount: "rhodes.akn",
+		name: "grafana/database/credentials",
+		dataJson: pulumi.jsonStringify({
+			username: "grafana",
+			password: grafanaDatabasePassword.result,
+		}),
+		customMetadata: {
+			data: {
+				description:
+					"Grafana's CNPG-managed role password (grafana.cnpg.cluster.yaml)",
+				application: "grafana",
+				...vaultSecretMetadata(grafanaDatabasePassword),
+			},
+		},
+	},
+	{ parent: grafanaDatabasePassword },
+);


### PR DESCRIPTION
## Summary

Three small follow-ups to the Grafana o11y rollout (issue 1159), found during
live verification and requested directly:

1. Move Grafana off its default embedded SQLite to a dedicated CNPG-backed
   PostgreSQL database.
2. Switch the VictoriaTraces datasource from the Jaeger API to the Tempo API.
3. Enable VictoriaLogs' OpenTelemetry preset for trace/severity derived fields.

**Related Issue:** #1159

## Changes Made

### CNPG-backed Grafana database

- **[`grafana.cnpg.cluster.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.cnpg.cluster.yaml)** — fresh single-instance CNPG cluster (`grafana` database/role), same barman-cloud plugin pattern as pocket-id/vault
- **[`grafana.cnpg.objectstore.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.cnpg.objectstore.yaml)** — S3 backup target (`s3://cnpg-rhodes-akn/grafana`)
- **[`grafana.cnpg.scheduledbackup.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.cnpg.scheduledbackup.yaml)** — weekly backup
- **[`grafana.database.externalsecret.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.database.externalsecret.yaml)** — pulls the DB role password from Vault
- **[`security/network-policy.allow-grafana-database-to-s3-backup.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/security/network-policy.allow-grafana-database-to-s3-backup.yaml)** — CNPG pod egress to `s3.chezmoi.sh`
- **[`grafana.instance.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml)** — adds `spec.config.database` (postgres) and a named `GF_DATABASE_PASSWORD` env var
- **[`stack/grafana.ts`](projects/rhodes.akn/src/infrastructure/pulumi/stack/grafana.ts)** — mints the DB role password and stores it in Vault, mirroring the existing admin-credentials pattern
- **[`stack/cloudnative-pg.ts`](projects/rhodes.akn/src/infrastructure/pulumi/stack/cloudnative-pg.ts)** — adds `o11y-system` to the namespaces that get the shared `cnpg-backup-credentials` Secret

### Traces: Jaeger → Tempo

- **[`grafana.datasource.victoriatraces.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/datasources/grafana.datasource.victoriatraces.yaml)** — `type: jaeger` → `type: tempo`, URL corrected to `/select/tempo`
- **[`grafana.datasource.victoriatraces-jaeger.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/datasources/grafana.datasource.victoriatraces-jaeger.yaml)** — new, keeps a Jaeger-typed datasource alive purely as the OTel-preset trace-link target (see Root Cause below)

### Logs: OpenTelemetry preset

- **[`grafana.datasource.victorialogs.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/datasources/grafana.datasource.victorialogs.yaml)** — adds `jsonData.otelPreset` (trace_id derived field, severity_text log-level rules), field names matching the o11y LXC's Vector pipeline output

## Technical Impact

### Infrastructure Components

Grafana gains its own single-instance CNPG PostgreSQL cluster with weekly S3
backups, using the same `barman-cloud.cloudnative-pg.io` plugin already used
by pocket-id and vault on this cluster.

### Security Implementation

The admin bootstrap credential path (read by the Grafana Operator's own API
client via named `env:` entries) is untouched — the operator never reads
database credentials, so this doesn't reopen the ownership/env-vs-envFrom
issues fixed earlier in the rollout (PRs #1218/#1219). The new CNPG pod gets
a dedicated egress policy to `s3.chezmoi.sh`; all other traffic is already
covered by the existing `allow-intra-namespace` policy.

### Root Cause (traces datasource)

The original Jaeger-type datasource pointed at `https://data.o11y.chezmoi.sh/traces`
(no path suffix). Confirmed live: VictoriaTraces actually serves the Jaeger
API under `/select/jaeger`, not at the proxied root — the old URL returned
`unsupported path requested` from every query. VictoriaTraces also implements
the Tempo HTTP API since v0.9.4 (confirmed live via `/select/tempo/api/echo`
→ 200), which additionally unlocks TraceQL and the Traces Drilldown plugin.
VictoriaLogs' OpenTelemetry preset can currently only link a `trace_id`
derived field to a Jaeger-type datasource, so a second, Jaeger-typed
datasource against the correct `/select/jaeger` path is kept alongside the
Tempo one purely as that link target — not meant to be browsed directly.

## Testing Validation

- [ ] `grafana-database` CNPG cluster reaches `Cluster in healthy state`
- [ ] Grafana pod starts against the new `[database]` postgres backend (check pod logs for connection errors)
- [ ] A pod restart no longer wipes users/dashboards
- [ ] VictoriaTraces (Tempo) datasource returns real trace data in Explore
- [ ] A log entry with a `trace_id` field shows a working link to the trace in VictoriaLogs' Explore view
- [ ] `pulumi preview` on rhodes.akn shows only the expected new resources (DB password secret, o11y-system backup-credentials Secret)

## Future Enhancements

- Filed as a separate issue: reworking metrics/logs field naming to be more
  OTEL-compatible (e.g. `host.name`) for logs↔metrics correlation, both for
  the LXC-shipped signals and future Kubernetes-sourced ones.

## Related Issues

Addresses #1159 (follow-up)

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
