### PR TITLE
Fix rhodes.akn cert-manager NetworkPolicy DNS-01 nameserver IPs

### DIFF
--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/cert-manager/cilium.io.v2.CiliumNetworkPolicy.allow-cert-manager-to-nameservers.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/cert-manager/cilium.io.v2.CiliumNetworkPolicy.allow-cert-manager-to-nameservers.yaml
@@ -4,20 +4,21 @@ kind: CiliumNetworkPolicy
 metadata:
   annotations:
     policy.networking.k8s.io/description: |
-      Allows the cert-manager controller to query public recursive resolvers (1.1.1.1, 8.8.8.8) on
-      port 53 for its DNS-01 self-check. This network's internal DNS answers "chezmoi.sh NS" with
+      Allows the cert-manager controller to query public recursive resolvers (9.9.9.9, 149.112.112.112)
+      on port 53 for its DNS-01 self-check. This network's internal DNS answers "chezmoi.sh NS" with
       ns.chezmoi.sh (a split-horizon-only BIND resolver, not one of the zone's real public Cloudflare
       NS records) - querying it directly for the self-check meant the ACME TXT record written via the
       Cloudflare solver was never found there, stalling every DNS-01 challenge forever. cert-manager
-      is configured with dns01RecursiveNameservers/dns01RecursiveNameserversOnly (catalog default
-      Helm values) to bypass that split-horizon NS answer entirely.
+      is configured with dns01RecursiveNameservers/dns01RecursiveNameserversOnly (rhodes.akn-specific
+      Helm values, see cert-manager.helmvalues/override.yaml) to bypass that split-horizon NS answer
+      entirely.
   name: allow-cert-manager-to-nameservers
   namespace: cert-manager-system
 spec:
   egress:
   - toCIDR:
-    - 1.1.1.1/32
-    - 8.8.8.8/32
+    - 9.9.9.9/32
+    - 149.112.112.112/32
     toPorts:
     - ports:
       - port: "53"

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/cert-manager/security/network-policy.allow-cert-manager-to-nameservers.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/cert-manager/security/network-policy.allow-cert-manager-to-nameservers.yaml
@@ -3,13 +3,14 @@ kind: CiliumNetworkPolicy
 metadata:
   annotations:
     policy.networking.k8s.io/description: |
-      Allows the cert-manager controller to query public recursive resolvers (1.1.1.1, 8.8.8.8) on
-      port 53 for its DNS-01 self-check. This network's internal DNS answers "chezmoi.sh NS" with
+      Allows the cert-manager controller to query public recursive resolvers (9.9.9.9, 149.112.112.112)
+      on port 53 for its DNS-01 self-check. This network's internal DNS answers "chezmoi.sh NS" with
       ns.chezmoi.sh (a split-horizon-only BIND resolver, not one of the zone's real public Cloudflare
       NS records) - querying it directly for the self-check meant the ACME TXT record written via the
       Cloudflare solver was never found there, stalling every DNS-01 challenge forever. cert-manager
-      is configured with dns01RecursiveNameservers/dns01RecursiveNameserversOnly (catalog default
-      Helm values) to bypass that split-horizon NS answer entirely.
+      is configured with dns01RecursiveNameservers/dns01RecursiveNameserversOnly (rhodes.akn-specific
+      Helm values, see cert-manager.helmvalues/override.yaml) to bypass that split-horizon NS answer
+      entirely.
   name: allow-cert-manager-to-nameservers
 spec:
   endpointSelector:
@@ -18,8 +19,8 @@ spec:
       app.kubernetes.io/component: controller
   egress:
     - toCIDR:
-        - 1.1.1.1/32
-        - 8.8.8.8/32
+        - 9.9.9.9/32
+        - 149.112.112.112/32
       toPorts:
         - ports:
             - port: "53"


### PR DESCRIPTION
## Summary

rhodes.akn's cert-manager `CiliumNetworkPolicy` allowed egress only to
Cloudflare and Google (1.1.1.1, 8.8.8.8), but cert-manager's Helm override
configures the DNS-01 self-check to query Quad9 (9.9.9.9, 149.112.112.112)
instead. Under Cilium's default-deny posture, cert-manager could never
reach the resolvers it was actually told to use, so the next ACME renewal
would stall and rhodes.akn's wildcard certificate (vault.chezmoi.sh,
auth.chezmoi.sh, argocd.akn.chezmoi.sh, and more) would eventually expire.

**Related Issue:** #1206

## Root Cause

`projects/rhodes.akn/src/infrastructure/kubernetes/cert-manager/cert-manager.helmvalues/override.yaml`
sets `dns01RecursiveNameservers: "9.9.9.9:53,149.112.112.112:53"` with
`dns01RecursiveNameserversOnly: true`, bypassing the internal split-horizon
resolver (talosnet-dns/BIND) that never has the ACME TXT record. But
`projects/rhodes.akn/src/infrastructure/kubernetes/cert-manager/security/network-policy.allow-cert-manager-to-nameservers.yaml`
only allowed egress to `1.1.1.1/32` and `8.8.8.8/32` — a different pair of
IPs entirely. The two files had drifted apart, and Cilium's default-deny
egress silently blocked the DNS-01 self-check queries. The policy's own
annotation also misdescribed the override as a "catalog default Helm
value," when it's rhodes.akn-specific per `override.yaml`'s own header
comment.

This mismatch was found while recreating lungmen.akn on a new
Omni-provisioned cluster (#1188, PR #1205) and copying rhodes.akn's
cert-manager setup as a template — lungmen.akn hit the live failure mode
directly, stalling with `dial tcp 10.128.0.3:53: i/o timeout` until its own
NetworkPolicy CIDRs were aligned with the Quad9 override.

## Fix

### cert-manager NetworkPolicy

- **[`projects/rhodes.akn/src/infrastructure/kubernetes/cert-manager/security/network-policy.allow-cert-manager-to-nameservers.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/cert-manager/security/network-policy.allow-cert-manager-to-nameservers.yaml)** — changed `egress[].toCIDR` from `1.1.1.1/32`/`8.8.8.8/32` to `9.9.9.9/32`/`149.112.112.112/32`, matching `cert-manager.helmvalues/override.yaml`'s `dns01RecursiveNameservers` exactly; corrected the annotation to describe the value as rhodes.akn-specific instead of a catalog default.

## Technical Impact

### Behavioural Changes

None until the next DNS-01 self-check runs (certificate renewal or a
manual Certificate/Secret deletion) — at that point cert-manager will
actually be able to reach the resolvers it queries, instead of having its
egress silently dropped.

### Regression Risk

Low. This is a pure CIDR/annotation correction that narrows and realigns
an existing allow-list to match the resolvers cert-manager is already
configured to use — it doesn't touch any other traffic path or workload.

### Observability

`kubectl get certificate` / `cert-manager` controller logs will show the
DNS-01 challenge complete instead of stalling; no new dashboards or
alerts needed.

## Testing Validation

- [x] `network-policy.allow-cert-manager-to-nameservers.yaml`'s `toCIDR` matches the IPs in `cert-manager.helmvalues/override.yaml`'s `dns01RecursiveNameservers`
- [x] Policy annotation accurately describes the override as cluster-specific, not a catalog default
- [ ] **Force-renewing rhodes.akn's wildcard Certificate completes DNS-01 validation without stalling** — this is the third acceptance criterion from #1206 and requires live cluster access this PR cannot perform. **Please verify manually after merge** by deleting/forcing renewal of rhodes.akn's wildcard Certificate (or its Secret) and confirming the DNS-01 challenge completes instead of stalling with a `dial tcp ... i/o timeout` against talosnet-dns.

## Related Issues

Closes #1206

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
