### PR TITLE
Kill stale-generation Caddy processes after LXC upgrade rootfs swap

### DIFF
--- a/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh
+++ b/projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh
@@ -700,6 +700,36 @@ lxc_upgrade() {
   _lxc_step "Health check" "(30s warm-up)"
   sleep 30
 
+  # Safety net: kill any tracked-service process still running from a
+  # stale Nix store generation. Leaked workers (observed with caddy) have
+  # been seen to survive the stop/rootfs-swap/start cycle above, each
+  # holding onto RSS indefinitely — on memory-constrained CTs this has
+  # OOM-killed unrelated services. By this point /run/current-system
+  # unambiguously points at the new generation, so any tracked-service
+  # process whose binary resolves outside that path is provably stale.
+  # This does not explain *why* the old process survives the stop — only
+  # catches it after the fact.
+  local svc_names="${_LXC_SERVICES[*]}"
+  local stale_procs
+  stale_procs=$(_lxc_ssh "${pve_host}" "pct exec ${vmid} -- /run/current-system/sw/bin/bash -lc '
+    CURRENT=\$(readlink -f /run/current-system)
+    for svc in ${svc_names}; do
+      for pid in \$(pgrep -x \"\${svc}\" 2>/dev/null); do
+        EXE=\$(readlink -f /proc/\${pid}/exe 2>/dev/null) || continue
+        case \"\${EXE}\" in
+          \"\${CURRENT}\"/*) ;;
+          *) echo \"\${svc} pid=\${pid} exe=\${EXE}\"; kill -9 \"\${pid}\" 2>/dev/null || true ;;
+        esac
+      done
+    done
+  '" || true)
+  if [[ -n ${stale_procs} ]]; then
+    while IFS= read -r line; do
+      [[ -n ${line} ]] || continue
+      _warn "Killed stale-generation process: ${line}"
+    done <<< "${stale_procs}"
+  fi
+
   local svc_list=""
   local s
   for s in "${_LXC_SERVICES[@]}"; do


### PR DESCRIPTION
## Summary

Adds a defensive check to `lxc_upgrade`'s post-start health step (Step 6) that kills any tracked-service process still running from a stale Nix store generation after an in-place rootfs-swap upgrade. This is a partial fix for the leaked-Caddy-process OOM issue on `oci-registry` (CT 104) — it catches the symptom, not the underlying cause.

**Related Issue:** #1153

## Root Cause

**Caveat added after this PR was opened — read before merging.** The original issue reports (quoting): "`ps aux` inside CT 104 showed **three** `caddy` processes running simultaneously, from **two** different Nix store generations" (`/nix/store/v3w6...-caddy-2.11.3/bin/caddy` started `Jul26`, `/nix/store/z618...-caddy-2.11.3/bin/caddy` started `Jul27`), and that `lxc_upgrade`'s stop/rootfs-swap/start cycle leaks the previous generation's processes across upgrades, eventually pushing the cgroup over its (then 512 MiB) limit and triggering the kernel to OOM-kill `zot` (`oom_kill=4` over 3 days per `/sys/fs/cgroup/lxc/104/memory.events` — that part is a real, cgroup-scoped kernel metric, not in question).

The "two leaked generations" claim itself is *not independently re-verifiable* at this point — the two orphaned PIDs it was based on were already killed as part of the original manual remediation, before this PR's investigation began. This matters because a live re-investigation on `pve-01.pve.chezmoi.sh` (done after this PR was opened, see "Live investigation" below) hit the *exact same failure mode* by accident: an initial host-wide `ps aux | grep caddy` also showed multiple `caddy` processes across two of the same store-path hashes named in this issue (`v3w6g2f0...` and `z6181...`) — but cgroup-scoping each PID individually showed they belonged to **three different LXCs** (101, 103, 104), not two generations stacked inside CT 104. Nix's content-addressed store means unrelated LXCs building the same Caddy version can legitimately share an identical store hash, so a host-level process listing can trivially misread normal cross-container processes as an intra-container generation leak. Whether the *original* investigation was scoped correctly (its own text says "ps aux inside CT 104", which — if it genuinely used `pct exec`/`lxc-attach` rather than a host-level listing — would not have this problem) cannot be confirmed retroactively.

Net effect: the OOM-kill event is real and CT-104-scoped; the specific "leaked Caddy processes are the cause" mechanism is plausible and consistent with the observed symptom, but rests on evidence this PR could not independently reproduce or re-verify, and the one attempt made here to gather comparable evidence hit a scoping mistake of exactly the kind that would produce a false positive. Treat the fix below as a safety net worth keeping regardless (see "Regression Risk" — it can only kill genuinely stale-generation processes, correctly scoped via `pct exec`), not as confirmation the original theory is fully correct.

This PR does not explain *why* the leaked process would survive `pct stop`, nor why a subsequent `pct reboot 104` (which should tear down the CT's PID namespace) reportedly failed to clear the same two orphaned PIDs in the original incident — that requires live host/CT debugging not available here (see "Not addressed" below).

## Fix

- **[`projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh`](projects/chezmoi.sh/src/infrastructure/proxmox/lxc/.mise/lib/lxc.sh)** — Step 6 (health check) now execs into the CT after `pct start`, resolves `/run/current-system` (which unambiguously reflects the new generation by this point), and for every service registered via `lxc_services` (e.g. `caddy`, `zot`, …) walks its running PIDs, compares `/proc/<pid>/exe` against the current generation's store path, and `kill -9`s + warns loudly on anything that resolves outside it. This runs for every LXC managed by `lxc_upgrade`, not just `oci-registry`, since the rootfs-swap flow is shared.

The `oci-registry` README sizing table was already updated to 1024 MiB in a prior commit (`abe727a3c`, "Document oci-registry's memory bump to 1024 MiB") — no change needed here.

## Technical Impact

### Behavioural Changes

`mise run lxc:upgrade` now actively kills and warns about any tracked-service process left running from a stale Nix store generation, for every LXC that uses this shared upgrade flow (`oci-registry`, `observability`, `omni`, `omni-infra-provider-proxmox`, `pve-exporter`, `talosnet-dns`). Previously these leaked silently across upgrades.

### Regression Risk

Low. The check only acts on processes whose systemd-unit name matches an entry the appliance already registered via `lxc_services`, and only kills a match when its resolved binary path falls outside `/run/current-system` — i.e. it cannot touch the freshly-started, correct-generation processes. Worst case if the heuristic is ever wrong (e.g. a service self-execs into a subshell before the check runs) is a spurious `kill -9` of a process that would otherwise have been replaced on the next upgrade anyway; the existing Step 7 rollback path is unaffected since this runs before the commit/rollback decision.

### Observability

The check's output surfaces as `⚠ Killed stale-generation process: <service> pid=<pid> exe=<path>` in the upgrade script's own logging (`_warn`), visible in the same terminal output as the rest of Step 6's health check.

## Testing Validation

- [x] `bash -n` syntax check passes on the modified script
- [ ] Live validation: run `mise run lxc:upgrade` twice in a row against `oci-registry` (or another managed LXC) and confirm `ps aux` inside the CT shows exactly one `caddy` process from the latest generation — **not run**. Live SSH access to `pve-01.pve.chezmoi.sh` became available after this PR was opened (see "Live investigation" below), but re-running `lxc_upgrade` twice against a production LXC is a more invasive action than what was authorized during that session — still needs to be run deliberately, ideally against a non-critical LXC first.

### Live investigation (post-open, on `pve-01.pve.chezmoi.sh`)

With SSH access to the Proxmox host, checked CT 104's actual state, correctly scoped this time to its own cgroup/PID namespace (`pct exec 104 -- ...`, not a host-wide `ps aux`, which was an earlier false lead that swept in unrelated Caddy processes from CT 101/103):

- **Currently no active leak**: exactly one `caddy` process in CT 104's cgroup, matching the single systemd-managed `caddy.service`. `memory.current` sits at ~957–1008 MiB against the 1024 MiB cgroup max — tight headroom even with a single generation running, independent of any leak.
- **`pct reboot 104` test**: captured the full process list in CT 104's cgroup (12 processes, one coherent generation), ran `pct reboot 104`, waited for the registry to come back (HTTP 200 within ~40s), and re-captured the process list — all new PIDs, zero leftovers from the pre-reboot generation, zero cross-container leakage. The teardown mechanism itself works correctly on a clean starting state.
- **What this does and doesn't tell us**: this test could not reproduce the original incident's mystery (orphaned PIDs surviving `pct reboot`), because CT 104 was already in a clean, single-generation state going in — the original incident's broken precondition (PIDs already reparented/orphaned from a prior `lxc_upgrade` leak) wasn't recreated. Reproducing it for real needs the actual leak-inducing sequence (two-plus consecutive `lxc_upgrade` rootfs-swap runs against `oci-registry` or another managed LXC), which is the still-pending validation step above.

## Not addressed (still open on issue #1153)

- **Root cause of PIDs surviving `pct reboot 104`** — still unexplained. A plain `pct reboot 104` on a clean CT 104 tore down its PID namespace correctly (see "Live investigation" above), so the mechanism isn't broken in general; whatever caused the original incident's two PIDs to survive a reboot needs the actual leak reproduced first, then a reboot tested against that broken state specifically.
- **Corrupted `openbao-softhsm` manifest blob** (`blobs/manifest affected` error for `ghcr.io/chezmoidotsh/flakes/openbao/openbao-softhsm:2.2.2-25.05-x86_64-linux`) — needs live registry access to confirm and re-push the blob; not attempted.

## Related Issues

Addresses #1153 (2 of 4 acceptance criteria: process-generation check, README sizing table already correct on `main`). Not closing — the `pct reboot` root cause and the corrupted blob remain open.

---

<sub>AI-assisted with claude:claude-sonnet-5 under human supervision</sub>

