### PR TITLE
Add drift detection for TrueNAS SMB service-account passwords

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,6 +404,9 @@ importers:
       '@pulumi/truenas':
         specifier: workspace:*
         version: link:../../../../../catalog/pulumi/sdks/truenas
+      '@pulumi/vault':
+        specifier: 'catalog:'
+        version: 7.10.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3))(typescript@5.9.3)
       handlebars:
         specifier: 'catalog:'
         version: 4.7.9

--- a/projects/chezmoi.sh/.mise.toml
+++ b/projects/chezmoi.sh/.mise.toml
@@ -14,6 +14,7 @@
 #   mise run pulumi:cloudflare-token:omni           # Inject Pulumi's Cloudflare token into omni's SOPS secret
 #   mise run pulumi:cloudflare-token:oci-registry   # Inject Pulumi's Cloudflare token into oci-registry's SOPS secret
 #   mise run pulumi:tailscale-oauth:observability   # Inject Pulumi's Tailscale OAuth key into observability's SOPS secret
+#   mise run bao:smb:drift-check                    # Check Pulumi vs. Vault drift for TrueNAS SMB passwords (hash-only)
 #
 # Prerequisites:
 #   - SSH key-based access to nas.chezmoi.sh as root user
@@ -131,3 +132,16 @@ run = '''
     '["CLOUDFLARE_API_TOKEN"]' "\"${TOKEN}\""
   echo "[SUCCESS] CLOUDFLARE_API_TOKEN updated in oci-registry/secrets/caddy.sops.env" >&2
 '''
+
+# -----------------------------------------------------------------------------
+# TrueNAS SMB Password Drift Check
+# -----------------------------------------------------------------------------
+# The immich/jellyfin/paperless-ngx TrueNAS SMB service-account passwords are
+# provisioned by Pulumi (stack/truenas/users/*.ts) but nothing syncs that
+# state into OpenBao automatically — see scripts/bao:smb:drift-check for the
+# full rationale and issue #1212. This task hash-compares the two sides;
+# never reads or prints an actual password value.
+
+[tasks."bao:smb:drift-check"]
+description = "Compare Pulumi's TrueNAS SMB password state against Vault (hash-only, never prints secret values)"
+run = "scripts/bao:smb:drift-check"

--- a/projects/chezmoi.sh/src/infrastructure/pulumi/package.json
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/package.json
@@ -25,6 +25,7 @@
 		"@pulumi/random": "catalog:",
 		"@pulumi/tailscale": "catalog:",
 		"@pulumi/truenas": "workspace:*",
+		"@pulumi/vault": "catalog:",
 		"handlebars": "catalog:"
 	},
 	"devDependencies": {

--- a/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/README.md
@@ -51,25 +51,26 @@ as a resource before the account referencing it can be constructed -- that order
 which one can structurally be the other's parent. Grouping them this way keeps a password and the one account it belongs
 to together in the resource tree (`pulumi stack`, state explorer), instead of two unrelated top-level resources.
 
-Most of these passwords are never pushed into OpenBao/Vault by this stack. This stack provisions the NAS, which sits
-below Vault in the dependency chain -- OpenBao's own storage can live on this NAS. A Vault write from here would make
-"the NAS exists" and "Vault is reachable" depend on each other, breaking both normal apply order and disaster recovery
-(this stack must be able to apply cleanly with Vault entirely down). Retrieve a generated password after `pulumi up`
-with:
+Any account whose password is read back out by a Kubernetes `ExternalSecret` also declares a `vault.kv.SecretV2`,
+writing the password straight to the path that `ExternalSecret` reads (`lungmen.akn/<app>/storage/smb`) -- that's the
+baseline, not an add-on: a credential Vault is supposed to hand out has no business being anything other than what
+Pulumi actually generated. `immich.ts`, `jellyfin.ts`, and `paperless-ngx.ts` do this today. Before this, nothing kept
+Vault's copy in sync with Pulumi's, and the two drifted apart (issue 1212).
+
+Accounts with no `ExternalSecret` reading them from Vault -- `home-assistant.ts` (consumed directly in Home Assistant's
+own backup config, never through Kubernetes) and `firesticktv.ts` (an on-device SMB login, no software consumer at all)
+-- have nothing to push and stay manual: retrieve the password after `pulumi up` with
 
 ```sh
 pulumi stack output <name>PasswordSecret --show-secrets
 ```
 
-and copy it to wherever it's consumed (OpenBao, Home Assistant's own backup config, ...) by hand.
+and copy it to wherever it's actually consumed, by hand.
 
-**Exception: `immich.ts`, `jellyfin.ts`, `paperless-ngx.ts`.** Each also declares a `vault.kv.SecretV2` writing its
-password to `lungmen.akn/<app>/storage/smb`, the path the app's own ExternalSecret reads for its SMB CSI mount -- these
-three drove real drift between Pulumi's state and Vault's stored value (issue 1212), since nothing else in the repo ever
-kept them in sync. That reintroduces the exact NAS/Vault circularity described above, but scoped narrowly: these are
-downstream app accounts, not anything Vault's own bootstrap depends on, so a `pulumi up` on this stack with Vault down
-fails only these three specific resources -- the rest of the stack (zpools, shares, every other account) still applies
-cleanly. Whether that's an acceptable trade-off for the stack as a whole, or whether these should move to a separate
-Vault-dependent stack instead, is exactly the kind of question issue 1109 (bootstrap circularity audit) is meant to
-settle -- treat this as a deliberate, narrow exception pending that review, not a precedent for adding more `vault.*`
-resources here.
+One real constraint on the `vault.kv.SecretV2` pattern: this stack provisions the NAS, which sits below Vault in the
+dependency chain whenever OpenBao's own storage lives on it, and a `vault.kv.SecretV2` resource needs Vault reachable to
+apply. None of the accounts here back Vault's own storage today, so this only ever costs those specific Vault-writing
+resources a failed apply if Vault happens to be down -- the rest of the stack (zpools, shares, every other account)
+still applies cleanly regardless. If an account backing Vault's own storage bootstrap is ever added to this stack, it
+must NOT get a `vault.kv.SecretV2` -- see issue 1109 for the broader NAS/Vault/Pulumi circularity this would otherwise
+reintroduce.

--- a/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/README.md
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/README.md
@@ -51,14 +51,25 @@ as a resource before the account referencing it can be constructed -- that order
 which one can structurally be the other's parent. Grouping them this way keeps a password and the one account it belongs
 to together in the resource tree (`pulumi stack`, state explorer), instead of two unrelated top-level resources.
 
-None of these passwords are ever pushed into OpenBao/Vault by this stack (no `vault.*` resource anywhere here, despite
-`@pulumi/vault` being available elsewhere in this monorepo). This stack provisions the NAS, which sits below Vault in
-the dependency chain -- OpenBao's own storage can live on this NAS. A Vault write from here would make "the NAS exists"
-and "Vault is reachable" depend on each other, breaking both normal apply order and disaster recovery (this stack must
-be able to apply cleanly with Vault entirely down). Retrieve a generated password after `pulumi up` with:
+Most of these passwords are never pushed into OpenBao/Vault by this stack. This stack provisions the NAS, which sits
+below Vault in the dependency chain -- OpenBao's own storage can live on this NAS. A Vault write from here would make
+"the NAS exists" and "Vault is reachable" depend on each other, breaking both normal apply order and disaster recovery
+(this stack must be able to apply cleanly with Vault entirely down). Retrieve a generated password after `pulumi up`
+with:
 
 ```sh
 pulumi stack output <name>PasswordSecret --show-secrets
 ```
 
 and copy it to wherever it's consumed (OpenBao, Home Assistant's own backup config, ...) by hand.
+
+**Exception: `immich.ts`, `jellyfin.ts`, `paperless-ngx.ts`.** Each also declares a `vault.kv.SecretV2` writing its
+password to `lungmen.akn/<app>/storage/smb`, the path the app's own ExternalSecret reads for its SMB CSI mount -- these
+three drove real drift between Pulumi's state and Vault's stored value (issue 1212), since nothing else in the repo ever
+kept them in sync. That reintroduces the exact NAS/Vault circularity described above, but scoped narrowly: these are
+downstream app accounts, not anything Vault's own bootstrap depends on, so a `pulumi up` on this stack with Vault down
+fails only these three specific resources -- the rest of the stack (zpools, shares, every other account) still applies
+cleanly. Whether that's an acceptable trade-off for the stack as a whole, or whether these should move to a separate
+Vault-dependent stack instead, is exactly the kind of question issue 1109 (bootstrap circularity audit) is meant to
+settle -- treat this as a deliberate, narrow exception pending that review, not a precedent for adding more `vault.*`
+resources here.

--- a/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/immich.ts
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/immich.ts
@@ -1,5 +1,7 @@
+import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
 import * as truenas from "@pulumi/truenas";
+import * as vault from "@pulumi/vault";
 
 import { managedApplicationsGroup, type Nfs4AclAssignment } from "../acls";
 import { builtInUsersGroup } from "../identities";
@@ -42,6 +44,24 @@ export const immichUser = new truenas.User(
 		home: "/var/empty",
 		shell: "/usr/sbin/nologin",
 		sudoCommands: [],
+	},
+	{ parent: immichPassword },
+);
+
+// Keeps OpenBao's lungmen.akn/immich/storage/smb secret (read by the
+// ExternalSecret backing immich's SMB CSI mount) in sync with this
+// account's actual password. Previously nothing in the repo did this --
+// Vault's copy was populated by hand once and silently drifted from
+// Pulumi's state afterward. See issue 1212.
+new vault.kv.SecretV2(
+	"smb-secret-immich",
+	{
+		mount: "lungmen.akn",
+		name: "immich/storage/smb",
+		dataJson: pulumi.jsonStringify({
+			username: "immich",
+			password: immichPassword.result,
+		}),
 	},
 	{ parent: immichPassword },
 );

--- a/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/jellyfin.ts
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/jellyfin.ts
@@ -1,5 +1,7 @@
+import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
 import * as truenas from "@pulumi/truenas";
+import * as vault from "@pulumi/vault";
 
 import { builtInUsersGroup } from "../identities";
 
@@ -42,6 +44,24 @@ export const jellyfinUser = new truenas.User(
 		home: "/var/empty",
 		shell: "/usr/sbin/nologin",
 		sudoCommands: [],
+	},
+	{ parent: jellyfinPassword },
+);
+
+// Keeps OpenBao's lungmen.akn/jellyfin/storage/smb secret (read by the
+// ExternalSecret backing jellyfin's SMB CSI mount) in sync with this
+// account's actual password. Previously nothing in the repo did this --
+// Vault's copy was populated by hand once and silently drifted from
+// Pulumi's state afterward. See issue 1212.
+new vault.kv.SecretV2(
+	"smb-secret-jellyfin",
+	{
+		mount: "lungmen.akn",
+		name: "jellyfin/storage/smb",
+		dataJson: pulumi.jsonStringify({
+			username: "jellyfin",
+			password: jellyfinPassword.result,
+		}),
 	},
 	{ parent: jellyfinPassword },
 );

--- a/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/paperless-ngx.ts
+++ b/projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/paperless-ngx.ts
@@ -1,5 +1,7 @@
+import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
 import * as truenas from "@pulumi/truenas";
+import * as vault from "@pulumi/vault";
 
 import { managedApplicationsGroup, type Nfs4AclAssignment } from "../acls";
 import { builtInUsersGroup } from "../identities";
@@ -47,6 +49,26 @@ export const paperlessUser = new truenas.User(
 		home: "/var/empty",
 		shell: "/usr/sbin/nologin",
 		sudoCommands: [],
+	},
+	{ parent: paperlessPassword },
+);
+
+// Keeps OpenBao's lungmen.akn/paperless-ngx/storage/smb secret (read by
+// the ExternalSecret backing paperless-ngx's SMB CSI mount) in sync with
+// this account's actual password. Previously nothing in the repo did
+// this -- Vault's copy was populated by hand once and silently drifted
+// from Pulumi's state afterward. See issue 1212. The Vault path key is
+// `paperless-ngx` (the app), the `username` field inside is `paperless`
+// (the actual TrueNAS account, see the note above).
+new vault.kv.SecretV2(
+	"smb-secret-paperless",
+	{
+		mount: "lungmen.akn",
+		name: "paperless-ngx/storage/smb",
+		dataJson: pulumi.jsonStringify({
+			username: "paperless",
+			password: paperlessPassword.result,
+		}),
 	},
 	{ parent: paperlessPassword },
 );

--- a/scripts/bao:smb:drift-check
+++ b/scripts/bao:smb:drift-check
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Detects drift between Pulumi's random.RandomPassword state (TrueNAS SMB
+# service accounts) and the password actually stored in OpenBao. Read-only,
+# hash-compare only -- the raw password is never printed, logged, or written
+# to disk anywhere in this script.
+#
+# Background: projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/
+# users/{immich,jellyfin,paperless-ngx}.ts each provision an SMB service
+# account with a random.RandomPassword exported as a stack output. Nothing
+# in the repo syncs that output into OpenBao (lungmen.akn/<app>/storage/smb,
+# read by the ExternalSecrets backing each app's SMB CSI mount) -- it was set
+# there by hand. If Pulumi's state and Vault ever disagree and a `pulumi up`
+# (or `--target-replace`) forces recreation of one of these
+# random.RandomPassword resources, Pulumi pushes its own stale password to
+# TrueNAS and silently breaks that app's SMB auth. See issue #1212.
+#
+# Usage:
+#   scripts/bao:smb:drift-check
+#
+# Requires:
+#   - `pulumi` with a stack selected for
+#     projects/chezmoi.sh/src/infrastructure/pulumi (PULUMI_STACK env, see
+#     that project's .mise/env.yaml)
+#   - `bao` on PATH with a session that can read lungmen.akn/<app>/storage/smb
+#     (`mise run bao:login`)
+#
+# When to run:
+#   - Before any `pulumi up`/`pulumi preview --target-replace` touching the
+#     truenas stack's `users/*` resources -- confirms a forced replacement
+#     won't push a stale password.
+#   - After rotating one of these SMB passwords by hand on TrueNAS/Vault, to
+#     confirm Pulumi's state was brought back in sync.
+#   - Periodically (e.g. monthly), same rationale as bao:secret:audit.
+#
+# Resyncing a rotated password: treat whichever side changed as the source of
+# truth and bring the other side to match by hand -- this script only
+# detects drift, it does not resync automatically, and neither direction is
+# safe to script blindly (a Vault write is a live production secret change;
+# a Pulumi-side fix touches `random.RandomPassword` state). Coordinate with
+# whoever owns the change before touching either side.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PULUMI_DIR="${REPO_ROOT}/projects/chezmoi.sh/src/infrastructure/pulumi"
+
+APPS=(immich jellyfin paperless-ngx)
+
+# macOS ships bash 3.2 (no associative arrays) -- a case statement keeps
+# this portable instead of relying on `declare -A`.
+pulumi_output_name() {
+  case "$1" in
+  immich) echo "immichPasswordSecret" ;;
+  jellyfin) echo "jellyfinPasswordSecret" ;;
+  paperless-ngx) echo "paperlessPasswordSecret" ;;
+  *)
+    error "no known Pulumi output for app '$1'"
+    exit 1
+    ;;
+  esac
+}
+
+info() { echo "Info: $1" >&2; }
+error() { echo "Error: $1" >&2; }
+
+hash_stdin() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+# Reads the given Pulumi stack output and returns its SHA-256 hash. The raw
+# value only ever lives in this function's local scope, never echoed.
+pulumi_password_hash() {
+  local output_name="$1" raw hash
+  if ! raw="$(pulumi stack output "${output_name}" --show-secrets --cwd "${PULUMI_DIR}" 2>&1)"; then
+    error "Pulumi output '${output_name}' failed: ${raw}"
+    exit 1
+  fi
+  hash="$(printf '%s' "${raw}" | hash_stdin)"
+  unset raw
+  printf '%s\n' "${hash}"
+}
+
+# Reads the SMB password field for the given app from Vault and returns its
+# SHA-256 hash. Same rule: the raw value never leaves this function's scope.
+vault_password_hash() {
+  local app="$1" raw hash
+  if ! raw="$(bao kv get -mount=lungmen.akn -field=password "${app}/storage/smb" 2>&1)"; then
+    error "Vault read for lungmen.akn/${app}/storage/smb failed: ${raw}"
+    exit 1
+  fi
+  hash="$(printf '%s' "${raw}" | hash_stdin)"
+  unset raw
+  printf '%s\n' "${hash}"
+}
+
+drifted=()
+for app in "${APPS[@]}"; do
+  info "Checking ${app}..."
+  output_name="$(pulumi_output_name "${app}")"
+  pulumi_hash="$(pulumi_password_hash "${output_name}")"
+  vault_hash="$(vault_password_hash "${app}")"
+  if [[ ${pulumi_hash} != "${vault_hash}" ]]; then
+    drifted+=("${app}")
+  fi
+done
+
+if [[ ${#drifted[@]} -gt 0 ]]; then
+  error "Password drift detected for: ${drifted[*]}"
+  error "Pulumi's random.RandomPassword state disagrees with the Vault-stored password at lungmen.akn/<app>/storage/smb."
+  exit 1
+fi
+
+info "No drift: Pulumi and Vault agree on the SMB password hash for ${APPS[*]}."


### PR DESCRIPTION
## ⚠️ Before applying this PR — read first

The three accounts have a **confirmed, current** drift today: Pulumi's `random.RandomPassword` state does not match
the Vault-stored password for `immich`, `jellyfin`, or `paperless-ngx` (issue #1212). Vault's value is the one that
actually works against TrueNAS right now (confirmed live for jellyfin/paperless-ngx).

Running `pulumi up` on this branch as-is would create the new `vault.kv.SecretV2` resources using Pulumi's **current,
stale** `random.RandomPassword` state as their value — overwriting Vault's currently-correct password with the wrong
one, breaking SMB auth for jellyfin and paperless-ngx immediately. **This is acceptance criterion 3 from #1212,
still unresolved**, and this PR does not resolve it. Reconcile Pulumi's state to match the live TrueNAS/Vault
password first (e.g. `pulumi state`-level correction, not a `pulumi up`) — a live production secrets change that
needs your explicit, confirmed go-ahead, not something to run blind off this PR.

## Summary

`immich`, `jellyfin`, and `paperless-ngx` each get a TrueNAS SMB service-account
password provisioned by Pulumi's `random.RandomPassword` and exported as a
stack output. Nothing in the repo synced that output into OpenBao
(`lungmen.akn/<app>/storage/smb`, read by the ExternalSecrets backing each
app's SMB CSI mount) — it was set there by hand, and issue #1212 confirms it
has since drifted from Pulumi's state for all three accounts. If a forced
replacement of any of these resources ever ran, Pulumi would silently push
its stale password to TrueNAS and break that app's SMB auth.

The issue's proposal section weighed three options. This PR now implements
two of them:

1. A mechanical pre-`pulumi up` drift check (detection).
2. Each account pushing its password straight to Vault via
   `vault.kv.SecretV2` (prevention — makes drift structurally impossible
   going forward, once the current drift above is resolved first).

**Related Issue:** #1212

## Changes Made

### TrueNAS SMB password drift-check tooling

- **[`scripts/bao:smb:drift-check`](scripts/bao:smb:drift-check)** — for each
  of `immich`, `jellyfin`, `paperless-ngx`, reads the Pulumi stack output and
  the Vault-stored password, SHA-256-hashes both, and compares the hashes.
  Exits non-zero listing which accounts have drifted. The raw password value
  never leaves a function's local scope — it's read, hashed immediately, and
  discarded; nothing is printed, logged, or written to disk. Mirrors the
  metadata-only discipline in `.agents/skills/bao-secret-audit/SKILL.md`.
- **[`projects/chezmoi.sh/.mise.toml`](projects/chezmoi.sh/.mise.toml)** —
  adds the `bao:smb:drift-check` task so the script is a one-command check
  (`mise run bao:smb:drift-check`) instead of a one-off.

### Pushing passwords to Vault from Pulumi

- **[`immich.ts`](projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/immich.ts)**,
  **[`jellyfin.ts`](projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/jellyfin.ts)**,
  **[`paperless-ngx.ts`](projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/paperless-ngx.ts)** —
  each now also declares a `vault.kv.SecretV2` writing its password to
  `lungmen.akn/<app>/storage/smb`, the same path the app's `ExternalSecret`
  reads. Any future password rotation (forced replace, provider upgrade,
  `--target-replace`) now keeps Vault in sync by construction — there is no
  code path left where Pulumi generates a new password without also pushing
  it to Vault.
- **[`package.json`](projects/chezmoi.sh/src/infrastructure/pulumi/package.json)** —
  adds `@pulumi/vault` (already used elsewhere in the monorepo, e.g.
  `catalog/pulumi/components/cluster-vault`).
- **[`users/README.md`](projects/chezmoi.sh/src/infrastructure/pulumi/stack/truenas/users/README.md)** —
  documents the rule: any account read back out via a Kubernetes
  `ExternalSecret` pushes to Vault; accounts with no Vault-reading consumer
  (`home-assistant.ts`, `firesticktv.ts`) stay manual, because there's
  nothing to push to. Also documents the one real constraint this
  introduces: a `vault.kv.SecretV2` resource needs Vault reachable to apply,
  which costs those specific resources a failed apply if Vault is down —
  acceptable today since no account in this stack backs Vault's own storage,
  but not to be repeated if one ever does (see issue #1109, commented
  there).

## Technical Impact

### Security Implementation

The drift-check script is hash-compare only, by design — it never reads a
secret value into anything that gets printed, logged, or persisted.

The `vault.kv.SecretV2` resources write the actual password (required —
that's the point), scoped to exactly the same Vault path and permission
level each app's `ExternalSecret` already reads from.

### Integration Points

The drift-check script reads from two existing sources of truth — the
`chezmoi_sh.live` Pulumi stack and OpenBao — without writing to either.

The `vault.kv.SecretV2` resources add a real write dependency from the
`truenas` Pulumi stack to Vault, for these three resources only. See the
"Before applying this PR" warning above and `users/README.md`'s "Password
handling" section for the full reasoning and the one constraint this
introduces.

## Testing Validation

- [x] `trunk check` reports no issues on all changed files
- [x] `tsc --noEmit` passes on the Pulumi program with the new
      `vault.kv.SecretV2` resources and `@pulumi/vault` dependency installed
- [x] Script logic exercised locally against dummy `pulumi`/`bao`
      stand-ins (match, full-drift, and partial-drift cases) — real
      Vault/TrueNAS/Pulumi state was never touched
- [ ] `mise run bao:smb:drift-check` run against the live stack — not run
      as part of this PR
- [ ] `pulumi preview` against the live stack showing the expected diff
      (three new `vault.kv.SecretV2` creates) — not run; **do this only
      after** the current drift is resolved, per the warning above

## Not done by this PR

- **Acceptance criterion 3 (resolving the current live drift)** is still
  open and now gates safely applying this PR at all — see the warning at
  the top. Needs your explicit, confirmed decision on which side
  (Pulumi/Vault) is authoritative before any `pulumi up` touches these
  resources.

## Related Issues

Refs #1212 — satisfies acceptance criteria 1 and, once the current drift is
resolved first, 2. Criterion 3 remains open; not closing the issue.

Comment left on #1109 flagging the new Vault dependency this introduces
into the `truenas` stack, for the bootstrap circularity review.

---

<sub>AI-assisted with claude:claude-sonnet-5 under human supervision</sub>
