### PR TITLE
Install Grafana Assistant app plugin on rhodes.akn

### DIFF
--- a/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.Grafana.grafana.yaml
+++ b/projects/rhodes.akn/dist/infrastructure/kubernetes/o11y/grafana.integreatly.org.v1beta1.Grafana.grafana.yaml
@@ -59,7 +59,7 @@ spec:
                 0.9.2, hpehpc-grafanaclusterview-panel 1.3.2, vaduga-mapgl-panel 2.9.0,
                 boazreicher-mosaicplot-panel 1.0.18, nikosc-percenttrend-panel 1.0.8,
                 novatec-sdg-panel 4.2.0, grafana-advisor-app 1.0.2, grafana-llm-app
-                1.0.8
+                1.0.8, grafana-assistant-app 2.0.46
             envFrom:
             - secretRef:
                 name: grafana-oidc-client

--- a/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml
+++ b/projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml
@@ -97,4 +97,5 @@ spec:
                     nikosc-percenttrend-panel 1.0.8,
                     novatec-sdg-panel 4.2.0,
                     grafana-advisor-app 1.0.2,
-                    grafana-llm-app 1.0.8
+                    grafana-llm-app 1.0.8,
+                    grafana-assistant-app 2.0.46


### PR DESCRIPTION
## Summary

Follow-up to #1229: installs the `grafana-assistant-app` plugin on the `rhodes.akn`
Grafana instance. This was deliberately left out of the first batch because it
requires a connected Grafana Cloud stack to function at all — confirmed via
[Grafana's self-managed docs](https://grafana.com/docs/grafana-cloud/machine-learning/assistant/self-managed/):
even self-hosted, Assistant forwards every request to Grafana Cloud for
processing, it never runs fully local (the separate LLM app, already installed
in #1229, is what talks to local/self-hosted LLMs). You've said you're setting
up a Grafana Cloud account to unblock it, so this PR installs the plugin —
connecting it to that account is a manual step in the Grafana UI (Administration
→ Plugins → Grafana Assistant → "Connect to Grafana Cloud"), not something a
manifest change can do.

**Related Issue:** None — direct follow-up to #1229.

## Changes Made

### Grafana instance — plugin installation

- **[`grafana.instance.yaml`](projects/rhodes.akn/src/infrastructure/kubernetes/o11y/grafana.instance.yaml)** — adds `grafana-assistant-app 2.0.46` to the existing `GF_INSTALL_PLUGINS` list.
- **`dist/.../grafana.integreatly.org.v1beta1.Grafana.grafana.yaml`** — regenerated via `dist:render`, not hand-edited.

## Plugin details

| Plugin | What it shows / when to use it | Last update | Why it's added now |
|---|---|---|---|
| **Grafana Assistant** (`grafana-assistant-app`, official) | In-app AI chat assistant: answers questions about your data, helps build dashboards/queries, navigates the instance. | 2026-08-05 (v2.0.46) | Official, free to install; requires `Grafana >=13.0.0-0` (deployed version is 13.0.1, satisfied). **Not functional until connected to a Grafana Cloud stack** — that connection step is manual, done by an org admin in the UI, and out of scope for this repo. |

## Technical Impact

### Infrastructure Components

One additional plugin in the existing `GF_INSTALL_PLUGINS` list — no new Kubernetes resources, no change to the deployment shape.

### Security Implementation

Same egress path already covered by `allow-operator-to-grafana-com` (grafana.com + storage.googleapis.com), verified working for the 11 plugins installed in #1229. Grafana-Labs official plugin, no unsigned-plugin override needed. No new secrets: the Cloud connection itself is an OAuth-style flow performed interactively in the UI, not a credential stored in this repo.

### Integration Points

Once connected to Grafana Cloud (manual, outside this PR), Assistant can optionally use the already-installed LLM app for parts of its workflow, per Grafana's docs.

## Testing Validation

- [ ] `grafana-deployment` pod reaches `Running` after rollout
- [ ] `grafana-assistant-app` appears under Administration → Plugins, enabled
- [ ] Org admin completes the "Connect to Grafana Cloud" flow and the Assistant chat icon becomes usable

## Related Issues

Addresses the Grafana Assistant follow-up noted in #1229.

---

<sub>AI-assisted with claude-code:claude-sonnet-5 under human supervision</sub>
