### PR TITLE
Fix CNPG DB ExternalSecret refresh lag on paperless-ngx and linkding

### DIFF
--- a/projects/lungmen.akn/dist/apps/linkding/external-secrets.io.v1.ExternalSecret.linkding-database-linkding.yaml
+++ b/projects/lungmen.akn/dist/apps/linkding/external-secrets.io.v1.ExternalSecret.linkding-database-linkding.yaml
@@ -11,7 +11,7 @@ spec:
   dataFrom:
   - extract:
       key: lungmen.akn/linkding/database/postgresql
-  refreshInterval: 1h
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: vault.chezmoi.sh

--- a/projects/lungmen.akn/dist/apps/paperless-ngx/external-secrets.io.v1.ExternalSecret.paperless-ngx-database-paperless.yaml
+++ b/projects/lungmen.akn/dist/apps/paperless-ngx/external-secrets.io.v1.ExternalSecret.paperless-ngx-database-paperless.yaml
@@ -11,7 +11,7 @@ spec:
   dataFrom:
   - extract:
       key: lungmen.akn/paperless-ngx/database/postgresql
-  refreshInterval: 1h
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: vault.chezmoi.sh

--- a/projects/lungmen.akn/src/apps/linkding/linkding.database.externalsecret.yaml
+++ b/projects/lungmen.akn/src/apps/linkding/linkding.database.externalsecret.yaml
@@ -7,7 +7,7 @@ spec:
   dataFrom:
     - extract:
         key: lungmen.akn/linkding/database/postgresql
-  refreshInterval: 1h
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: vault.chezmoi.sh

--- a/projects/lungmen.akn/src/apps/paperless-ngx/paperless-ngx.database.externalsecret.yaml
+++ b/projects/lungmen.akn/src/apps/paperless-ngx/paperless-ngx.database.externalsecret.yaml
@@ -7,7 +7,7 @@ spec:
   dataFrom:
     - extract:
         key: lungmen.akn/paperless-ngx/database/postgresql
-  refreshInterval: 1h
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: vault.chezmoi.sh


### PR DESCRIPTION
## Summary

On `lungmen.akn`, the CNPG-side `PushSecret` republishes rotated DB role
passwords to OpenBao every 5m, but `paperless-ngx` and `linkding`'s own
`ExternalSecret`s (reading that OpenBao path back into the app namespace)
were still polling every 1h — a drift window where the app can hold a stale,
already-invalid credential. This completes the fix started for `immich` in
`46a30b438`.

**Related Issue:** #1233

## Root Cause

`catalog/helm/mutualized-cnpg-databases` provisions, per DB role: a
`Password` generator, a CNPG-managed-role `ExternalSecret`
(`refreshInterval: "0"`, correct — a generator must not re-roll every
reconcile), and a `PushSecret` (`refreshInterval: 5m`) that republishes the
generated credential to OpenBao. Each app then reads that OpenBao path back
via its own, independently-clocked `ExternalSecret`. When the three apps'
`ExternalSecret`s were set to `refreshInterval: 1h`, a rotated password could
take up to an hour to reach the app after it was already live in OpenBao.

Evidence:
- Issue #1214 observed `paperless-ngx-0` crash-looping for ~5 cycles during
  the `lungmen-akn` cluster recreation, requiring manual `Secret` deletion to
  force ESO to re-pull — but its acceptance criteria only covered a separate
  `linkding` rotation no-op, so this refresh-lag gap itself was never fixed.
- Recurred independently in production: `immich-server` logged 54
  `PostgresError: password authentication failed for user "immich"` errors
  across 2026-08-07/08, self-healing only once the hourly `ExternalSecret`
  refresh caught up.

## Fix

Reduced `refreshInterval` from `1h` to `5m` — matching the `PushSecret`'s own
republish cadence, no point polling faster than the source updates — for:

- **[`projects/lungmen.akn/src/apps/paperless-ngx/paperless-ngx.database.externalsecret.yaml`](projects/lungmen.akn/src/apps/paperless-ngx/paperless-ngx.database.externalsecret.yaml)**
- **[`projects/lungmen.akn/src/apps/linkding/linkding.database.externalsecret.yaml`](projects/lungmen.akn/src/apps/linkding/linkding.database.externalsecret.yaml)**

`dist/` re-rendered for both apps; diff is the identical single-field change.

## Technical Impact

### Behavioural Changes

Both apps now pick up a rotated DB password within 5 minutes instead of up
to 1 hour. No other behavioural change — pure refresh-cadence tightening.

### Regression Risk

Low. Same one-line change already live and validated for `immich`
(`46a30b438`) with no adverse effect; polling ESO 12x more often per app is
negligible load, and the CNPG-side `PushSecret` already runs at this cadence.

### Observability

`kubectl get externalsecret -n <namespace>` shows the new `refreshInterval`;
`kubectl logs` on both apps should show no new `password authentication
failed` errors after rollout.

## Testing Validation

- [x] `dist:render` output matches the `src/` change (single-field diff, both apps)
- [x] `trunk check` clean
- [ ] Post-merge: `kubectl logs` on `paperless-ngx` and `linkding` clean of auth errors after the next password rotation

## Related Issues

Closes #1233

---

<sub>AI-assisted with anthropic:claude-sonnet-5 under human supervision</sub>
